### PR TITLE
feat(core): createMigrationRunner() + onReady lifecycle (PR 7)

### DIFF
--- a/.changeset/feat-core-migration-runner.md
+++ b/.changeset/feat-core-migration-runner.md
@@ -1,0 +1,28 @@
+---
+"@vttforge/core": minor
+---
+
+Add `createMigrationRunner()` for declarative schema migrations, plus
+`onReady` lifecycle on `registerSystem()`.
+
+`createMigrationRunner({ systemId, migrations, ... })` returns `{ register(),
+run(), targetVersion }`. Call `register()` from `init` to register the
+`schemaVersion` setting; call `run()` from `ready` (gated by
+`game.user.isGM`) to execute every pending migration in order. Migrations use
+semver versions and `foundry.utils.isNewerVersion` for comparison — the same
+contract `system.json`'s `flags.<systemId>.needsMigrationVersion` /
+`compatibleMigrationVersion` use, matching the dnd5e production pattern.
+
+Failure semantics: `schemaVersion` is committed per-migration, so a
+mid-sequence throw leaves the world at the last successful version and the
+retry on the next world load picks up exactly where it failed. Migration
+errors are wrapped in `VttfError VTTF-0004` with the original error on
+`.cause`; calling `run()` against a world older than `compatibleVersion`
+throws `VttfError VTTF-0005`.
+
+`registerSystem()` gains `onReady?: () => void | Promise<void>` — the natural
+place to wire `migrationRunner.run()`. Not GM-gated; consumer guards inside
+their callback.
+
+New error codes (append-only): `VTTF-0004 MigrationFailed`,
+`VTTF-0005 WorldTooOldForMigration`.

--- a/packages/core/src/__tests__/migrations.test.ts
+++ b/packages/core/src/__tests__/migrations.test.ts
@@ -1,0 +1,399 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { VttfError } from '../errors/registry.js';
+import type { GameSettingsApi } from '../foundry-globals.js';
+import { createMigrationRunner } from '../migrations/runner.js';
+import type { Migration, MigrationLogger } from '../migrations/types.js';
+
+function makeSettings(initial: Record<string, string> = {}): GameSettingsApi & {
+  store: Record<string, string>;
+  registerSpy: ReturnType<typeof vi.fn>;
+} {
+  const store: Record<string, string> = { ...initial };
+  const registerSpy = vi.fn();
+  return {
+    store,
+    registerSpy,
+    register(namespace: string, key: string, config: unknown): void {
+      registerSpy(namespace, key, config);
+    },
+    get<T = unknown>(namespace: string, key: string): T {
+      return store[`${namespace}.${key}`] as unknown as T;
+    },
+    async set<T>(namespace: string, key: string, value: T): Promise<T> {
+      store[`${namespace}.${key}`] = value as unknown as string;
+      return value;
+    },
+  };
+}
+
+function makeLogger(): MigrationLogger & { calls: Array<[string, string]> } {
+  const calls: Array<[string, string]> = [];
+  return {
+    calls,
+    info: (m) => {
+      calls.push(['info', m]);
+    },
+    warn: (m) => {
+      calls.push(['warn', m]);
+    },
+    error: (m) => {
+      calls.push(['error', m]);
+    },
+  };
+}
+
+const INITIAL = '0.0.0';
+const FOUNDRY_NEWER = (next: string, current: string): boolean => {
+  const parse = (v: string) => v.split('.').map((p) => Number.parseInt(p, 10) || 0);
+  const a = parse(next);
+  const b = parse(current);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai > bi) return true;
+    if (ai < bi) return false;
+  }
+  return false;
+};
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).foundry;
+  delete (globalThis as Record<string, unknown>).game;
+  delete (globalThis as Record<string, unknown>).ui;
+});
+
+describe('createMigrationRunner — basics', () => {
+  it('targetVersion is the last migration version', () => {
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        { version: '1.0.0', fn: vi.fn() },
+        { version: '2.0.0', fn: vi.fn() },
+      ],
+      settings: makeSettings(),
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    expect(runner.targetVersion).toBe('2.0.0');
+  });
+
+  it('targetVersion is "0.0.0" when no migrations are declared', () => {
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [],
+      settings: makeSettings(),
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    expect(runner.targetVersion).toBe(INITIAL);
+  });
+
+  it('run() is a no-op when no migrations are declared', async () => {
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [],
+      settings: makeSettings(),
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    expect(await runner.run()).toEqual([]);
+  });
+});
+
+describe('createMigrationRunner — register()', () => {
+  it('registers the schemaVersion setting on the configured systemId', () => {
+    const settings = makeSettings();
+    const runner = createMigrationRunner({
+      systemId: 'my-system',
+      migrations: [{ version: '1.0.0', fn: vi.fn() }],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    runner.register();
+    expect(settings.registerSpy).toHaveBeenCalledTimes(1);
+    const [namespace, key, config] = settings.registerSpy.mock.calls[0]!;
+    expect(namespace).toBe('my-system');
+    expect(key).toBe('schemaVersion');
+    expect((config as { scope: string; config: boolean; default: string }).scope).toBe('world');
+    expect((config as { config: boolean }).config).toBe(false);
+    expect((config as { default: string }).default).toBe('0.0.0');
+  });
+
+  it('honours custom settingKey', () => {
+    const settings = makeSettings();
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      settingKey: 'dataVersion',
+      migrations: [{ version: '1.0.0', fn: vi.fn() }],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    runner.register();
+    expect(settings.registerSpy.mock.calls[0]![1]).toBe('dataVersion');
+  });
+});
+
+describe('createMigrationRunner — run()', () => {
+  it('returns [] when stored version equals targetVersion', async () => {
+    const settings = makeSettings({ 'sys.schemaVersion': '2.0.0' });
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        { version: '1.0.0', fn: fn1 },
+        { version: '2.0.0', fn: fn2 },
+      ],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    expect(await runner.run()).toEqual([]);
+    expect(fn1).not.toHaveBeenCalled();
+    expect(fn2).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when stored version is newer than targetVersion', async () => {
+    const settings = makeSettings({ 'sys.schemaVersion': '3.0.0' });
+    const fn = vi.fn();
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [{ version: '2.0.0', fn }],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    expect(await runner.run()).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('runs every migration in order from a fresh world and advances schemaVersion to the target', async () => {
+    const order: string[] = [];
+    const settings = makeSettings();
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        {
+          version: '1.0.0',
+          fn: async () => {
+            order.push('v1');
+          },
+        },
+        {
+          version: '1.5.0',
+          fn: async () => {
+            order.push('v1.5');
+          },
+        },
+        {
+          version: '2.0.0',
+          fn: async () => {
+            order.push('v2');
+          },
+        },
+      ],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    const ran = await runner.run();
+    expect(order).toEqual(['v1', 'v1.5', 'v2']);
+    expect(ran).toEqual(['1.0.0', '1.5.0', '2.0.0']);
+    expect(settings.store['sys.schemaVersion']).toBe('2.0.0');
+  });
+
+  it('skips migrations already covered by stored version', async () => {
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    const fn3 = vi.fn();
+    const settings = makeSettings({ 'sys.schemaVersion': '1.5.0' });
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        { version: '1.0.0', fn: fn1 },
+        { version: '1.5.0', fn: fn2 },
+        { version: '2.0.0', fn: fn3 },
+      ],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    const ran = await runner.run();
+    expect(fn1).not.toHaveBeenCalled();
+    expect(fn2).not.toHaveBeenCalled();
+    expect(fn3).toHaveBeenCalledOnce();
+    expect(ran).toEqual(['2.0.0']);
+  });
+
+  it('persists schemaVersion incrementally — each migration commits before the next starts', async () => {
+    const settings = makeSettings();
+    const observed: string[] = [];
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        {
+          version: '1.0.0',
+          fn: () => {
+            observed.push(`before:${settings.store['sys.schemaVersion'] ?? 'undefined'}`);
+          },
+        },
+        {
+          version: '2.0.0',
+          fn: () => {
+            observed.push(`before:${settings.store['sys.schemaVersion'] ?? 'undefined'}`);
+          },
+        },
+      ],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    await runner.run();
+    expect(observed).toEqual(['before:undefined', 'before:1.0.0']);
+  });
+});
+
+describe('createMigrationRunner — VTTF-0004 failure handling', () => {
+  it('wraps a thrown migration in VttfError VTTF-0004 with the original error as cause', async () => {
+    const original = new Error('boom');
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        {
+          version: '1.0.0',
+          description: 'breaks things',
+          fn: () => {
+            throw original;
+          },
+        },
+      ],
+      settings: makeSettings(),
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    const err = await runner.run().catch((e) => e);
+    expect(err).toBeInstanceOf(VttfError);
+    expect((err as VttfError).code).toBe('VTTF-0004');
+    expect((err as VttfError).cause).toBe(original);
+    expect((err as VttfError).message).toContain('breaks things');
+  });
+
+  it('leaves schemaVersion at the last successful migration when a later one throws', async () => {
+    const settings = makeSettings();
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        { version: '1.0.0', fn: vi.fn() },
+        { version: '2.0.0', fn: vi.fn() },
+        {
+          version: '3.0.0',
+          fn: () => {
+            throw new Error('nope');
+          },
+        },
+      ],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    await runner.run().catch(() => {});
+    expect(settings.store['sys.schemaVersion']).toBe('2.0.0');
+  });
+
+  it('does not modify schemaVersion when the very first migration throws', async () => {
+    const settings = makeSettings();
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        {
+          version: '1.0.0',
+          fn: () => {
+            throw new Error('nope');
+          },
+        },
+      ],
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    await runner.run().catch(() => {});
+    expect(settings.store['sys.schemaVersion']).toBeUndefined();
+  });
+
+  it('throws VTTF-0004 when migrations are out of order', async () => {
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [
+        { version: '2.0.0', fn: vi.fn() },
+        { version: '1.0.0', fn: vi.fn() },
+      ],
+      settings: makeSettings(),
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    const err = await runner.run().catch((e) => e);
+    expect((err as VttfError).code).toBe('VTTF-0004');
+    expect((err as VttfError).message).toContain('out of order');
+  });
+});
+
+describe('createMigrationRunner — VTTF-0005 compatibleVersion floor', () => {
+  it('throws VTTF-0005 when stored version is strictly older than compatibleVersion', async () => {
+    const settings = makeSettings({ 'sys.schemaVersion': '0.5.0' });
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [{ version: '2.0.0', fn: vi.fn() }],
+      compatibleVersion: '1.0.0',
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    const err = await runner.run().catch((e) => e);
+    expect((err as VttfError).code).toBe('VTTF-0005');
+  });
+
+  it('allows runs when stored version equals compatibleVersion', async () => {
+    const fn = vi.fn();
+    const settings = makeSettings({ 'sys.schemaVersion': '1.0.0' });
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [{ version: '2.0.0', fn }],
+      compatibleVersion: '1.0.0',
+      settings,
+      logger: makeLogger(),
+      isNewerVersion: FOUNDRY_NEWER,
+    });
+    expect(await runner.run()).toEqual(['2.0.0']);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('createMigrationRunner — default resolution fallbacks', () => {
+  it('throws VTTF-0002 when run() is called without game.settings (and no override)', async () => {
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [{ version: '1.0.0', fn: vi.fn() }],
+    });
+    const err = await runner.run().catch((e) => e);
+    expect(err).toBeInstanceOf(VttfError);
+    expect((err as VttfError).code).toBe('VTTF-0002');
+  });
+
+  it('resolves foundry.utils.isNewerVersion from globalThis by default', async () => {
+    const isNewer = vi.fn(
+      (next: string, current: string) =>
+        next.localeCompare(current, undefined, { numeric: true }) > 0,
+    );
+    (globalThis as Record<string, unknown>).foundry = { utils: { isNewerVersion: isNewer } };
+    const runner = createMigrationRunner({
+      systemId: 'sys',
+      migrations: [{ version: '2.0.0', fn: vi.fn() }] as ReadonlyArray<Migration>,
+      settings: makeSettings(),
+      logger: makeLogger(),
+    });
+    await runner.run();
+    expect(isNewer).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/__tests__/register-system.test.ts
+++ b/packages/core/src/__tests__/register-system.test.ts
@@ -138,4 +138,49 @@ describe('registerSystem', () => {
     const initCallback = hooks.once.mock.calls[0]?.[1] as () => void;
     expect(() => initCallback()).toThrow(VttfError);
   });
+
+  it('does not register a ready hook when onReady is omitted', () => {
+    const { hooks } = setupFoundryGlobals();
+    registerSystem({ id: 'my-system' });
+    const readyCalls = hooks.once.mock.calls.filter((call) => call[0] === 'ready');
+    expect(readyCalls).toHaveLength(0);
+  });
+
+  it('schedules onReady via Hooks.once("ready")', () => {
+    const { hooks } = setupFoundryGlobals();
+    const onReady = vi.fn();
+    registerSystem({ id: 'my-system', onReady });
+    const readyCall = hooks.once.mock.calls.find((call) => call[0] === 'ready');
+    expect(readyCall).toBeDefined();
+    expect(typeof readyCall?.[1]).toBe('function');
+  });
+
+  it('invokes onReady when the ready hook fires', () => {
+    const { hooks } = setupFoundryGlobals();
+    const onReady = vi.fn();
+    registerSystem({ id: 'my-system', onReady });
+    const readyCallback = hooks.once.mock.calls.find((call) => call[0] === 'ready')?.[1] as
+      | (() => void)
+      | undefined;
+    expect(readyCallback).toBeDefined();
+    readyCallback?.();
+    expect(onReady).toHaveBeenCalledOnce();
+  });
+
+  it('supports async onReady (returned promise is fire-and-forget)', async () => {
+    const { hooks } = setupFoundryGlobals();
+    let resolved = false;
+    const onReady = vi.fn(async () => {
+      await Promise.resolve();
+      resolved = true;
+    });
+    registerSystem({ id: 'my-system', onReady });
+    const readyCallback = hooks.once.mock.calls.find((call) => call[0] === 'ready')?.[1] as
+      | (() => void)
+      | undefined;
+    readyCallback?.();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(resolved).toBe(true);
+    expect(onReady).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/core/src/errors/registry.ts
+++ b/packages/core/src/errors/registry.ts
@@ -40,6 +40,18 @@ const REGISTRY: Readonly<Record<VttfErrorCode, VttfErrorEntry>> = Object.freeze(
     summary:
       'SystemConfig.get() / set() was called with a key that was never passed to SystemConfig.register(). Register the setting in your init hook before reading it.',
   }),
+  'VTTF-0004': Object.freeze({
+    code: 'VTTF-0004',
+    name: 'MigrationFailed',
+    summary:
+      'A migration function passed to createMigrationRunner() threw. The original error is available on .cause. The schemaVersion setting is not advanced past the failed migration so retrying on the next world load picks up where the failure left off.',
+  }),
+  'VTTF-0005': Object.freeze({
+    code: 'VTTF-0005',
+    name: 'WorldTooOldForMigration',
+    summary:
+      'createMigrationRunner() was called on a world whose stored schemaVersion is older than the configured compatibleVersion floor. Upgrade the world to a supported intermediate version before continuing — running migrations across the gap would corrupt data.',
+  }),
 });
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@
  *   - BaseItemSheet()              — ItemSheetV2 + HandlebarsApplicationMixin
  *   - fields()                     — typed bag of foundry.data.fields constructors
  *   - InferSchema<T>               — derive `system` shape from defineSchema()
+ *   - createMigrationRunner()      — declarative schema migrations (register + run)
  *   - VttfError + error registry   — VTTF-NNNN codes with docs URLs
  *
  * Foundry classes are resolved from `globalThis.foundry` lazily so the package
@@ -78,5 +79,12 @@ export type {
   SettingConfig,
   SettingScope,
 } from './foundry-globals.js';
+export { createMigrationRunner } from './migrations/runner.js';
+export type {
+  Migration,
+  MigrationLogger,
+  MigrationRunner,
+  MigrationRunnerOptions,
+} from './migrations/types.js';
 export { registerSystem, type SystemRegistration } from './register-system.js';
 export { SystemConfig } from './system-config.js';

--- a/packages/core/src/migrations/runner.ts
+++ b/packages/core/src/migrations/runner.ts
@@ -1,0 +1,237 @@
+/**
+ * `createMigrationRunner` — declarative schema migrations for Foundry systems.
+ *
+ * Replaces the copy-pasted "schemaVersion setting + Hooks.once('ready') +
+ * isNewerVersion compare + sequential await" pattern documented in the
+ * foundry-vtt-system-dev skill (§"Data Migration" and `references/data-migration.md`
+ * §5 "Migration Registry"). The runner owns no hooks — call `register()` from
+ * your `init` hook and `run()` from your `ready` hook (gated by
+ * `game.user.isGM`).
+ *
+ * Versions are semver strings, compared with `foundry.utils.isNewerVersion` —
+ * the same comparator dnd5e uses for production migrations (see
+ * `foundry-vtt-system-dev` `references/production-patterns.md` §8 "Migration
+ * Versioning via System Flags"). This lines up cleanly with `system.json`'s
+ * `flags.<systemId>.needsMigrationVersion` / `compatibleMigrationVersion`.
+ *
+ * Failures advance `schemaVersion` only past migrations that *completed* — a
+ * mid-sequence throw leaves the world at the last successful version so the
+ * retry on the next world load picks up exactly where it failed.
+ */
+
+import { VttfError } from '../errors/registry.js';
+import type { GameSettingsApi } from '../foundry-globals.js';
+import type {
+  Migration,
+  MigrationLogger,
+  MigrationRunner,
+  MigrationRunnerOptions,
+} from './types.js';
+
+const DEFAULT_SETTING_KEY = 'schemaVersion';
+const INITIAL_VERSION = '0.0.0';
+
+interface FoundryUtilsApi {
+  isNewerVersion?: (next: string, current: string) => boolean;
+}
+
+interface FoundryUiNotifications {
+  info?: (msg: string) => unknown;
+  warn?: (msg: string) => unknown;
+  error?: (msg: string) => unknown;
+}
+
+function resolveIsNewerVersion(): (next: string, current: string) => boolean {
+  const foundry = (globalThis as Record<string, unknown>).foundry as
+    | { utils?: FoundryUtilsApi }
+    | undefined;
+  const fn = foundry?.utils?.isNewerVersion;
+  if (typeof fn === 'function') return fn;
+  // Last-resort fallback for non-Foundry runtimes — naive numeric semver compare.
+  // Real consumers always run inside Foundry where the proper comparator exists.
+  return naiveIsNewerVersion;
+}
+
+function naiveIsNewerVersion(next: string, current: string): boolean {
+  const parse = (v: string): number[] =>
+    v.split('.').map((part) => {
+      const n = Number.parseInt(part, 10);
+      return Number.isNaN(n) ? 0 : n;
+    });
+  const a = parse(next);
+  const b = parse(current);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai > bi) return true;
+    if (ai < bi) return false;
+  }
+  return false;
+}
+
+function resolveSettings(): GameSettingsApi {
+  const game = (globalThis as Record<string, unknown>).game as
+    | { settings?: GameSettingsApi }
+    | undefined;
+  const settings = game?.settings;
+  if (
+    settings === undefined ||
+    typeof settings.register !== 'function' ||
+    typeof settings.get !== 'function' ||
+    typeof settings.set !== 'function'
+  ) {
+    throw new VttfError(
+      'VTTF-0002',
+      'globalThis.game.settings is not available — call createMigrationRunner().register() inside the Foundry runtime (or pass an explicit settings adapter in MigrationRunnerOptions).',
+    );
+  }
+  return settings;
+}
+
+function resolveLogger(): MigrationLogger {
+  const ui = (globalThis as Record<string, unknown>).ui as
+    | { notifications?: FoundryUiNotifications }
+    | undefined;
+  const notifications = ui?.notifications;
+  return {
+    info(message) {
+      console.info(message);
+      notifications?.info?.(message);
+    },
+    warn(message) {
+      console.warn(message);
+      notifications?.warn?.(message);
+    },
+    error(message) {
+      console.error(message);
+      notifications?.error?.(message);
+    },
+  };
+}
+
+function lastVersion(migrations: ReadonlyArray<Migration>): string {
+  if (migrations.length === 0) return INITIAL_VERSION;
+  return migrations[migrations.length - 1]!.version;
+}
+
+function assertAscending(
+  migrations: ReadonlyArray<Migration>,
+  isNewer: (next: string, current: string) => boolean,
+): void {
+  for (let i = 1; i < migrations.length; i++) {
+    const prev = migrations[i - 1]!.version;
+    const next = migrations[i]!.version;
+    if (!isNewer(next, prev)) {
+      throw new VttfError(
+        'VTTF-0004',
+        `Migration list out of order: ${next} must be newer than ${prev}.`,
+      );
+    }
+  }
+}
+
+/**
+ * Build a migration runner for a system. See module header for the failure
+ * semantics; see `Migration` JSDoc for the per-entry shape.
+ *
+ * @example
+ * ```ts
+ * const migrations = createMigrationRunner({
+ *   systemId: 'my-system',
+ *   migrations: [
+ *     { version: '1.0.0', description: 'Rename bio → biography', fn: migrateV1 },
+ *     { version: '2.0.0', description: 'Add hp.temp', fn: migrateV2 },
+ *   ],
+ *   compatibleVersion: '0.9.0',
+ * });
+ *
+ * registerSystem({
+ *   id: 'my-system',
+ *   onAfterInit: () => migrations.register(),
+ *   onReady: async () => {
+ *     if (!game.user.isGM) return;
+ *     await migrations.run();
+ *   },
+ * });
+ * ```
+ */
+export function createMigrationRunner(options: MigrationRunnerOptions): MigrationRunner {
+  const settingKey = options.settingKey ?? DEFAULT_SETTING_KEY;
+  const target = lastVersion(options.migrations);
+  const settingsOverride = options.settings;
+  const loggerOverride = options.logger;
+  const isNewerOverride = options.isNewerVersion;
+
+  return {
+    targetVersion: target,
+
+    register(): void {
+      const settings = settingsOverride ?? resolveSettings();
+      settings.register<string>(options.systemId, settingKey, {
+        name: 'Schema Version',
+        hint: 'Internal schema version for VTTForge data migration tracking. Do not edit by hand.',
+        scope: 'world',
+        config: false,
+        type: String,
+        default: INITIAL_VERSION,
+      });
+    },
+
+    async run(): Promise<ReadonlyArray<string>> {
+      if (options.migrations.length === 0) return [];
+
+      const settings = settingsOverride ?? resolveSettings();
+      const logger = loggerOverride ?? resolveLogger();
+      const isNewer = isNewerOverride ?? resolveIsNewerVersion();
+
+      assertAscending(options.migrations, isNewer);
+
+      const stored = settings.get<string>(options.systemId, settingKey);
+      const current = stored ?? INITIAL_VERSION;
+
+      if (options.compatibleVersion !== undefined) {
+        if (isNewer(options.compatibleVersion, current)) {
+          throw new VttfError(
+            'VTTF-0005',
+            `World schemaVersion ${current} is older than ${options.systemId}'s compatibleVersion ${options.compatibleVersion}. Upgrade through an intermediate release first.`,
+          );
+        }
+      }
+
+      const pending = options.migrations.filter((m) => isNewer(m.version, current));
+      if (pending.length === 0) return [];
+
+      const ran: string[] = [];
+      let lastApplied = current;
+      logger.warn(
+        `${options.systemId} | Running ${pending.length} pending migration(s) from ${current} to ${target}.`,
+      );
+
+      for (const migration of pending) {
+        const label = migration.description
+          ? `${migration.version} — ${migration.description}`
+          : migration.version;
+        logger.info(`${options.systemId} | Migrating to ${label}`);
+        try {
+          await migration.fn();
+        } catch (cause) {
+          if (isNewer(lastApplied, current)) {
+            await settings.set(options.systemId, settingKey, lastApplied);
+          }
+          throw new VttfError(
+            'VTTF-0004',
+            `Migration to ${label} failed for system "${options.systemId}". schemaVersion left at ${lastApplied}.`,
+            { cause },
+          );
+        }
+        await settings.set(options.systemId, settingKey, migration.version);
+        lastApplied = migration.version;
+        ran.push(migration.version);
+      }
+
+      logger.info(`${options.systemId} | Migration complete. schemaVersion = ${target}.`);
+      return ran;
+    },
+  };
+}

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Public types for `createMigrationRunner()`.
+ *
+ * Versions are semver strings so they line up with `system.json`'s
+ * `flags.<systemId>.needsMigrationVersion` / `compatibleMigrationVersion` and
+ * with `foundry.utils.isNewerVersion` (the comparator dnd5e uses in
+ * production). A migration that targets `"2.4.0"` runs once the stored
+ * `schemaVersion` is anything strictly older than `"2.4.0"`.
+ */
+
+import type { GameSettingsApi } from '../foundry-globals.js';
+
+export interface Migration {
+  /** Semver version this migration brings the world to. */
+  readonly version: string;
+  /** Optional human-readable description — logged when the migration runs and shown in error messages. */
+  readonly description?: string;
+  /** The migration body. May be sync or async. Should be idempotent (safe to re-run after partial failure). */
+  readonly fn: () => void | Promise<void>;
+}
+
+export interface MigrationLogger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+export interface MigrationRunnerOptions {
+  /** System id — used as the `game.settings` namespace. */
+  readonly systemId: string;
+  /** Migrations in ascending version order. Empty array is allowed (`run()` is a no-op then). */
+  readonly migrations: ReadonlyArray<Migration>;
+  /** Settings key under `systemId`. Defaults to `'schemaVersion'`. */
+  readonly settingKey?: string;
+  /**
+   * Compatibility floor — worlds with a stored schemaVersion strictly older than this
+   * throw `VttfError VTTF-0005` instead of running migrations. Mirrors the
+   * `flags.<systemId>.compatibleMigrationVersion` declaration in `system.json`.
+   */
+  readonly compatibleVersion?: string;
+  /**
+   * Override the semver comparator. Defaults to `foundry.utils.isNewerVersion`
+   * resolved at call time. Test-only injection.
+   */
+  readonly isNewerVersion?: (next: string, current: string) => boolean;
+  /**
+   * Override `game.settings`. Defaults to `globalThis.game.settings` resolved
+   * at call time. Test-only injection.
+   */
+  readonly settings?: GameSettingsApi;
+  /**
+   * Override the logger. Defaults to a `console` + `ui.notifications` adapter.
+   * Test-only injection.
+   */
+  readonly logger?: MigrationLogger;
+}
+
+export interface MigrationRunner {
+  /** The target version (last migration's `version`, or `'0.0.0'` if the list is empty). */
+  readonly targetVersion: string;
+  /**
+   * Register the `schemaVersion` setting. Call once from your `init` hook so
+   * Foundry knows about it before any world load. Re-calls are idempotent (the
+   * underlying `game.settings.register` enforces that).
+   */
+  register(): void;
+  /**
+   * Run every migration whose version is newer than the stored
+   * `schemaVersion`, in order. Returns the list of versions actually executed
+   * (empty when the world is already up to date). Throws `VttfError VTTF-0004`
+   * wrapping the original error if any migration throws; throws
+   * `VttfError VTTF-0005` if the stored version is older than `compatibleVersion`.
+   *
+   * Call from your `ready` hook, gated by `game.user.isGM` — this method does
+   * NOT enforce GM-only itself so consumers can compose differently if needed.
+   */
+  run(): Promise<ReadonlyArray<string>>;
+}

--- a/packages/core/src/register-system.ts
+++ b/packages/core/src/register-system.ts
@@ -8,9 +8,9 @@
  *   init       → CONFIG mutations (dataModels, documentClass, statusEffects)
  *   i18nInit   → translate CONFIG labels
  *   setup      → enrichers, packs
- *   ready      → migrations (GM-only)
+ *   ready      → migrations (GM-only — consumer guards inside onReady)
  *
- * v0.1 scope: `init` only. `setup`/`ready` callbacks land in v0.1.1.
+ * v0.1 scope: `init` + `ready`. `setup` / `i18nInit` callbacks remain v0.1.1.
  *
  * Per PRD §11 open question #1, we wrap the hook ourselves ("explicit hook for
  * now"); callers don't need to write `Hooks.once("init", ...)` themselves.
@@ -60,6 +60,15 @@ export interface SystemRegistration {
 
   /** Optional post-init hook for work that depends on the mutations above. */
   readonly onAfterInit?: () => void;
+
+  /**
+   * Optional `ready` hook — fires once after Foundry has finished bootstrap.
+   * The natural home for migration runners (`createMigrationRunner().run()`).
+   *
+   * **Not GM-gated.** Guard inside your callback (`if (!game.user.isGM) return;`)
+   * when the work is GM-only — migrations always are.
+   */
+  readonly onReady?: () => void | Promise<void>;
 }
 
 const registered = new Set<string>();
@@ -113,6 +122,14 @@ export function registerSystem(config: SystemRegistration): SystemRegistration {
   hooks.once('init', () => {
     applyInit(config);
   });
+  if (config.onReady !== undefined) {
+    hooks.once('ready', () => {
+      // Foundry awaits ready-hook results, but `Hooks.once` types it as
+      // `unknown` so we don't return anything ourselves — Foundry treats
+      // Promise rejections as unhandled, which is the right escalation.
+      void config.onReady?.();
+    });
+  }
 
   return config;
 }


### PR DESCRIPTION
## Summary

Internal planning slice — declarative schema migrations. Replaces the copy-pasted `schemaVersion + Hooks.once('ready') + isNewerVersion + sequential await` block every shipping system writes (dnd5e is the production reference).

## API

```ts
import { createMigrationRunner, registerSystem } from '@vttforge/core';

const migrations = createMigrationRunner({
  systemId: 'my-system',
  migrations: [
    { version: '1.0.0', description: 'Rename bio → biography', fn: migrateV1 },
    { version: '2.0.0', description: 'Add hp.temp', fn: migrateV2 },
  ],
  compatibleVersion: '0.9.0', // optional floor
});

registerSystem({
  id: 'my-system',
  onAfterInit: () => migrations.register(), // register the schemaVersion setting
  onReady: async () => {
    if (!game.user.isGM) return;
    await migrations.run();
  },
});
```

## Design highlights

- **Semver strings** for versions, compared with `foundry.utils.isNewerVersion` — the same contract `system.json`'s `flags.<systemId>.needsMigrationVersion` / `compatibleMigrationVersion` use, matching the dnd5e production pattern.
- **Per-migration commit** — `schemaVersion` advances after each migration succeeds, so a mid-sequence throw leaves the world at the last successful version. Retry on next load picks up exactly where it failed.
- **`registerSystem.onReady` is NOT GM-gated.** Consumer guards inside the callback (per PRD §11 "explicit hook for now"). Keeps `registerSystem` plumbing, not policy.
- **`createMigrationRunner` doesn't own a `Hooks.once('ready')`** itself — composes with whatever lifecycle the consumer wants. Tested in isolation without any global Foundry mocks needed.

## New error codes (append-only)

| Code | Name | Trigger |
|---|---|---|
| `VTTF-0004` | `MigrationFailed` | A migration `fn` threw. Original error on `.cause`. `schemaVersion` left at the last successful migration. |
| `VTTF-0005` | `WorldTooOldForMigration` | Stored `schemaVersion` is older than the configured `compatibleVersion` floor. |

## Files

| Path | What |
|---|---|
| `packages/core/src/migrations/types.ts` | `Migration`, `MigrationRunnerOptions`, `MigrationRunner`, `MigrationLogger` |
| `packages/core/src/migrations/runner.ts` | `createMigrationRunner()` — register/run/targetVersion |
| `packages/core/src/register-system.ts` | New `onReady?: () => void \| Promise<void>` field + `Hooks.once('ready')` wiring |
| `packages/core/src/errors/registry.ts` | Add `VTTF-0004` + `VTTF-0005` |
| `packages/core/src/index.ts` | Re-exports |
| `packages/core/src/__tests__/migrations.test.ts` | 18 new tests covering basics / register / run / failure / compat floor / default resolution |
| `packages/core/src/__tests__/register-system.test.ts` | 4 new tests for `onReady` wiring |
| `.changeset/feat-core-migration-runner.md` | `@vttforge/core` minor bump |

## Test plan

- [x] `pnpm typecheck` — all 10 tasks green
- [x] `pnpm test` — core: 70 → 92 (+22 new)
- [x] `pnpm build` — single `dist/index.mjs` + `dist/index.d.mts`, no nested directories
- [x] `pnpm format` / `pnpm lint` — clean (only the long-standing `RefuseToPinLocal` syncpack notice)
- [x] `pnpm --filter @vttforge/core publint` — all good
- [ ] Manual smoke inside Foundry via `docker-compose.dev.yml` once `examples/simple-system` lands a real migration sequence in PR 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
