### PR TITLE
chore(examples,docker): make simple-system render inside Foundry v13

### DIFF
--- a/.changeset/chore-example-render-fixes.md
+++ b/.changeset/chore-example-render-fixes.md
@@ -1,0 +1,33 @@
+---
+"@vttforge-examples/simple-system": patch
+---
+
+Make `examples/simple-system` actually render inside Foundry v13:
+
+- **Bundle the entry with tsdown** (`dist/main.mjs`). Browsers can't resolve
+  bare specifiers like `@vttforge/core`, and Foundry serves system files as
+  static assets — so the entry point has to be self-contained. This is what
+  `@vttforge/vite-plugin` will own in v0.2; we pre-empt it locally.
+- `system.json` now points to `dist/main.mjs`.
+- **Template/CSS fixes** discovered while testing the SDK against a live
+  Foundry runtime:
+  - Templates iterate `tabs` directly (ApplicationV2's single-group
+    `_prepareTabs` output is keyed by tab id; nested `tabs.<group>.<tabId>`
+    is only for multi-group sheets).
+  - Tab nav uses `<button type="button">`; `<a>` without `href` doesn't
+    trigger ApplicationV2's pointer-event delegation.
+  - Each sheet ships its own `tab` action handler that toggles the `.active`
+    class on the matching nav button and content section. (The SDK should
+    hoist this; tracked as a follow-up.)
+  - Opaque sheet background — without it Foundry's default leaves the
+    canvas bleeding through.
+- **Compose**: drop the `user:` override and pin `user: "0:0"` so felddy can
+  chown the named volume on first boot; the previous override blocked the
+  install with `EACCES: permission denied`. `.env.example` updated to
+  match — no more UID/GID knobs needed.
+- **Temporary `_prepareContext` workaround** in both sheets unwraps the
+  single-group `context.tabs.primary` that `BaseActorSheet._prepareContext`
+  adds today. The SDK fix removes the need for this — a follow-up PR makes
+  the auto-wrap fire only for multi-group sheets.
+
+No `@vttforge/core` change.

--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,6 @@ FOUNDRY_LICENSE_KEY=
 FOUNDRY_USERNAME=
 FOUNDRY_PASSWORD=
 
-# Optional: override the container UID/GID so file permissions on the mounted
-# volumes match your host user. Defaults to macOS (501:20). Linux is usually 1000:1000.
-# FOUNDRY_UID=1000
-# FOUNDRY_GID=1000
+# The container runs as felddy's default user (`node`, UID 421) which owns
+# the named foundry-dev-data volume. Don't add a `user:` override to the
+# compose unless you're bind-mounting Foundry's data dir to the host.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,12 @@
 services:
   foundry:
     image: felddy/foundryvtt:13
-    user: "${FOUNDRY_UID:-501}:${FOUNDRY_GID:-20}"
+    # Run as root so felddy's entrypoint can chown the named volume on first
+    # boot. Foundry itself drops privileges via felddy's launcher once the
+    # data directory is set up. (The ordem-paranormal compose works with a
+    # numeric `user:` only because that volume was bootstrapped against an
+    # older felddy image that chmod 0777'd /data/Data.)
+    user: "0:0"
     environment:
       FOUNDRY_LICENSE_KEY: ${FOUNDRY_LICENSE_KEY}
       FOUNDRY_USERNAME: ${FOUNDRY_USERNAME}

--- a/examples/simple-system/package.json
+++ b/examples/simple-system/package.json
@@ -5,7 +5,7 @@
   "description": "Reference Foundry VTT system built on @vttforge/core + @vttforge/styles.",
   "type": "module",
   "scripts": {
-    "build": "echo 'simple-system: scaffolding lands in v0.1.0'",
+    "build": "tsdown",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
@@ -15,7 +15,9 @@
   },
   "devDependencies": {
     "happy-dom": "catalog:",
+    "tsdown": "catalog:",
     "typescript": "catalog:",
+    "unrun": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/examples/simple-system/scripts/sheets/character-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/character-sheet.mjs
@@ -32,6 +32,7 @@ export class CharacterSheet extends BaseActorSheet() {
       },
       position: { width: 640, height: 700 },
       actions: {
+        tab: CharacterSheet._onTab,
         rollAbility: CharacterSheet._onRollAbility,
         createGear: CharacterSheet._onCreateGear,
         deleteItem: CharacterSheet._onDeleteItem,
@@ -82,6 +83,13 @@ export class CharacterSheet extends BaseActorSheet() {
   /** @override */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
+    // BaseActorSheet auto-wraps the single-group context.tabs as { primary: {...} },
+    // which collides with ApplicationV2's flat default. Unwrap so the template
+    // can use `tabs.<tabId>.cssClass` per Foundry's own convention. TODO: fix
+    // upstream in @vttforge/core (PR follow-up).
+    if (context.tabs?.primary && Object.keys(context.tabs).length === 1) {
+      context.tabs = context.tabs.primary;
+    }
     const actor = this.document;
     const system = actor.system;
     const abilityLabels = {
@@ -118,6 +126,28 @@ export class CharacterSheet extends BaseActorSheet() {
       return false;
     }
     return undefined;
+  }
+
+  /**
+   * Default tab navigation handler — ApplicationV2 doesn't ship one. Manages
+   * the `.active` class on both the nav `.item` and the matching `.tab`
+   * section directly instead of delegating to `changeTab`, which couples to
+   * an HTML structure not yet matched by this template.
+   */
+  static _onTab(_event, target) {
+    // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time — capturing into a local prevents the noThisInStatic auto-fix from rewriting downstream `this.X` to `CharacterSheet.X`
+    const sheet = this;
+    const group = target.dataset.group;
+    const tab = target.dataset.tab;
+    if (!group || !tab) return;
+    sheet.tabGroups[group] = tab;
+    const root = sheet.element;
+    for (const link of root.querySelectorAll(`nav[data-group="${group}"] [data-tab]`)) {
+      link.classList.toggle('active', link.dataset.tab === tab);
+    }
+    for (const section of root.querySelectorAll(`section.tab[data-group="${group}"]`)) {
+      section.classList.toggle('active', section.dataset.tab === tab);
+    }
   }
 
   static async _onRollAbility(_event, target) {

--- a/examples/simple-system/scripts/sheets/gear-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/gear-sheet.mjs
@@ -21,9 +21,29 @@ export class GearSheet extends BaseItemSheet() {
         icon: 'fa-solid fa-sack',
       },
       position: { width: 480, height: 420 },
+      actions: {
+        tab: GearSheet._onTab,
+      },
     },
     { inplace: false },
   );
+
+  /** Default tab navigation handler — ApplicationV2 doesn't ship one. */
+  static _onTab(_event, target) {
+    // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
+    const sheet = this;
+    const group = target.dataset.group;
+    const tab = target.dataset.tab;
+    if (!group || !tab) return;
+    sheet.tabGroups[group] = tab;
+    const root = sheet.element;
+    for (const link of root.querySelectorAll(`nav[data-group="${group}"] [data-tab]`)) {
+      link.classList.toggle('active', link.dataset.tab === tab);
+    }
+    for (const section of root.querySelectorAll(`section.tab[data-group="${group}"]`)) {
+      section.classList.toggle('active', section.dataset.tab === tab);
+    }
+  }
 
   static PARTS = {
     sheet: {
@@ -54,6 +74,10 @@ export class GearSheet extends BaseItemSheet() {
   /** @override */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
+    // Same single-group tabs unwrap as CharacterSheet — see comment there.
+    if (context.tabs?.primary && Object.keys(context.tabs).length === 1) {
+      context.tabs = context.tabs.primary;
+    }
     const item = this.document;
     context.item = item;
     context.system = item.system;

--- a/examples/simple-system/styles/example.css
+++ b/examples/simple-system/styles/example.css
@@ -10,12 +10,20 @@
  * so nothing leaks into core Foundry UI.
  */
 
+/* Force an opaque sheet background — without this, Foundry's ApplicationV2
+ * default is transparent in many themes and the canvas bleeds through.
+ * Falls back to a dark slate before Foundry's tokens load. */
+.vttforge-example.sheet,
+.vttforge-example .window-content {
+  background: var(--color-bg-primary, #1c1c22);
+  opacity: 1;
+}
+
 .vttforge-example.sheet {
   display: flex;
   flex-direction: column;
   gap: var(--vttf-space-4, 0.75rem);
   padding: var(--vttf-space-4, 0.75rem);
-  background: var(--vttf-color-surface, var(--color-bg-primary));
   color: var(--vttf-color-text, var(--color-text-primary));
   font-family: var(--vttf-font-family, var(--font-primary));
 }
@@ -99,7 +107,7 @@
   border-bottom: 1px solid var(--vttf-color-border, var(--color-border));
 }
 
-.vttforge-example .tab-link {
+.vttforge-example .sheet-tabs .item {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -109,7 +117,7 @@
   text-decoration: none;
 }
 
-.vttforge-example .tab-link.active {
+.vttforge-example .sheet-tabs .item.active {
   border-bottom-color: var(--vttf-color-accent, var(--color-warm-2));
   font-weight: 600;
 }

--- a/examples/simple-system/system.json
+++ b/examples/simple-system/system.json
@@ -8,7 +8,7 @@
     "verified": "13.341"
   },
   "authors": [{ "name": "VTTForge Contributors" }],
-  "esmodules": ["scripts/main.mjs"],
+  "esmodules": ["dist/main.mjs"],
   "styles": ["styles/example.css"],
   "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
   "documentTypes": {

--- a/examples/simple-system/templates/actor/character-sheet.hbs
+++ b/examples/simple-system/templates/actor/character-sheet.hbs
@@ -49,21 +49,21 @@
   </header>
 
   <nav class="sheet-tabs" data-group="primary">
-    {{#each tabs.primary.tabs as |tab|}}
-      <a class="tab-link{{#if tab.active}} active{{/if}}"
-         data-tab="{{tab.id}}"
-         data-group="primary"
-         data-action="tab"
-         title="{{localize tab.label}}">
+    {{#each tabs as |tab|}}
+      <button type="button" class="item {{tab.cssClass}}"
+              data-tab="{{tab.id}}"
+              data-group="primary"
+              data-action="tab"
+              title="{{localize tab.label}}">
         {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
         <span>{{localize tab.label}}</span>
-      </a>
+      </button>
     {{/each}}
   </nav>
 
   <section class="sheet-body">
     {{!-- ABILITIES --}}
-    <section class="tab abilities {{#if tabs.primary.tabs.[0].active}}active{{/if}}"
+    <section class="tab abilities {{tabs.abilities.cssClass}}"
              data-tab="abilities" data-group="primary">
       <div class="ability-grid">
         {{#each abilities as |ability|}}
@@ -83,7 +83,7 @@
     </section>
 
     {{!-- INVENTORY --}}
-    <section class="tab inventory {{#if tabs.primary.tabs.[1].active}}active{{/if}}"
+    <section class="tab inventory {{tabs.inventory.cssClass}}"
              data-tab="inventory" data-group="primary">
       <header class="inventory-header">
         <h3>{{localize "VTTFORGE_EXAMPLE.Sheet.Inventory"}}</h3>
@@ -112,7 +112,7 @@
     </section>
 
     {{!-- BIOGRAPHY --}}
-    <section class="tab biography {{#if tabs.primary.tabs.[2].active}}active{{/if}}"
+    <section class="tab biography {{tabs.biography.cssClass}}"
              data-tab="biography" data-group="primary">
       {{#if isEditable}}
         <prose-mirror name="system.biography"

--- a/examples/simple-system/templates/item/gear-sheet.hbs
+++ b/examples/simple-system/templates/item/gear-sheet.hbs
@@ -8,21 +8,21 @@
   </header>
 
   <nav class="sheet-tabs" data-group="primary">
-    {{#each tabs.primary.tabs as |tab|}}
-      <a class="tab-link{{#if tab.active}} active{{/if}}"
-         data-tab="{{tab.id}}"
-         data-group="primary"
-         data-action="tab"
-         title="{{localize tab.label}}">
+    {{#each tabs as |tab|}}
+      <button type="button" class="item {{tab.cssClass}}"
+              data-tab="{{tab.id}}"
+              data-group="primary"
+              data-action="tab"
+              title="{{localize tab.label}}">
         {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
         <span>{{localize tab.label}}</span>
-      </a>
+      </button>
     {{/each}}
   </nav>
 
   <section class="sheet-body">
     {{!-- DETAILS --}}
-    <section class="tab details {{#if tabs.primary.tabs.[0].active}}active{{/if}}"
+    <section class="tab details {{tabs.details.cssClass}}"
              data-tab="details" data-group="primary">
       <div class="field">
         <label>{{localize "VTTFORGE_EXAMPLE.Gear.Quantity"}}</label>
@@ -35,7 +35,7 @@
     </section>
 
     {{!-- DESCRIPTION --}}
-    <section class="tab description {{#if tabs.primary.tabs.[1].active}}active{{/if}}"
+    <section class="tab description {{tabs.description.cssClass}}"
              data-tab="description" data-group="primary">
       {{#if isEditable}}
         <prose-mirror name="system.description"

--- a/examples/simple-system/tsdown.config.mjs
+++ b/examples/simple-system/tsdown.config.mjs
@@ -1,0 +1,27 @@
+import { defineConfig } from 'tsdown';
+
+/**
+ * Bundle the example system into a single ESM file Foundry can serve over
+ * HTTP. Replaces the work that `@vttforge/vite-plugin` will own in v0.2.
+ *
+ * The browser-side ESM loader can't resolve bare specifiers like
+ * `@vttforge/core` — Foundry serves files as static assets, not through a
+ * Node module resolver. tsdown inlines @vttforge/core (and the example's
+ * own `./` imports) into `dist/system.mjs` so the manifest can ship a
+ * fully-resolved entry point.
+ */
+export default defineConfig({
+  entry: ['scripts/main.mjs'],
+  format: 'esm',
+  platform: 'browser',
+  target: 'es2022',
+  outDir: 'dist',
+  outExtensions: () => ({ js: '.mjs' }),
+  sourcemap: true,
+  clean: true,
+  dts: false,
+  // Force-bundle the workspace dep — by default tsdown treats anything
+  // declared in package.json `dependencies` as external. For a Foundry
+  // system the browser must receive fully-resolved code.
+  noExternal: [/^@vttforge\//],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,15 @@ importers:
       happy-dom:
         specifier: 'catalog:'
         version: 20.9.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.21)(typescript@6.0.3)(unrun@0.3.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unrun:
+        specifier: 'catalog:'
+        version: 0.3.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

PR 9 shipped the structure but never validated end-to-end against a real Foundry instance. Booting via `docker-compose.dev.yml` uncovered a chain of issues; this PR is the punch list to fix them.

🎯 **After this PR merges, the simple-system actually renders inside Foundry**: tabbed character sheet, ability rolls, inventory drag-drop, migration runner — the full v0.1 SDK surface, working end-to-end.

## What changed

### Bundle the entry with tsdown
Browsers can't resolve bare specifiers like `@vttforge/core`, and Foundry serves system files as static assets — so the entry has to ship pre-bundled. That's `@vttforge/vite-plugin`'s job in v0.2; for now we bundle locally with tsdown.

- `tsdown.config.mjs` → `dist/main.mjs` (with `noExternal: [/^@vttforge\//]` to inline the workspace dep)
- `system.json` `esmodules` → `dist/main.mjs`
- `package.json` build script → `tsdown` (+ devDeps tsdown, unrun)

### Sheet rendering fixes
Live-verified against `felddy/foundryvtt:13`:
- Templates iterate `tabs` directly. ApplicationV2's single-group `_prepareTabs` output is keyed by tab id, not nested under group.
- Tab nav uses `<button type=\"button\">` instead of `<a>` — ApplicationV2's pointer-event delegation requires a focusable, clickable element.
- Each sheet ships its own `tab` action handler that toggles `.active` on the matching nav button and content section. **This SHOULD live in `BaseActorSheet` / `BaseItemSheet`** — tracked as the follow-up SDK PR.
- Sheet ships an opaque background; without it Foundry's ApplicationV2 default leaves the canvas bleeding through.

### Docker fix
- compose now pins `user: \"0:0\"` so felddy's entrypoint can chown the named `foundry-dev-data` volume on first boot. The previous attempt to override `user:` with the host UID failed with `EACCES: permission denied` because the volume directory was `root:root 0755` before felddy could touch it.
- Drop the `FOUNDRY_UID` / `FOUNDRY_GID` env knobs from `.env.example` — they don't apply when the container runs as root.

### Temporary SDK workaround
`CharacterSheet._prepareContext` and `GearSheet._prepareContext` both unwrap `context.tabs.primary` to `context.tabs`. `BaseActorSheet._prepareContext` currently auto-wraps single-group sheets under their group name, colliding with ApplicationV2's flat default. The SDK fix (follow-up PR) removes the override for single-group sheets, after which this workaround disappears.

## Where these issues came from

All discovered during local development/testing — not derived from any external Foundry source code. Things like the pointer-event delegation requirement, the single-group tabs flat shape, and the `<button>` vs `<a>` distinction were found by booting the example, observing what didn't render, and inspecting at runtime.

## Test plan

- [x] `pnpm typecheck` — all 10 tasks green
- [x] `pnpm test` — 97 core + 7 example boot smoke = 104 tests
- [x] `pnpm build` — example produces `dist/main.mjs` (~42KB, includes `@vttforge/core` inlined)
- [x] `pnpm format` / `pnpm lint` — clean
- [x] **Real Foundry smoke**: `docker compose -f docker-compose.dev.yml up`, install VTTForge Example System, create a Character actor, open sheet — tabs render, tab nav switches sections, abilities grid shows the 6 D&D-style attributes with derived `+0` mods, Health shows 10/11 (derived from level 1 + conMod 0), New Gear button creates a gear item via the typed drop dispatch path.

## Follow-ups

- PR #N+1: Fix `BaseActorSheet._prepareContext` to skip tab auto-wrap on single-group sheets + hoist the `tab` action handler to the base. After that lands, drop the unwrap workaround + the per-sheet `tab` action in this example.
- PR #N+2: README + internal docs sync (still pending from earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
