### PR TITLE
feat(core): add fields() factory and InferSchema<T> (PR 5)

### DIFF
--- a/.changeset/feat-core-fields-infer-schema.md
+++ b/.changeset/feat-core-fields-infer-schema.md
@@ -1,0 +1,18 @@
+---
+"@vttforge/core": minor
+---
+
+Add `fields()` factory and `InferSchema<T>` for typed `defineSchema()` outputs.
+
+Covers the v0.1 partial scope from PRD §7: `NumberField`, `StringField`,
+`BooleanField`, `HTMLField`, `ArrayField`, `SchemaField`, `ColorField`,
+`FilePathField`. Calling `fields()` lazy-resolves `globalThis.foundry.data.fields`
+and throws `VttfError VTTF-0002` outside the Foundry runtime — same pattern as
+`BaseTypeDataModel()` / `BaseActorSheet()`.
+
+`InferSchema<S>` derives the `system` shape from a `defineSchema()` return value,
+recursing through `ArrayField` and `SchemaField` and honouring the single
+nullability rule `nullable: true` → `T | null`. Full class-level inference
+(`BaseTypeDataModel<typeof Schema>`), `$inferData`, `EmbeddedDataField`,
+`EmbeddedDocumentField`, `TypedSchemaField`, and the full required×initial
+nullability matrix remain v1.0 scope and will ship from `@vttforge/types`.

--- a/packages/core/src/__tests__/infer-schema.test.ts
+++ b/packages/core/src/__tests__/infer-schema.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  type ArrayFieldInstance,
+  type BooleanFieldInstance,
+  type ColorFieldInstance,
+  type FilePathFieldInstance,
+  fields,
+  type HTMLFieldInstance,
+  type NumberFieldInstance,
+  type SchemaFieldInstance,
+  type StringFieldInstance,
+} from '../data/fields.js';
+import type { InferField, InferSchema } from '../data/infer-schema.js';
+import { VttfError } from '../errors/registry.js';
+
+class FakeNumberField {}
+class FakeStringField {}
+class FakeBooleanField {}
+class FakeHTMLField {}
+class FakeColorField {}
+class FakeFilePathField {}
+class FakeArrayField {}
+class FakeSchemaField {}
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).foundry = {
+    data: {
+      fields: {
+        NumberField: FakeNumberField,
+        StringField: FakeStringField,
+        BooleanField: FakeBooleanField,
+        HTMLField: FakeHTMLField,
+        ColorField: FakeColorField,
+        FilePathField: FakeFilePathField,
+        ArrayField: FakeArrayField,
+        SchemaField: FakeSchemaField,
+      },
+    },
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).foundry;
+});
+
+describe('fields()', () => {
+  it('throws VTTF-0002 when foundry.data.fields is missing', () => {
+    delete (globalThis as Record<string, unknown>).foundry;
+    expect(() => fields()).toThrow(VttfError);
+  });
+
+  it('throws VTTF-0002 when foundry exists but data.fields does not', () => {
+    (globalThis as Record<string, unknown>).foundry = { data: {} };
+    expect(() => fields()).toThrow(VttfError);
+  });
+
+  it('returns the foundry data.fields bag when present', () => {
+    const f = fields();
+    expect(f.NumberField).toBe(FakeNumberField);
+    expect(f.StringField).toBe(FakeStringField);
+    expect(f.BooleanField).toBe(FakeBooleanField);
+    expect(f.HTMLField).toBe(FakeHTMLField);
+    expect(f.ColorField).toBe(FakeColorField);
+    expect(f.FilePathField).toBe(FakeFilePathField);
+    expect(f.ArrayField).toBe(FakeArrayField);
+    expect(f.SchemaField).toBe(FakeSchemaField);
+  });
+});
+
+describe('InferField<F> — scalar fields', () => {
+  it('NumberField → number', () => {
+    expectTypeOf<InferField<NumberFieldInstance>>().toEqualTypeOf<number>();
+  });
+
+  it('StringField → string', () => {
+    expectTypeOf<InferField<StringFieldInstance>>().toEqualTypeOf<string>();
+  });
+
+  it('BooleanField → boolean', () => {
+    expectTypeOf<InferField<BooleanFieldInstance>>().toEqualTypeOf<boolean>();
+  });
+
+  it('HTMLField → string', () => {
+    expectTypeOf<InferField<HTMLFieldInstance>>().toEqualTypeOf<string>();
+  });
+
+  it('ColorField → string', () => {
+    expectTypeOf<InferField<ColorFieldInstance>>().toEqualTypeOf<string>();
+  });
+
+  it('FilePathField → string', () => {
+    expectTypeOf<InferField<FilePathFieldInstance>>().toEqualTypeOf<string>();
+  });
+});
+
+describe('InferField<F> — composite fields', () => {
+  it('ArrayField of NumberField → number[]', () => {
+    type T = InferField<ArrayFieldInstance<NumberFieldInstance>>;
+    expectTypeOf<T>().toEqualTypeOf<number[]>();
+  });
+
+  it('ArrayField of StringField → string[]', () => {
+    type T = InferField<ArrayFieldInstance<StringFieldInstance>>;
+    expectTypeOf<T>().toEqualTypeOf<string[]>();
+  });
+
+  it('SchemaField → recursive object', () => {
+    type T = InferField<
+      SchemaFieldInstance<{
+        value: NumberFieldInstance;
+        max: NumberFieldInstance;
+      }>
+    >;
+    expectTypeOf<T>().toEqualTypeOf<{ value: number; max: number }>();
+  });
+
+  it('SchemaField nested inside ArrayField → object[]', () => {
+    type T = InferField<ArrayFieldInstance<SchemaFieldInstance<{ name: StringFieldInstance }>>>;
+    expectTypeOf<T>().toEqualTypeOf<{ name: string }[]>();
+  });
+});
+
+describe('InferField<F> — nullability (v0.1 single rule)', () => {
+  it('nullable: true → T | null', () => {
+    type T = InferField<NumberFieldInstance<{ nullable: true }>>;
+    expectTypeOf<T>().toEqualTypeOf<number | null>();
+  });
+
+  it('nullable: false (default) → T', () => {
+    type T = InferField<NumberFieldInstance<{ nullable: false }>>;
+    expectTypeOf<T>().toEqualTypeOf<number>();
+  });
+
+  it('no nullable option → T', () => {
+    type T = InferField<StringFieldInstance>;
+    expectTypeOf<T>().toEqualTypeOf<string>();
+  });
+});
+
+describe('InferSchema<S>', () => {
+  it('flat schema of three scalar fields', () => {
+    type T = InferSchema<{
+      level: NumberFieldInstance;
+      name: StringFieldInstance;
+      active: BooleanFieldInstance;
+    }>;
+    expectTypeOf<T>().toEqualTypeOf<{ level: number; name: string; active: boolean }>();
+  });
+
+  it('character-shaped schema with nested SchemaField and ArrayField', () => {
+    type T = InferSchema<{
+      level: NumberFieldInstance;
+      health: SchemaFieldInstance<{
+        value: NumberFieldInstance;
+        max: NumberFieldInstance;
+      }>;
+      biography: HTMLFieldInstance;
+      nicknames: ArrayFieldInstance<StringFieldInstance>;
+      portrait: FilePathFieldInstance;
+    }>;
+    expectTypeOf<T>().toEqualTypeOf<{
+      level: number;
+      health: { value: number; max: number };
+      biography: string;
+      nicknames: string[];
+      portrait: string;
+    }>();
+  });
+
+  it('propagates nullability through the schema', () => {
+    type T = InferSchema<{
+      hp: NumberFieldInstance<{ nullable: true }>;
+      name: StringFieldInstance;
+    }>;
+    expectTypeOf<T>().toEqualTypeOf<{ hp: number | null; name: string }>();
+  });
+});

--- a/packages/core/src/data/field-options.ts
+++ b/packages/core/src/data/field-options.ts
@@ -1,0 +1,63 @@
+/**
+ * Option interfaces for the Foundry v13 data fields covered by `@vttforge/core`'s
+ * v0.1 `InferSchema<T>` surface.
+ *
+ * Mirrors the shape documented at https://foundryvtt.com/api/v13/ for each
+ * `foundry.data.fields.*` class. Properties are structural — they exist purely
+ * so the conditional types in `./infer-schema.ts` can extract semantics like
+ * `nullable: true` without us pulling in `fvtt-types` (deferred to
+ * `@vttforge/types` v1.0).
+ */
+
+/**
+ * Properties shared by every Foundry data field option object.
+ *
+ * Mirrors the base `DataFieldOptions` interface documented at
+ * https://foundryvtt.com/api/v13/classes/foundry.data.fields.DataField.html.
+ */
+export interface DataFieldOptions {
+  readonly required?: boolean;
+  readonly nullable?: boolean;
+  readonly initial?: unknown;
+  readonly readonly?: boolean;
+  readonly gmOnly?: boolean;
+  readonly label?: string;
+  readonly hint?: string;
+  readonly validationError?: string;
+  readonly validate?: (value: unknown) => boolean | undefined;
+}
+
+export interface NumberFieldOptions extends DataFieldOptions {
+  readonly integer?: boolean;
+  readonly positive?: boolean;
+  readonly min?: number;
+  readonly max?: number;
+  readonly step?: number;
+  readonly choices?: readonly number[] | Record<string, number>;
+}
+
+export interface StringFieldOptions extends DataFieldOptions {
+  readonly blank?: boolean;
+  readonly trim?: boolean;
+  readonly textSearch?: boolean;
+  readonly choices?: readonly string[] | Record<string, string>;
+}
+
+export type BooleanFieldOptions = DataFieldOptions;
+
+export type HTMLFieldOptions = StringFieldOptions;
+
+export type ColorFieldOptions = StringFieldOptions;
+
+export interface FilePathFieldOptions extends StringFieldOptions {
+  readonly categories?: ReadonlyArray<'IMAGE' | 'VIDEO' | 'AUDIO' | 'TEXT' | 'FONT' | 'GRAPHICS'>;
+  readonly base64?: boolean;
+  readonly wildcard?: boolean;
+}
+
+export interface ArrayFieldOptions extends DataFieldOptions {
+  readonly min?: number;
+  readonly max?: number;
+}
+
+export type SchemaFieldOptions = DataFieldOptions;

--- a/packages/core/src/data/fields.ts
+++ b/packages/core/src/data/fields.ts
@@ -1,0 +1,183 @@
+/**
+ * `fields()` — typed bag of Foundry v13 data-field constructors.
+ *
+ * Foundry idiom inside `defineSchema()` is `const f = foundry.data.fields`. We
+ * mirror that, but routed through a factory so the import succeeds in Node
+ * (tests, IDE typecheck) where the global is absent. The factory resolves
+ * `globalThis.foundry.data.fields` lazily — same pattern as
+ * `BaseTypeDataModel()` (see `base-type-data-model.ts:25`) and
+ * `BaseActorSheet()` (see `base-actor-sheet.ts:40`).
+ *
+ * v0.1 covers eight fields (PRD §7): NumberField, StringField, BooleanField,
+ * HTMLField, ArrayField, SchemaField, ColorField, FilePathField. The instance
+ * interfaces carry a phantom `[BRAND]` tag and an `options` capture so the
+ * conditional types in `./infer-schema.ts` can extract the runtime semantics
+ * (e.g. `nullable: true`).
+ *
+ * `EmbeddedDataField`, `EmbeddedDocumentField`, `TypedSchemaField`, and the
+ * full required×initial nullability matrix ship with `@vttforge/types` v1.0.
+ */
+
+import { VttfError } from '../errors/registry.js';
+import type {
+  ArrayFieldOptions,
+  BooleanFieldOptions,
+  ColorFieldOptions,
+  FilePathFieldOptions,
+  HTMLFieldOptions,
+  NumberFieldOptions,
+  SchemaFieldOptions,
+  StringFieldOptions,
+} from './field-options.js';
+
+declare const BRAND: unique symbol;
+
+/**
+ * Anything that satisfies the `FieldInstance` shape — used as the inner-field
+ * constraint on `ArrayField` and as the value type of `SchemaField`'s child
+ * map. Keeps the conditional types in `./infer-schema.ts` straightforward.
+ */
+export interface FieldInstance {
+  readonly [BRAND]: string;
+  readonly options: unknown;
+}
+
+export interface NumberFieldInstance<O extends NumberFieldOptions = NumberFieldOptions>
+  extends FieldInstance {
+  readonly [BRAND]: 'number';
+  readonly options: O;
+}
+
+export interface StringFieldInstance<O extends StringFieldOptions = StringFieldOptions>
+  extends FieldInstance {
+  readonly [BRAND]: 'string';
+  readonly options: O;
+}
+
+export interface BooleanFieldInstance<O extends BooleanFieldOptions = BooleanFieldOptions>
+  extends FieldInstance {
+  readonly [BRAND]: 'boolean';
+  readonly options: O;
+}
+
+export interface HTMLFieldInstance<O extends HTMLFieldOptions = HTMLFieldOptions>
+  extends FieldInstance {
+  readonly [BRAND]: 'html';
+  readonly options: O;
+}
+
+export interface ColorFieldInstance<O extends ColorFieldOptions = ColorFieldOptions>
+  extends FieldInstance {
+  readonly [BRAND]: 'color';
+  readonly options: O;
+}
+
+export interface FilePathFieldInstance<O extends FilePathFieldOptions = FilePathFieldOptions>
+  extends FieldInstance {
+  readonly [BRAND]: 'filePath';
+  readonly options: O;
+}
+
+export interface ArrayFieldInstance<
+  Inner extends FieldInstance = FieldInstance,
+  O extends ArrayFieldOptions = ArrayFieldOptions,
+> extends FieldInstance {
+  readonly [BRAND]: 'array';
+  readonly element: Inner;
+  readonly options: O;
+}
+
+export interface SchemaFieldInstance<
+  S extends Record<string, FieldInstance> = Record<string, FieldInstance>,
+  O extends SchemaFieldOptions = SchemaFieldOptions,
+> extends FieldInstance {
+  readonly [BRAND]: 'schema';
+  readonly fields: S;
+  readonly options: O;
+}
+
+export interface NumberFieldCtor {
+  new <O extends NumberFieldOptions = NumberFieldOptions>(options?: O): NumberFieldInstance<O>;
+}
+
+export interface StringFieldCtor {
+  new <O extends StringFieldOptions = StringFieldOptions>(options?: O): StringFieldInstance<O>;
+}
+
+export interface BooleanFieldCtor {
+  new <O extends BooleanFieldOptions = BooleanFieldOptions>(options?: O): BooleanFieldInstance<O>;
+}
+
+export interface HTMLFieldCtor {
+  new <O extends HTMLFieldOptions = HTMLFieldOptions>(options?: O): HTMLFieldInstance<O>;
+}
+
+export interface ColorFieldCtor {
+  new <O extends ColorFieldOptions = ColorFieldOptions>(options?: O): ColorFieldInstance<O>;
+}
+
+export interface FilePathFieldCtor {
+  new <O extends FilePathFieldOptions = FilePathFieldOptions>(
+    options?: O,
+  ): FilePathFieldInstance<O>;
+}
+
+export interface ArrayFieldCtor {
+  new <Inner extends FieldInstance, O extends ArrayFieldOptions = ArrayFieldOptions>(
+    element: Inner,
+    options?: O,
+  ): ArrayFieldInstance<Inner, O>;
+}
+
+export interface SchemaFieldCtor {
+  new <S extends Record<string, FieldInstance>, O extends SchemaFieldOptions = SchemaFieldOptions>(
+    fields: S,
+    options?: O,
+  ): SchemaFieldInstance<S, O>;
+}
+
+/**
+ * Typed bag returned by `fields()`. Each property is the corresponding
+ * `foundry.data.fields.*` class — the runtime value is Foundry's own
+ * constructor; the type is our overlay.
+ */
+export interface FieldsApi {
+  readonly NumberField: NumberFieldCtor;
+  readonly StringField: StringFieldCtor;
+  readonly BooleanField: BooleanFieldCtor;
+  readonly HTMLField: HTMLFieldCtor;
+  readonly ColorField: ColorFieldCtor;
+  readonly FilePathField: FilePathFieldCtor;
+  readonly ArrayField: ArrayFieldCtor;
+  readonly SchemaField: SchemaFieldCtor;
+}
+
+interface FoundryDataNamespace {
+  readonly fields?: Record<string, unknown>;
+}
+
+interface FoundryRoot {
+  readonly data?: FoundryDataNamespace;
+}
+
+/**
+ * Resolve `globalThis.foundry.data.fields` and return it typed as `FieldsApi`.
+ *
+ * Call this inside `defineSchema()` (or any code that runs after Foundry's
+ * `init` hook). Calling at module scope will throw when imported from Node
+ * tests — the global only exists inside the Foundry runtime.
+ *
+ * @throws `VttfError` with code `VTTF-0002` when `foundry.data.fields` is
+ * missing.
+ */
+export function fields(): FieldsApi {
+  const foundry = (globalThis as Record<string, unknown>).foundry as FoundryRoot | undefined;
+  const f = foundry?.data?.fields;
+  if (f === undefined || f === null) {
+    throw new VttfError(
+      'VTTF-0002',
+      'foundry.data.fields is not available. Call fields() inside the Foundry runtime (or stub the global in tests).',
+    );
+  }
+  return f as unknown as FieldsApi;
+}

--- a/packages/core/src/data/infer-schema.ts
+++ b/packages/core/src/data/infer-schema.ts
@@ -1,0 +1,81 @@
+/**
+ * `InferSchema<T>` — derive the runtime shape of `actor.system` (or
+ * `item.system`) from a `defineSchema()` return value.
+ *
+ * v0.1 scope (PRD §7): the eight field brands in `./fields.ts`. Recurses
+ * through `ArrayField` and `SchemaField`. Out of scope until v1.0 (moves to
+ * `@vttforge/types`): `EmbeddedDataField`, `EmbeddedDocumentField`,
+ * `TypedSchemaField`, and the full required×initial nullability matrix.
+ *
+ * The single nullability rule honoured here is `nullable: true` → `T | null`.
+ * Combinations like `required: false, initial: undefined` → `T | undefined`
+ * are intentionally out of scope; documenting them would lock semantics that
+ * still need real-world validation against shipped systems.
+ */
+
+import type {
+  ArrayFieldInstance,
+  BooleanFieldInstance,
+  ColorFieldInstance,
+  FieldInstance,
+  FilePathFieldInstance,
+  HTMLFieldInstance,
+  NumberFieldInstance,
+  SchemaFieldInstance,
+  StringFieldInstance,
+} from './fields.js';
+
+/**
+ * Flatten an intersection / mapped type into a plain object literal so IDE
+ * hovers stay readable (Matt Pocock's `Prettify`). Use on every public
+ * conditional-type surface — PRD §7 TS-hygiene rule.
+ */
+export type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+type ApplyNullability<O, T> = O extends { nullable: true } ? T | null : T;
+
+/**
+ * Map a single field instance to its runtime TypeScript type. `never` for
+ * shapes we don't recognise — the v1.0 `@vttforge/types` package will widen
+ * this matrix to the remaining Foundry fields.
+ */
+export type InferField<F> =
+  F extends NumberFieldInstance<infer O>
+    ? ApplyNullability<O, number>
+    : F extends StringFieldInstance<infer O>
+      ? ApplyNullability<O, string>
+      : F extends BooleanFieldInstance<infer O>
+        ? ApplyNullability<O, boolean>
+        : F extends HTMLFieldInstance<infer O>
+          ? ApplyNullability<O, string>
+          : F extends ColorFieldInstance<infer O>
+            ? ApplyNullability<O, string>
+            : F extends FilePathFieldInstance<infer O>
+              ? ApplyNullability<O, string>
+              : F extends ArrayFieldInstance<infer Inner, infer O>
+                ? ApplyNullability<O, InferField<Inner>[]>
+                : F extends SchemaFieldInstance<infer S, infer O>
+                  ? ApplyNullability<O, InferSchema<S>>
+                  : never;
+
+/**
+ * Map a `defineSchema()` return value to the corresponding `system` shape.
+ *
+ * @example
+ * ```ts
+ * class CharacterData extends BaseTypeDataModel() {
+ *   static defineSchema() {
+ *     const f = fields();
+ *     return {
+ *       level: new f.NumberField({ required: true, initial: 1 }),
+ *       biography: new f.HTMLField(),
+ *     };
+ *   }
+ * }
+ * type CharacterSystem = InferSchema<ReturnType<typeof CharacterData.defineSchema>>;
+ * // → { level: number; biography: string }
+ * ```
+ */
+export type InferSchema<S extends Record<string, FieldInstance>> = Prettify<{
+  [K in keyof S]: InferField<S[K]>;
+}>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,12 +1,14 @@
 /**
  * @vttforge/core — runtime utilities for FoundryVTT v13+ systems and modules.
  *
- * v0.0.1 surface:
+ * v0.1 surface:
  *
  *   - registerSystem()             — one-call init, replaces Hooks.once("init")
  *   - SystemConfig                 — typed wrapper around game.settings
  *   - BaseTypeDataModel()          — TypeDataModel with safe migrateData default
  *   - BaseActorSheet()             — ActorSheetV2 + HandlebarsApplicationMixin
+ *   - fields()                     — typed bag of foundry.data.fields constructors
+ *   - InferSchema<T>               — derive `system` shape from defineSchema()
  *   - VttfError + error registry   — VTTF-NNNN codes with docs URLs
  *
  * Foundry classes are resolved from `globalThis.foundry` lazily so the package
@@ -14,10 +16,43 @@
  * `@vttforge/types` in v1.0.
  */
 
-export const VTTFORGE_CORE_VERSION = '0.0.1';
+export const VTTFORGE_CORE_VERSION = '0.1.0';
 
 export { BaseActorSheet, VTTFORGE_SHEET_CLASS } from './base-actor-sheet.js';
 export { BaseTypeDataModel } from './base-type-data-model.js';
+export type {
+  ArrayFieldOptions,
+  BooleanFieldOptions,
+  ColorFieldOptions,
+  DataFieldOptions,
+  FilePathFieldOptions,
+  HTMLFieldOptions,
+  NumberFieldOptions,
+  SchemaFieldOptions,
+  StringFieldOptions,
+} from './data/field-options.js';
+export {
+  type ArrayFieldCtor,
+  type ArrayFieldInstance,
+  type BooleanFieldCtor,
+  type BooleanFieldInstance,
+  type ColorFieldCtor,
+  type ColorFieldInstance,
+  type FieldInstance,
+  type FieldsApi,
+  type FilePathFieldCtor,
+  type FilePathFieldInstance,
+  fields,
+  type HTMLFieldCtor,
+  type HTMLFieldInstance,
+  type NumberFieldCtor,
+  type NumberFieldInstance,
+  type SchemaFieldCtor,
+  type SchemaFieldInstance,
+  type StringFieldCtor,
+  type StringFieldInstance,
+} from './data/fields.js';
+export type { InferField, InferSchema, Prettify } from './data/infer-schema.js';
 export {
   docsUrlFor,
   getErrorEntry,


### PR DESCRIPTION
## Summary

Internal planning slice — gives `BaseTypeDataModel` a real type story.

- New `fields()` factory: typed bag of `foundry.data.fields.*` constructors. Resolves `globalThis.foundry.data.fields` lazily and throws `VttfError VTTF-0002` when called outside the Foundry runtime — same lazy-resolution pattern already used by `BaseTypeDataModel()` and `BaseActorSheet()`.
- New `InferSchema<S>` conditional type: derives the `system` shape from `defineSchema()`. Recurses through `ArrayField` / `SchemaField`. Wrapped in `Prettify<T>` for IDE hover readability (PRD §7 TS-hygiene rule).
- 8 fields supported in v0.1 (PRD §7 partial scope): `NumberField`, `StringField`, `BooleanField`, `HTMLField`, `ArrayField`, `SchemaField`, `ColorField`, `FilePathField`. Single nullability rule honoured: `nullable: true` → `T | null`.
- `EmbeddedDataField`, `EmbeddedDocumentField`, `TypedSchemaField`, class-level generic, `$inferData`, and the full `required×initial` nullability matrix remain v1.0 scope and ship from `@vttforge/types`.

## Usage

```ts
import { BaseTypeDataModel, fields, type InferSchema } from '@vttforge/core';

class CharacterData extends BaseTypeDataModel() {
  static defineSchema() {
    const f = fields();
    return {
      level: new f.NumberField({ required: true, integer: true, initial: 1 }),
      health: new f.SchemaField({
        value: new f.NumberField({ required: true, initial: 10 }),
        max: new f.NumberField({ required: true, initial: 10 }),
      }),
      biography: new f.HTMLField(),
    };
  }
}

type CharacterSystem = InferSchema<ReturnType<typeof CharacterData.defineSchema>>;
// → { level: number; health: { value: number; max: number }; biography: string }
```

## Files

| Path | What |
|---|---|
| `packages/core/src/data/field-options.ts` | Option interfaces (`DataFieldOptions` + 8 specialised) |
| `packages/core/src/data/fields.ts` | Branded instance/ctor interfaces, `FieldsApi`, `fields()` |
| `packages/core/src/data/infer-schema.ts` | `Prettify<T>`, `InferField<F>`, `InferSchema<S>` |
| `packages/core/src/__tests__/infer-schema.test.ts` | 19 runtime + type-level tests (`expectTypeOf`) |
| `packages/core/src/index.ts` | Re-exports for the new surface |
| `.changeset/feat-core-fields-infer-schema.md` | `@vttforge/core` minor bump |

## Test plan

- [x] `pnpm typecheck` — all 10 tasks green
- [x] `pnpm test` — core suite: 32 → 51 tests (+19 new)
- [x] `pnpm build` — single bundled `dist/index.mjs` + `dist/index.d.mts`, no nested `data/` directory in the dist
- [x] `pnpm format` — biome clean
- [x] `pnpm lint` — biome ci + syncpack clean (only the pre-existing `RefuseToPinLocal` notices)
- [x] `pnpm --filter @vttforge/core publint` — all good
- [x] Smoke test in `examples/simple-system` (scratch `__smoke__.mts`) — types flow through, deleted before commit
- [ ] Manual sheet preview inside Foundry — out of scope for PR 5 (PR 6 covers the sheet surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
