### PR TITLE
chore(docker): add docker-compose.dev.yml for local Foundry v13

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Foundry VTT credentials for local development with Docker (docker-compose.dev.yml).
+# Copy this file to .env and fill in your values. Never commit .env.
+
+# Your Foundry VTT license key (https://foundryvtt.com → Purchased Licenses).
+FOUNDRY_LICENSE_KEY=
+
+# Your foundryvtt.com account credentials. Used by the felddy/foundryvtt image
+# to download the licensed Foundry distribution on first container start.
+FOUNDRY_USERNAME=
+FOUNDRY_PASSWORD=
+
+# Optional: override the container UID/GID so file permissions on the mounted
+# volumes match your host user. Defaults to macOS (501:20). Linux is usually 1000:1000.
+# FOUNDRY_UID=1000
+# FOUNDRY_GID=1000

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,25 @@ pnpm lint           # Biome lint + format check
 pnpm build          # tsdown build of every package
 ```
 
+### Running Foundry locally via Docker
+
+For sheet/runtime work you'll want a real Foundry v13 instance with the example system loaded. The repo ships a `docker-compose.dev.yml` that uses the [felddy/foundryvtt](https://hub.docker.com/r/felddy/foundryvtt) image and mounts `examples/simple-system` + `examples/simple-module` read-only into the container's data tree.
+
+1. **Copy the env template** and fill in your Foundry credentials (license key + foundryvtt.com login — these stay on your machine, never commit `.env`):
+   ```bash
+   cp .env.example .env
+   ```
+2. **Start Foundry:**
+   ```bash
+   docker compose -f docker-compose.dev.yml up
+   ```
+3. Open <http://localhost:30000>. On first boot the image downloads the licensed Foundry distribution into the `foundry-dev-data` volume (one-time, slow). Subsequent boots are fast.
+4. Inside Foundry, create a world using the **VTTForge Example** system (or activate the example module). Code changes in `examples/simple-system/` and `examples/simple-module/` are visible immediately — refresh the world to reload.
+
+`Ctrl+C` stops the container. To wipe Foundry state (worlds, settings) and start clean: `docker compose -f docker-compose.dev.yml down -v`.
+
+> Foundry credentials are personal and license-gated. We intentionally **do not** run Foundry in GitHub Actions — each contributor brings their own license for local smoke tests.
+
 ### Adding a changeset
 
 If your PR changes anything user-visible in any `@vttforge/*` package, **add a changeset**:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,18 @@
+services:
+  foundry:
+    image: felddy/foundryvtt:13
+    user: "${FOUNDRY_UID:-501}:${FOUNDRY_GID:-20}"
+    environment:
+      FOUNDRY_LICENSE_KEY: ${FOUNDRY_LICENSE_KEY}
+      FOUNDRY_USERNAME: ${FOUNDRY_USERNAME}
+      FOUNDRY_PASSWORD: ${FOUNDRY_PASSWORD}
+      CONTAINER_PRESERVE_CONFIG: "true"
+    volumes:
+      - foundry-dev-data:/data
+      - ./examples/simple-system:/data/Data/systems/vttforge-example:ro
+      - ./examples/simple-module:/data/Data/modules/vttforge-example-module:ro
+    ports:
+      - "30000:30000"
+
+volumes:
+  foundry-dev-data:


### PR DESCRIPTION
## Summary

Adapted from the [`ordem-paranormal`](https://github.com/fcsouza/ordemparanormal_fvtt) compose, scoped to the VTTForge monorepo:

- `felddy/foundryvtt:13` with personal credentials via `.env`
- `examples/simple-system` mounted read-only at `Data/systems/vttforge-example`
- `examples/simple-module` mounted read-only at `Data/modules/vttforge-example-module`
- UID/GID overridable via `FOUNDRY_UID` / `FOUNDRY_GID` (default macOS `501:20`; Linux contributors set `1000:1000`)

**Local-only by design.** Foundry licenses are personal and license-gated, so we intentionally do not run Foundry in GitHub Actions — each contributor brings their own license for local smoke tests. `CONTRIBUTING.md` gains a "Running Foundry locally via Docker" section.

## Why

PR 9 of [the internal roadmap](../blob/main/internal roadmap) targets `examples/simple-system` actually running inside Foundry. Without a one-command path to a real Foundry, that smoke test is "open Foundry by hand and symlink stuff" — fragile and undocumented. This unblocks all the sheet/runtime PRs (6, 7, 9).

## Test plan

- [x] `docker compose -f docker-compose.dev.yml config` validates (parses, mounts resolve to absolute host paths)
- [x] `.env.example` whitelist already present in `.gitignore` (`.env*` ignored, `!.env.example` allowed)
- [x] CONTRIBUTING.md instructions read top-to-bottom
- [ ] `docker compose up` on a clean machine + open <http://localhost:30000> + create world with the VTTForge Example system (run after merge with real credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
