### PR TITLE
feat(core): BaseActorSheet/BaseItemSheet boilerplate eliminators (PR 6)

### DIFF
--- a/.changeset/feat-core-actor-sheet-boilerplate.md
+++ b/.changeset/feat-core-actor-sheet-boilerplate.md
@@ -1,0 +1,26 @@
+---
+"@vttforge/core": minor
+---
+
+Extend `BaseActorSheet` and add `BaseItemSheet` — the boilerplate every shipping
+system copy-pastes is now hoisted into the SDK.
+
+- `static DRAG_DROP` — declare drag sources / drop targets as data; the base
+  wires real `foundry.applications.ux.DragDrop` instances in `_onRender` with
+  `isEditable`-gated permissions and a default `_onDragStart` that serialises
+  `data-item-id` elements as `{ type: "Item", uuid }`.
+- `_prepareContext` auto-fills `context.tabs[group]` for every group declared
+  in ApplicationV2's `static TABS`, eliminating manual `_prepareTabs(group)`
+  calls in subclass `_prepareContext`.
+- Typed drop dispatch: override `onDropItem(item, event)` / `onDropActor(...)` /
+  `onDropFolder(...)` / `onDropActiveEffect(...)` and skip the `fromUuid()`
+  ceremony. Returning `undefined` falls through to Foundry's default
+  `_onDropX`; return anything else to take ownership.
+- New `BaseItemSheet()` mirror with the same `static DRAG_DROP` + tab
+  auto-population, minus the drop dispatch (items rarely receive drops).
+- Exports new `DragDropConfig` type for typed `static DRAG_DROP` declarations.
+
+`editImage` is intentionally not reinvented — it already ships on
+`DocumentSheetV2` (inherited by both `ActorSheetV2` and `ItemSheetV2`).
+Templates wire `<img data-edit="img">` and Foundry's built-in action handles
+the `FilePicker` flow.

--- a/packages/core/src/__tests__/base-actor-sheet.test.ts
+++ b/packages/core/src/__tests__/base-actor-sheet.test.ts
@@ -1,28 +1,64 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { BaseActorSheet, VTTFORGE_SHEET_CLASS } from '../base-actor-sheet.js';
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseActorSheet, type DragDropConfig, VTTFORGE_SHEET_CLASS } from '../base-actor-sheet.js';
 import { VttfError } from '../errors/registry.js';
 
-class FakeActorSheetV2 {}
+class FakeActorSheetV2 {
+  async _prepareContext(_options: unknown): Promise<Record<string, unknown>> {
+    return { fromSuper: true };
+  }
+  _onRender(_context: unknown, _options: unknown): void {
+    /* foundry super */
+  }
+  async _onDrop(_event: DragEvent): Promise<void> {
+    /* foundry super dispatcher */
+  }
+  async _onDropItem(_event: DragEvent, _data: { uuid?: string }): Promise<string> {
+    return 'super:_onDropItem';
+  }
+  async _onDropActor(_event: DragEvent, _data: { uuid?: string }): Promise<string> {
+    return 'super:_onDropActor';
+  }
+  async _onDropFolder(_event: DragEvent, _data: { uuid?: string }): Promise<string> {
+    return 'super:_onDropFolder';
+  }
+  async _onDropActiveEffect(_event: DragEvent, _data: { uuid?: string }): Promise<string> {
+    return 'super:_onDropActiveEffect';
+  }
+}
 
 const HandlebarsApplicationMixin = (base: typeof FakeActorSheetV2) =>
   class extends base {
     static readonly _mixed = true;
   };
 
+const dragDropBinds: Array<{ config: Record<string, unknown>; element: HTMLElement }> = [];
+
+class FakeDragDrop {
+  constructor(public config: Record<string, unknown>) {}
+  bind(element: HTMLElement): void {
+    dragDropBinds.push({ config: this.config, element });
+  }
+}
+
 beforeEach(() => {
+  dragDropBinds.length = 0;
   (globalThis as Record<string, unknown>).foundry = {
     applications: {
       sheets: { ActorSheetV2: FakeActorSheetV2 },
       api: { HandlebarsApplicationMixin },
+      ux: { DragDrop: FakeDragDrop },
     },
   };
 });
 
 afterEach(() => {
   delete (globalThis as Record<string, unknown>).foundry;
+  delete (globalThis as Record<string, unknown>).fromUuid;
 });
 
-describe('BaseActorSheet', () => {
+describe('BaseActorSheet — runtime resolution', () => {
   it('throws VTTF-0002 when the required globals are missing', () => {
     delete (globalThis as Record<string, unknown>).foundry;
     expect(() => BaseActorSheet()).toThrow(VttfError);
@@ -34,15 +70,17 @@ describe('BaseActorSheet', () => {
     expect(instance).toBeInstanceOf(FakeActorSheetV2);
     expect((Sub as unknown as { _mixed: boolean })._mixed).toBe(true);
   });
+});
 
-  it('always ships the vttforge marker class in DEFAULT_OPTIONS', () => {
+describe('BaseActorSheet — DEFAULT_OPTIONS', () => {
+  it('always ships the vttforge marker class', () => {
     const Sub = BaseActorSheet();
     const opts = (Sub as unknown as { DEFAULT_OPTIONS: { classes: readonly string[] } })
       .DEFAULT_OPTIONS;
     expect(opts.classes).toContain(VTTFORGE_SHEET_CLASS);
   });
 
-  it('defaults DEFAULT_OPTIONS to a sensible form-mode submitOnChange config', () => {
+  it('defaults to a submitOnChange form configuration', () => {
     const Sub = BaseActorSheet();
     const opts = (
       Sub as unknown as {
@@ -57,5 +95,219 @@ describe('BaseActorSheet', () => {
     expect(opts.form.submitOnChange).toBe(true);
     expect(opts.form.closeOnSubmit).toBe(false);
     expect(opts.window.resizable).toBe(true);
+  });
+
+  it('defaults DRAG_DROP to an empty array', () => {
+    const Sub = BaseActorSheet();
+    const dragDrop = (Sub as unknown as { DRAG_DROP: readonly unknown[] }).DRAG_DROP;
+    expect(dragDrop).toEqual([]);
+  });
+});
+
+describe('BaseActorSheet — _prepareContext tab auto-population', () => {
+  it('calls super._prepareContext and injects context.tabs for every TABS group', async () => {
+    const Base = BaseActorSheet();
+    const prepareTabs = vi.fn((group: string) => ({ group, active: 'first' }));
+    class Sheet extends Base {
+      static TABS = {
+        primary: { tabs: [{ id: 'first', group: 'primary', label: 'First' }], initial: 'first' },
+        secondary: { tabs: [{ id: 'a', group: 'secondary', label: 'A' }], initial: 'a' },
+      };
+      _prepareTabs = prepareTabs;
+    }
+    const instance = new Sheet();
+    const ctx = (await instance._prepareContext({})) as Record<string, unknown>;
+    expect(ctx.fromSuper).toBe(true);
+    expect(prepareTabs).toHaveBeenCalledWith('primary');
+    expect(prepareTabs).toHaveBeenCalledWith('secondary');
+    expect(ctx.tabs).toEqual({
+      primary: { group: 'primary', active: 'first' },
+      secondary: { group: 'secondary', active: 'first' },
+    });
+  });
+
+  it('skips tab injection when no TABS are declared', async () => {
+    const Base = BaseActorSheet();
+    class Sheet extends Base {}
+    const instance = new Sheet();
+    const ctx = (await instance._prepareContext({})) as Record<string, unknown>;
+    expect(ctx.fromSuper).toBe(true);
+    expect(ctx.tabs).toBeUndefined();
+  });
+});
+
+describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
+  it('does nothing when DRAG_DROP is empty', () => {
+    const Sub = BaseActorSheet();
+    const instance = new Sub();
+    (instance as { element: HTMLElement }).element = document.createElement('div');
+    instance._onRender({}, {});
+    expect(dragDropBinds).toHaveLength(0);
+  });
+
+  it('binds one DragDrop per static DRAG_DROP entry with default permissions and callbacks', () => {
+    const Base = BaseActorSheet();
+    class Sheet extends Base {
+      static DRAG_DROP: ReadonlyArray<DragDropConfig> = [
+        { dragSelector: '.item[draggable]' },
+        { dropSelector: '.inventory' },
+      ];
+    }
+    const instance = new Sheet();
+    const element = document.createElement('div');
+    (instance as { element: HTMLElement }).element = element;
+    (instance as { isEditable: boolean }).isEditable = true;
+    instance._onRender({}, {});
+    expect(dragDropBinds).toHaveLength(2);
+    const first = dragDropBinds[0]!;
+    expect(first.element).toBe(element);
+    expect(first.config.dragSelector).toBe('.item[draggable]');
+    const perms = first.config.permissions as { dragstart: () => boolean; drop: () => boolean };
+    expect(perms.dragstart()).toBe(true);
+    expect(perms.drop()).toBe(true);
+    const callbacks = first.config.callbacks as Record<string, unknown>;
+    expect(typeof callbacks.dragstart).toBe('function');
+    expect(typeof callbacks.drop).toBe('function');
+  });
+
+  it('honours user-supplied permissions and callbacks (user wins over defaults)', () => {
+    const Base = BaseActorSheet();
+    const customDrag = vi.fn();
+    class Sheet extends Base {
+      static DRAG_DROP: ReadonlyArray<DragDropConfig> = [
+        {
+          dragSelector: '.x',
+          permissions: { dragstart: () => false, drop: () => false },
+          callbacks: { dragstart: customDrag },
+        },
+      ];
+    }
+    const instance = new Sheet();
+    (instance as { element: HTMLElement }).element = document.createElement('div');
+    (instance as { isEditable: boolean }).isEditable = true;
+    instance._onRender({}, {});
+    expect(dragDropBinds).toHaveLength(1);
+    const entry = dragDropBinds[0]!;
+    const perms = entry.config.permissions as { dragstart: () => boolean; drop: () => boolean };
+    expect(perms.dragstart()).toBe(false);
+    expect(perms.drop()).toBe(false);
+    const callbacks = entry.config.callbacks as Record<string, unknown>;
+    expect(callbacks.dragstart).toBe(customDrag);
+  });
+
+  it('isEditable false locks dragstart and drop', () => {
+    const Base = BaseActorSheet();
+    class Sheet extends Base {
+      static DRAG_DROP: ReadonlyArray<DragDropConfig> = [{ dragSelector: '.item' }];
+    }
+    const instance = new Sheet();
+    (instance as { element: HTMLElement }).element = document.createElement('div');
+    (instance as { isEditable: boolean }).isEditable = false;
+    instance._onRender({}, {});
+    const perms = dragDropBinds[0]!.config.permissions as {
+      dragstart: () => boolean;
+      drop: () => boolean;
+    };
+    expect(perms.dragstart()).toBe(false);
+    expect(perms.drop()).toBe(false);
+  });
+});
+
+describe('BaseActorSheet — default _onDragStart', () => {
+  it('serializes the item identified by data-item-id', () => {
+    const Sub = BaseActorSheet();
+    const instance = new Sub();
+    (instance as { document: { items: { get(id: string): { uuid: string } } } }).document = {
+      items: { get: (id) => ({ uuid: `Item.${id}` }) },
+    };
+    const setData = vi.fn();
+    const target = document.createElement('li');
+    target.dataset.itemId = 'abc';
+    const event = {
+      currentTarget: target,
+      dataTransfer: { setData },
+    } as unknown as DragEvent;
+    instance._onDragStart(event);
+    expect(setData).toHaveBeenCalledWith(
+      'application/json',
+      JSON.stringify({ type: 'Item', uuid: 'Item.abc' }),
+    );
+  });
+
+  it('does nothing when the target has no data-item-id', () => {
+    const Sub = BaseActorSheet();
+    const instance = new Sub();
+    const setData = vi.fn();
+    const event = {
+      currentTarget: document.createElement('div'),
+      dataTransfer: { setData },
+    } as unknown as DragEvent;
+    instance._onDragStart(event);
+    expect(setData).not.toHaveBeenCalled();
+  });
+});
+
+describe('BaseActorSheet — typed drop dispatch', () => {
+  function setupFromUuid(uuid: string, doc: unknown): void {
+    (globalThis as Record<string, unknown>).fromUuid = vi
+      .fn()
+      .mockImplementation(async (u: string) => (u === uuid ? doc : null));
+  }
+
+  it('routes _onDropItem → onDropItem with the resolved document; returning a value short-circuits super', async () => {
+    setupFromUuid('Item.x', { id: 'x', kind: 'item' });
+    const Base = BaseActorSheet();
+    const onDropItem = vi.fn().mockResolvedValue('subclass-handled');
+    class Sheet extends Base {
+      onDropItem = onDropItem;
+    }
+    const instance = new Sheet();
+    const event = {} as DragEvent;
+    const result = await instance._onDropItem(event, { uuid: 'Item.x' });
+    expect(onDropItem).toHaveBeenCalledWith({ id: 'x', kind: 'item' }, event);
+    expect(result).toBe('subclass-handled');
+  });
+
+  it('falls through to super when the sugar returns undefined', async () => {
+    setupFromUuid('Item.y', { id: 'y' });
+    const Base = BaseActorSheet();
+    class Sheet extends Base {
+      onDropItem = vi.fn().mockResolvedValue(undefined);
+    }
+    const instance = new Sheet();
+    const result = await instance._onDropItem({} as DragEvent, { uuid: 'Item.y' });
+    expect(result).toBe('super:_onDropItem');
+  });
+
+  it('falls through to super when fromUuid resolves to null', async () => {
+    setupFromUuid('Item.missing', null);
+    const Base = BaseActorSheet();
+    class Sheet extends Base {
+      onDropItem = vi.fn();
+    }
+    const instance = new Sheet();
+    const result = await instance._onDropItem({} as DragEvent, { uuid: 'Other.id' });
+    expect(result).toBe('super:_onDropItem');
+  });
+
+  it('dispatches all four document kinds to their typed sugar handlers', async () => {
+    (globalThis as Record<string, unknown>).fromUuid = vi.fn(async (u: string) => ({ uuid: u }));
+    const Base = BaseActorSheet();
+    const onActor = vi.fn().mockResolvedValue('actor-ok');
+    const onFolder = vi.fn().mockResolvedValue('folder-ok');
+    const onEffect = vi.fn().mockResolvedValue('effect-ok');
+    class Sheet extends Base {
+      onDropActor = onActor;
+      onDropFolder = onFolder;
+      onDropActiveEffect = onEffect;
+    }
+    const instance = new Sheet();
+    const evt = {} as DragEvent;
+    expect(await instance._onDropActor(evt, { uuid: 'Actor.a' })).toBe('actor-ok');
+    expect(await instance._onDropFolder(evt, { uuid: 'Folder.f' })).toBe('folder-ok');
+    expect(await instance._onDropActiveEffect(evt, { uuid: 'ActiveEffect.e' })).toBe('effect-ok');
+    expect(onActor).toHaveBeenCalledWith({ uuid: 'Actor.a' }, evt);
+    expect(onFolder).toHaveBeenCalledWith({ uuid: 'Folder.f' }, evt);
+    expect(onEffect).toHaveBeenCalledWith({ uuid: 'ActiveEffect.e' }, evt);
   });
 });

--- a/packages/core/src/__tests__/base-item-sheet.test.ts
+++ b/packages/core/src/__tests__/base-item-sheet.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VTTFORGE_SHEET_CLASS } from '../base-actor-sheet.js';
+import { BaseItemSheet } from '../base-item-sheet.js';
+import { VttfError } from '../errors/registry.js';
+
+class FakeItemSheetV2 {
+  async _prepareContext(_options: unknown): Promise<Record<string, unknown>> {
+    return { fromSuper: true };
+  }
+  _onRender(_context: unknown, _options: unknown): void {
+    /* foundry super */
+  }
+}
+
+const HandlebarsApplicationMixin = (base: typeof FakeItemSheetV2) =>
+  class extends base {
+    static readonly _mixed = true;
+  };
+
+const dragDropBinds: Array<{ config: Record<string, unknown>; element: HTMLElement }> = [];
+
+class FakeDragDrop {
+  constructor(public config: Record<string, unknown>) {}
+  bind(element: HTMLElement): void {
+    dragDropBinds.push({ config: this.config, element });
+  }
+}
+
+beforeEach(() => {
+  dragDropBinds.length = 0;
+  (globalThis as Record<string, unknown>).foundry = {
+    applications: {
+      sheets: { ItemSheetV2: FakeItemSheetV2 },
+      api: { HandlebarsApplicationMixin },
+      ux: { DragDrop: FakeDragDrop },
+    },
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).foundry;
+});
+
+describe('BaseItemSheet', () => {
+  it('throws VTTF-0002 when the required globals are missing', () => {
+    delete (globalThis as Record<string, unknown>).foundry;
+    expect(() => BaseItemSheet()).toThrow(VttfError);
+  });
+
+  it('returns a class that extends ItemSheetV2 via HandlebarsApplicationMixin', () => {
+    const Sub = BaseItemSheet();
+    const instance = new Sub();
+    expect(instance).toBeInstanceOf(FakeItemSheetV2);
+    expect((Sub as unknown as { _mixed: boolean })._mixed).toBe(true);
+  });
+
+  it('always ships the vttforge marker class', () => {
+    const Sub = BaseItemSheet();
+    const opts = (Sub as unknown as { DEFAULT_OPTIONS: { classes: readonly string[] } })
+      .DEFAULT_OPTIONS;
+    expect(opts.classes).toContain(VTTFORGE_SHEET_CLASS);
+  });
+
+  it('defaults to submitOnChange and a narrower position than the actor sheet', () => {
+    const Sub = BaseItemSheet();
+    const opts = (
+      Sub as unknown as {
+        DEFAULT_OPTIONS: {
+          form: { submitOnChange: boolean; closeOnSubmit: boolean };
+          position: { width: number; height: number };
+        };
+      }
+    ).DEFAULT_OPTIONS;
+    expect(opts.form.submitOnChange).toBe(true);
+    expect(opts.form.closeOnSubmit).toBe(false);
+    expect(opts.position.width).toBeLessThan(600);
+  });
+
+  it('auto-fills context.tabs for every TABS group', async () => {
+    const Base = BaseItemSheet();
+    const prepareTabs = vi.fn((group: string) => ({ group }));
+    class Sheet extends Base {
+      static TABS = {
+        primary: { tabs: [{ id: 'desc', group: 'primary', label: 'Desc' }], initial: 'desc' },
+      };
+      _prepareTabs = prepareTabs;
+    }
+    const instance = new Sheet();
+    const ctx = (await instance._prepareContext({})) as Record<string, unknown>;
+    expect(ctx.fromSuper).toBe(true);
+    expect(prepareTabs).toHaveBeenCalledWith('primary');
+    expect(ctx.tabs).toEqual({ primary: { group: 'primary' } });
+  });
+
+  it('binds DragDrop entries declared via static DRAG_DROP', () => {
+    const Base = BaseItemSheet();
+    class Sheet extends Base {
+      static DRAG_DROP = [{ dragSelector: '.item' }];
+    }
+    const instance = new Sheet();
+    (instance as { element: HTMLElement }).element = document.createElement('div');
+    (instance as { isEditable: boolean }).isEditable = true;
+    instance._onRender({}, {});
+    expect(dragDropBinds).toHaveLength(1);
+    const perms = dragDropBinds[0]!.config.permissions as {
+      dragstart: () => boolean;
+      drop: () => boolean;
+    };
+    expect(perms.dragstart()).toBe(true);
+  });
+});

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -1,15 +1,29 @@
 /**
- * BaseActorSheet — minimal `ActorSheetV2 + HandlebarsApplicationMixin` baseline.
+ * BaseActorSheet — `ActorSheetV2 + HandlebarsApplicationMixin` baseline with the
+ * boilerplate every shipping system copy-pastes hoisted into the SDK.
  *
- * v0.1 surface intentionally small:
+ * What this adds beyond stock Foundry v13:
  *
- * - Resolves `foundry.applications.sheets.ActorSheetV2` and
- *   `foundry.applications.api.HandlebarsApplicationMixin` from globalThis.
- * - Ships a `DEFAULT_OPTIONS` template subclasses merge into, including the
- *   `vttforge` marker class so consumer CSS can scope safely (per
- *   foundry-vtt-system-dev §"Styling & Themes" rule #2).
- * - DragDrop wiring, _getTabs elimination, image picker — all v0.1-close, not
- *   foundation.
+ * - **`static DRAG_DROP`** — declare drag sources / drop targets as data, get
+ *   `foundry.applications.ux.DragDrop` instances wired in `_onRender` with
+ *   `isEditable`-gated permissions and a sensible default `_onDragStart` that
+ *   serialises `data-item-id` elements as `{ type: "Item", uuid }`.
+ * - **`_prepareContext` auto-fills `context.tabs[group]`** for every group
+ *   declared in ApplicationV2's `static TABS`, so subclass `_prepareContext`
+ *   implementations stop having to call `_prepareTabs(group)` by hand.
+ * - **Typed drop dispatch** — override `onDropItem(item, event)` /
+ *   `onDropActor(actor, event)` / `onDropFolder(folder, event)` /
+ *   `onDropActiveEffect(effect, event)` and skip the `fromUuid()` ceremony.
+ *   Returning `undefined` falls through to Foundry's default `_onDropX`
+ *   behaviour; return any other value to take ownership.
+ *
+ * Intentional non-additions:
+ *
+ * - `editImage` action — already shipped by `DocumentSheetV2` (inherited by
+ *   `ActorSheetV2`). Templates wire `<img data-edit="img">` and Foundry's
+ *   built-in action handles the `FilePicker` flow.
+ * - `_getTabs()` — ApplicationV2 already owns the tab state machine; we only
+ *   eliminate the `_prepareTabs` call in `_prepareContext`.
  *
  * Resolved lazily so subclasses can be declared at module load without
  * Foundry globals existing yet (test boot, ESM hoist).
@@ -20,6 +34,31 @@ import { VttfError } from './errors/registry.js';
 // biome-ignore lint/suspicious/noExplicitAny: Foundry's ActorSheetV2 shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
 
+/**
+ * Declarative DragDrop entry consumed by `_onRender`. Mirrors the
+ * `foundry.applications.ux.DragDrop` constructor config. Permissions and
+ * callbacks fall back to sensible defaults that honour `this.isEditable` and
+ * the default `_onDragStart` / `_onDrop`.
+ */
+export interface DragDropConfig {
+  readonly dragSelector?: string;
+  readonly dropSelector?: string;
+  readonly permissions?: {
+    readonly dragstart?: () => boolean;
+    readonly drop?: () => boolean;
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: DragEvent payload is browser-native; consumers route to their own typed handlers
+  readonly callbacks?: Record<string, (...args: any[]) => unknown>;
+}
+
+interface DragDropInstance {
+  bind(element: HTMLElement): void;
+}
+
+interface DragDropCtor {
+  new (config: Record<string, unknown>): DragDropInstance;
+}
+
 interface FoundryApplicationsApi {
   HandlebarsApplicationMixin?: (base: AnyConstructor) => AnyConstructor;
 }
@@ -28,9 +67,14 @@ interface FoundryApplicationsSheets {
   ActorSheetV2?: AnyConstructor;
 }
 
+interface FoundryApplicationsUx {
+  DragDrop?: DragDropCtor;
+}
+
 interface FoundryApplications {
   api?: FoundryApplicationsApi;
   sheets?: FoundryApplicationsSheets;
+  ux?: FoundryApplicationsUx;
 }
 
 interface FoundryGlobal {
@@ -50,6 +94,25 @@ function resolveBases(): { Base: AnyConstructor; mixin: (b: AnyConstructor) => A
   return { Base, mixin };
 }
 
+function resolveDragDrop(): DragDropCtor | undefined {
+  const foundry = (globalThis as Record<string, unknown>).foundry as FoundryGlobal | undefined;
+  const ctor = foundry?.applications?.ux?.DragDrop;
+  return typeof ctor === 'function' ? ctor : undefined;
+}
+
+async function resolveFromUuid(uuid: string): Promise<unknown> {
+  const fn = (globalThis as Record<string, unknown>).fromUuid as
+    | ((u: string) => Promise<unknown>)
+    | undefined;
+  if (typeof fn !== 'function') return null;
+  return fn(uuid);
+}
+
+interface DropPayload {
+  readonly type?: string;
+  readonly uuid?: string;
+}
+
 /**
  * Marker class that consumer CSS uses for scoping. Always present on every
  * VTTForge-derived sheet so rules like `.vttforge .actor-sheet { ... }` work.
@@ -57,17 +120,33 @@ function resolveBases(): { Base: AnyConstructor; mixin: (b: AnyConstructor) => A
 export const VTTFORGE_SHEET_CLASS = 'vttforge';
 
 /**
- * Build the `BaseActorSheet` for the current Foundry runtime.
+ * Build the `BaseActorSheet` for the current Foundry runtime. See module
+ * header for the boilerplate this base eliminates.
  *
- * Subclasses look like:
- *
- *   class CharacterSheet extends BaseActorSheet() {
- *     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
- *       super.DEFAULT_OPTIONS,
- *       { classes: ['my-system'], position: { width: 720 } }
- *     );
- *     static PARTS = { ... };
+ * @example
+ * ```ts
+ * class CharacterSheet extends BaseActorSheet() {
+ *   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+ *     super.DEFAULT_OPTIONS,
+ *     { classes: ['my-system'], position: { width: 720 } },
+ *   );
+ *   static PARTS = { ... };
+ *   static TABS = {
+ *     primary: {
+ *       tabs: [
+ *         { id: 'features', group: 'primary', label: 'Features' },
+ *         { id: 'inventory', group: 'primary', label: 'Inventory' },
+ *       ],
+ *       initial: 'features',
+ *     },
+ *   };
+ *   static DRAG_DROP = [{ dragSelector: '.item[draggable=true]', dropSelector: null }];
+ *   async onDropItem(item, event) {
+ *     if (item.type !== 'weapon') return false;
+ *     // …fall through to super by returning undefined.
  *   }
+ * }
+ * ```
  */
 export function BaseActorSheet(): AnyConstructor {
   const { Base, mixin } = resolveBases();
@@ -82,6 +161,163 @@ export function BaseActorSheet(): AnyConstructor {
       form: { submitOnChange: true, closeOnSubmit: false },
       actions: {},
     } as const;
+
+    /**
+     * Declarative DragDrop entries. Each becomes a
+     * `foundry.applications.ux.DragDrop` instance bound in `_onRender`.
+     * Subclasses override by re-declaring `static DRAG_DROP = [...]`.
+     */
+    static readonly DRAG_DROP: ReadonlyArray<DragDropConfig> = [];
+
+    /**
+     * Augment ApplicationV2's context with `tabs[group]` for every group
+     * declared in `static TABS`, so subclasses can render tabs without
+     * having to call `_prepareTabs(group)` manually.
+     */
+    async _prepareContext(options: unknown): Promise<Record<string, unknown>> {
+      const superPrepare = (
+        Mixed.prototype as {
+          _prepareContext?: (options: unknown) => Promise<Record<string, unknown>>;
+        }
+      )._prepareContext;
+      const context =
+        typeof superPrepare === 'function'
+          ? ((await superPrepare.call(this, options)) as Record<string, unknown>)
+          : {};
+      const tabsConfig = (this.constructor as { TABS?: Record<string, unknown> }).TABS;
+      if (tabsConfig && typeof tabsConfig === 'object') {
+        const groups = Object.keys(tabsConfig);
+        if (groups.length > 0) {
+          const prepareTabs = (this as { _prepareTabs?: (group: string) => unknown })._prepareTabs;
+          const tabs: Record<string, unknown> = {};
+          for (const group of groups) {
+            tabs[group] = typeof prepareTabs === 'function' ? prepareTabs.call(this, group) : {};
+          }
+          context.tabs = tabs;
+        }
+      }
+      return context;
+    }
+
+    /**
+     * Wire each `static DRAG_DROP` entry into a real `DragDrop` instance.
+     * Permissions default to `this.isEditable`; callbacks default to
+     * `_onDragStart` / `_onDrop`. Subclasses extending `_onRender` MUST call
+     * `super._onRender(context, options)` to keep DragDrop wired.
+     */
+    _onRender(context: unknown, options: unknown): void {
+      const superRender = (
+        Mixed.prototype as { _onRender?: (context: unknown, options: unknown) => void }
+      )._onRender;
+      if (typeof superRender === 'function') {
+        superRender.call(this, context, options);
+      }
+      const configs = (this.constructor as { DRAG_DROP?: ReadonlyArray<DragDropConfig> }).DRAG_DROP;
+      if (!configs?.length) return;
+      const DragDrop = resolveDragDrop();
+      if (!DragDrop) return;
+      const element = (this as { element?: HTMLElement }).element;
+      if (!element) return;
+      const onDragStart = (this as { _onDragStart?: (event: DragEvent) => void })._onDragStart;
+      const onDrop = (this as { _onDrop?: (event: DragEvent) => void })._onDrop;
+      for (const cfg of configs) {
+        new DragDrop({
+          dragSelector: cfg.dragSelector,
+          dropSelector: cfg.dropSelector,
+          permissions: {
+            dragstart: cfg.permissions?.dragstart ?? (() => this.#isEditable()),
+            drop: cfg.permissions?.drop ?? (() => this.#isEditable()),
+          },
+          callbacks: {
+            ...(typeof onDragStart === 'function' ? { dragstart: onDragStart.bind(this) } : {}),
+            ...(typeof onDrop === 'function' ? { drop: onDrop.bind(this) } : {}),
+            ...(cfg.callbacks ?? {}),
+          },
+        }).bind(element);
+      }
+    }
+
+    /**
+     * Default drag handler — serialises the item identified by
+     * `data-item-id` on the drag source element. Override for richer payloads
+     * (Actor drags, custom UUIDs).
+     */
+    _onDragStart(event: DragEvent): void {
+      const target = event.currentTarget as HTMLElement | null;
+      const itemId = target?.dataset?.itemId;
+      if (!itemId || !event.dataTransfer) return;
+      const items = (
+        this as { document?: { items?: { get(id: string): { uuid: string } | undefined } } }
+      ).document?.items;
+      const item = items?.get(itemId);
+      if (!item) return;
+      event.dataTransfer.setData(
+        'application/json',
+        JSON.stringify({ type: 'Item', uuid: item.uuid }),
+      );
+    }
+
+    /**
+     * Typed drop sugar. Subclasses override this instead of `_onDropItem`
+     * to skip the `fromUuid()` ceremony. Return `undefined` to fall through
+     * to Foundry's default `_onDropItem`; return anything else to take
+     * ownership of the drop.
+     */
+    async onDropItem(_item: unknown, _event: DragEvent): Promise<unknown> {
+      return undefined;
+    }
+    async onDropActor(_actor: unknown, _event: DragEvent): Promise<unknown> {
+      return undefined;
+    }
+    async onDropFolder(_folder: unknown, _event: DragEvent): Promise<unknown> {
+      return undefined;
+    }
+    async onDropActiveEffect(_effect: unknown, _event: DragEvent): Promise<unknown> {
+      return undefined;
+    }
+
+    async _onDropItem(event: DragEvent, data: DropPayload): Promise<unknown> {
+      return this.#dispatchDrop('_onDropItem', 'onDropItem', event, data);
+    }
+    async _onDropActor(event: DragEvent, data: DropPayload): Promise<unknown> {
+      return this.#dispatchDrop('_onDropActor', 'onDropActor', event, data);
+    }
+    async _onDropFolder(event: DragEvent, data: DropPayload): Promise<unknown> {
+      return this.#dispatchDrop('_onDropFolder', 'onDropFolder', event, data);
+    }
+    async _onDropActiveEffect(event: DragEvent, data: DropPayload): Promise<unknown> {
+      return this.#dispatchDrop('_onDropActiveEffect', 'onDropActiveEffect', event, data);
+    }
+
+    async #dispatchDrop(
+      superKey: '_onDropItem' | '_onDropActor' | '_onDropFolder' | '_onDropActiveEffect',
+      sugarKey: 'onDropItem' | 'onDropActor' | 'onDropFolder' | 'onDropActiveEffect',
+      event: DragEvent,
+      data: DropPayload,
+    ): Promise<unknown> {
+      const uuid = data?.uuid;
+      if (uuid) {
+        const doc = await resolveFromUuid(uuid);
+        if (doc) {
+          const result = await (
+            this as unknown as Record<
+              typeof sugarKey,
+              (doc: unknown, event: DragEvent) => Promise<unknown>
+            >
+          )[sugarKey](doc, event);
+          if (result !== undefined) return result;
+        }
+      }
+      const superFn = (Mixed.prototype as Record<typeof superKey, unknown>)[superKey] as
+        | ((event: DragEvent, data: DropPayload) => Promise<unknown>)
+        | undefined;
+      if (typeof superFn === 'function') return superFn.call(this, event, data);
+      return undefined;
+    }
+
+    #isEditable(): boolean {
+      return Boolean((this as { isEditable?: boolean }).isEditable);
+    }
   }
 
   return VttforgeBaseActorSheet as unknown as AnyConstructor;

--- a/packages/core/src/base-item-sheet.ts
+++ b/packages/core/src/base-item-sheet.ts
@@ -1,0 +1,175 @@
+/**
+ * BaseItemSheet — `ItemSheetV2 + HandlebarsApplicationMixin` baseline. Mirror
+ * of `BaseActorSheet` minus the typed drop dispatch (items rarely receive
+ * drops; the rare case that does can override `_onDrop` directly).
+ *
+ * Carries the same boilerplate-eliminators:
+ *
+ * - `static DRAG_DROP` — declarative `foundry.applications.ux.DragDrop` wiring
+ *   in `_onRender`, with `isEditable`-gated permissions.
+ * - `_prepareContext` auto-fills `context.tabs[group]` for every group declared
+ *   in ApplicationV2's `static TABS`.
+ *
+ * As with `BaseActorSheet`, `editImage` is intentionally not added — it ships
+ * built-in on `DocumentSheetV2` (parent of `ItemSheetV2`).
+ */
+
+import type { DragDropConfig } from './base-actor-sheet.js';
+import { VTTFORGE_SHEET_CLASS } from './base-actor-sheet.js';
+import { VttfError } from './errors/registry.js';
+
+// biome-ignore lint/suspicious/noExplicitAny: Foundry's ItemSheetV2 shape lives in fvtt-types (deferred to @vttforge/types v1.0)
+type AnyConstructor = new (...args: any[]) => any;
+
+interface DragDropInstance {
+  bind(element: HTMLElement): void;
+}
+
+interface DragDropCtor {
+  new (config: Record<string, unknown>): DragDropInstance;
+}
+
+interface FoundryApplicationsApi {
+  HandlebarsApplicationMixin?: (base: AnyConstructor) => AnyConstructor;
+}
+
+interface FoundryApplicationsSheets {
+  ItemSheetV2?: AnyConstructor;
+}
+
+interface FoundryApplicationsUx {
+  DragDrop?: DragDropCtor;
+}
+
+interface FoundryApplications {
+  api?: FoundryApplicationsApi;
+  sheets?: FoundryApplicationsSheets;
+  ux?: FoundryApplicationsUx;
+}
+
+interface FoundryGlobal {
+  applications?: FoundryApplications;
+}
+
+function resolveBases(): { Base: AnyConstructor; mixin: (b: AnyConstructor) => AnyConstructor } {
+  const foundry = (globalThis as Record<string, unknown>).foundry as FoundryGlobal | undefined;
+  const Base = foundry?.applications?.sheets?.ItemSheetV2;
+  const mixin = foundry?.applications?.api?.HandlebarsApplicationMixin;
+  if (typeof Base !== 'function' || typeof mixin !== 'function') {
+    throw new VttfError(
+      'VTTF-0002',
+      'foundry.applications.sheets.ItemSheetV2 and/or foundry.applications.api.HandlebarsApplicationMixin are not available. Define your BaseItemSheet subclasses inside the Foundry runtime (or stub the global in tests).',
+    );
+  }
+  return { Base, mixin };
+}
+
+function resolveDragDrop(): DragDropCtor | undefined {
+  const foundry = (globalThis as Record<string, unknown>).foundry as FoundryGlobal | undefined;
+  const ctor = foundry?.applications?.ux?.DragDrop;
+  return typeof ctor === 'function' ? ctor : undefined;
+}
+
+/**
+ * Build the `BaseItemSheet` for the current Foundry runtime.
+ *
+ * @example
+ * ```ts
+ * class WeaponSheet extends BaseItemSheet() {
+ *   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+ *     super.DEFAULT_OPTIONS,
+ *     { classes: ['my-system'], position: { width: 540 } },
+ *   );
+ *   static PARTS = { ... };
+ *   static TABS = {
+ *     primary: {
+ *       tabs: [
+ *         { id: 'description', group: 'primary', label: 'Description' },
+ *         { id: 'details', group: 'primary', label: 'Details' },
+ *       ],
+ *       initial: 'description',
+ *     },
+ *   };
+ * }
+ * ```
+ */
+export function BaseItemSheet(): AnyConstructor {
+  const { Base, mixin } = resolveBases();
+  const Mixed = mixin(Base);
+
+  class VttforgeBaseItemSheet extends Mixed {
+    static readonly DEFAULT_OPTIONS = {
+      classes: [VTTFORGE_SHEET_CLASS],
+      window: { resizable: true },
+      position: { width: 520, height: 480 },
+      tag: 'form',
+      form: { submitOnChange: true, closeOnSubmit: false },
+      actions: {},
+    } as const;
+
+    static readonly DRAG_DROP: ReadonlyArray<DragDropConfig> = [];
+
+    async _prepareContext(options: unknown): Promise<Record<string, unknown>> {
+      const superPrepare = (
+        Mixed.prototype as {
+          _prepareContext?: (options: unknown) => Promise<Record<string, unknown>>;
+        }
+      )._prepareContext;
+      const context =
+        typeof superPrepare === 'function'
+          ? ((await superPrepare.call(this, options)) as Record<string, unknown>)
+          : {};
+      const tabsConfig = (this.constructor as { TABS?: Record<string, unknown> }).TABS;
+      if (tabsConfig && typeof tabsConfig === 'object') {
+        const groups = Object.keys(tabsConfig);
+        if (groups.length > 0) {
+          const prepareTabs = (this as { _prepareTabs?: (group: string) => unknown })._prepareTabs;
+          const tabs: Record<string, unknown> = {};
+          for (const group of groups) {
+            tabs[group] = typeof prepareTabs === 'function' ? prepareTabs.call(this, group) : {};
+          }
+          context.tabs = tabs;
+        }
+      }
+      return context;
+    }
+
+    _onRender(context: unknown, options: unknown): void {
+      const superRender = (
+        Mixed.prototype as { _onRender?: (context: unknown, options: unknown) => void }
+      )._onRender;
+      if (typeof superRender === 'function') {
+        superRender.call(this, context, options);
+      }
+      const configs = (this.constructor as { DRAG_DROP?: ReadonlyArray<DragDropConfig> }).DRAG_DROP;
+      if (!configs?.length) return;
+      const DragDrop = resolveDragDrop();
+      if (!DragDrop) return;
+      const element = (this as { element?: HTMLElement }).element;
+      if (!element) return;
+      const onDragStart = (this as { _onDragStart?: (event: DragEvent) => void })._onDragStart;
+      const onDrop = (this as { _onDrop?: (event: DragEvent) => void })._onDrop;
+      for (const cfg of configs) {
+        new DragDrop({
+          dragSelector: cfg.dragSelector,
+          dropSelector: cfg.dropSelector,
+          permissions: {
+            dragstart: cfg.permissions?.dragstart ?? (() => this.#isEditable()),
+            drop: cfg.permissions?.drop ?? (() => this.#isEditable()),
+          },
+          callbacks: {
+            ...(typeof onDragStart === 'function' ? { dragstart: onDragStart.bind(this) } : {}),
+            ...(typeof onDrop === 'function' ? { drop: onDrop.bind(this) } : {}),
+            ...(cfg.callbacks ?? {}),
+          },
+        }).bind(element);
+      }
+    }
+
+    #isEditable(): boolean {
+      return Boolean((this as { isEditable?: boolean }).isEditable);
+    }
+  }
+
+  return VttforgeBaseItemSheet as unknown as AnyConstructor;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@
  *   - SystemConfig                 — typed wrapper around game.settings
  *   - BaseTypeDataModel()          — TypeDataModel with safe migrateData default
  *   - BaseActorSheet()             — ActorSheetV2 + HandlebarsApplicationMixin
+ *   - BaseItemSheet()              — ItemSheetV2 + HandlebarsApplicationMixin
  *   - fields()                     — typed bag of foundry.data.fields constructors
  *   - InferSchema<T>               — derive `system` shape from defineSchema()
  *   - VttfError + error registry   — VTTF-NNNN codes with docs URLs
@@ -16,9 +17,14 @@
  * `@vttforge/types` in v1.0.
  */
 
-export const VTTFORGE_CORE_VERSION = '0.1.0';
+export const VTTFORGE_CORE_VERSION = '0.2.0';
 
-export { BaseActorSheet, VTTFORGE_SHEET_CLASS } from './base-actor-sheet.js';
+export {
+  BaseActorSheet,
+  type DragDropConfig,
+  VTTFORGE_SHEET_CLASS,
+} from './base-actor-sheet.js';
+export { BaseItemSheet } from './base-item-sheet.js';
 export { BaseTypeDataModel } from './base-type-data-model.js';
 export type {
   ArrayFieldOptions,


### PR DESCRIPTION
## Summary

Internal planning slice — the real SDK win: hoist the 100+ lines every shipping system copy-pastes for sheet wiring into `@vttforge/core`.

**Surface additions:**

- **`static DRAG_DROP`** — declarative `foundry.applications.ux.DragDrop` config bag wired in `_onRender` with `isEditable`-gated permissions and a default `_onDragStart` that serialises `data-item-id` elements as `{ type: "Item", uuid }`. New exported type `DragDropConfig` for typed declarations.
- **Auto-populated `context.tabs[group]`** — `_prepareContext` injects the result of `_prepareTabs(group)` for every group declared in ApplicationV2's `static TABS`, so subclass `_prepareContext` implementations stop having to do it by hand.
- **Typed drop dispatch** — `onDropItem(item, event)` / `onDropActor` / `onDropFolder` / `onDropActiveEffect` skip the `fromUuid()` ceremony. Return `undefined` to fall through to Foundry's default; return anything else to take ownership.
- **`BaseItemSheet()`** — mirror class for `ItemSheetV2` with the same TABS + DRAG_DROP surface (no drop dispatch — items rarely receive drops).

**Intentional non-additions** (changed from the original plan after verifying against the v13 API):

- `editImage` already ships on `DocumentSheetV2.DEFAULT_OPTIONS.actions`. Templates wire `<img data-edit="img">` and the built-in handler opens `FilePicker`. Don't reinvent.
- `_getTabs()` — ApplicationV2 already owns the tab state machine. We only eliminate the `_prepareTabs` boilerplate in `_prepareContext`.

## Usage

```ts
class CharacterSheet extends BaseActorSheet() {
  static DEFAULT_OPTIONS = foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
    classes: ['my-system'],
    position: { width: 720 },
  });

  static PARTS = { /* … */ };

  static TABS = {
    primary: {
      tabs: [
        { id: 'features', group: 'primary', label: 'Features' },
        { id: 'inventory', group: 'primary', label: 'Inventory' },
      ],
      initial: 'features',
    },
  };

  static DRAG_DROP = [{ dragSelector: '.item[draggable=true]', dropSelector: null }];

  async onDropItem(item, event) {
    if (item.type !== 'weapon') return false; // taken over — no super
    // return undefined → falls through to Foundry's default _onDropItem
  }
}
```

Compare with what the system used to ship: ~36 lines for `#createDragDropHandlers`, ~50 lines of `_getTabs`/`_prepareTabs` plumbing, ~15 lines of `fromUuid` ceremony per drop type. All gone.

## Files

| Path | What |
|---|---|
| `packages/core/src/base-actor-sheet.ts` | Extended with DRAG_DROP, tab auto-fill, typed drop dispatch |
| `packages/core/src/base-item-sheet.ts` | New — mirror for ItemSheetV2 |
| `packages/core/src/index.ts` | Re-exports + `VTTFORGE_CORE_VERSION` realigned to `0.2.0` |
| `packages/core/src/__tests__/base-actor-sheet.test.ts` | 13 new cases (DRAG_DROP wiring, drop dispatch, isEditable gates) |
| `packages/core/src/__tests__/base-item-sheet.test.ts` | New mirror test file |
| `.changeset/feat-core-actor-sheet-boilerplate.md` | `@vttforge/core` minor bump |

## Test plan

- [x] `pnpm typecheck` — 10 tasks green
- [x] `pnpm test` — core: 51 → 70 (+19 new); happy-dom env applied to the sheet tests via `// @vitest-environment happy-dom`
- [x] `pnpm build` — `dist/index.mjs` grew from ~14kB to ~21kB; single bundle, no nested directories
- [x] `pnpm format` / `pnpm lint` — biome ci clean (4 non-blocking warnings on `!` non-null in test array indexing)
- [x] `pnpm --filter @vttforge/core publint` — all good
- [ ] Manual smoke inside Foundry via `docker-compose.dev.yml` (PR #8) once `examples/simple-system` lands a real sheet in PR 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
