### PR TITLE
fix(core): single-group tabs flat + ship default  action

### DIFF
--- a/.changeset/fix-base-sheet-tabs-action.md
+++ b/.changeset/fix-base-sheet-tabs-action.md
@@ -1,0 +1,35 @@
+---
+"@vttforge/core": minor
+"@vttforge-examples/simple-system": patch
+---
+
+Fix `BaseActorSheet` / `BaseItemSheet` tab handling so sheets work without
+per-consumer workarounds.
+
+Two issues surfaced when running the example sheet inside a live Foundry v13:
+
+- **`context.tabs` double-wrap on single-group sheets.** The previous
+  `_prepareContext` override unconditionally set `context.tabs[group]`,
+  even when ApplicationV2 already populated a flat
+  `context.tabs[tabId]` for single-group sheets. The collision forced
+  consumers to either unwrap manually or write `context.tabs.<group>.<tabId>`
+  in every template. Fixed: BaseActorSheet/BaseItemSheet now only fill
+  `context.tabs[group]` for **multi-group** sheets (single-group sheets
+  see ApplicationV2's flat shape untouched).
+
+- **No default `tab`-style action handler.** ApplicationV2 doesn't ship a
+  built-in handler for `data-action="…"` tab navigation buttons, and the
+  bare name `tab` is reserved by the framework (custom handlers under that
+  name never fire). Fixed: both base sheets now ship a `vttforgeTab`
+  action that toggles `.active` on the matching nav button
+  (`[data-action="vttforgeTab"][data-group=…][data-tab=…]`) and content
+  section (`section.tab[data-group=…][data-tab=…]`) and updates
+  `sheet.tabGroups[group]`. Templates that already used the old per-sheet
+  workaround need to rename `data-action="tab"` → `data-action="vttforgeTab"`.
+
+Discovered during development testing — not derived from any external
+source.
+
+Patch bump for the example: drops the `_prepareContext` unwrap workaround
+and the per-sheet `_onTab` static handlers added in the previous PR,
+since both now live in the SDK.

--- a/examples/simple-system/scripts/sheets/character-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/character-sheet.mjs
@@ -32,7 +32,6 @@ export class CharacterSheet extends BaseActorSheet() {
       },
       position: { width: 640, height: 700 },
       actions: {
-        tab: CharacterSheet._onTab,
         rollAbility: CharacterSheet._onRollAbility,
         createGear: CharacterSheet._onCreateGear,
         deleteItem: CharacterSheet._onDeleteItem,
@@ -83,13 +82,6 @@ export class CharacterSheet extends BaseActorSheet() {
   /** @override */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    // BaseActorSheet auto-wraps the single-group context.tabs as { primary: {...} },
-    // which collides with ApplicationV2's flat default. Unwrap so the template
-    // can use `tabs.<tabId>.cssClass` per Foundry's own convention. TODO: fix
-    // upstream in @vttforge/core (PR follow-up).
-    if (context.tabs?.primary && Object.keys(context.tabs).length === 1) {
-      context.tabs = context.tabs.primary;
-    }
     const actor = this.document;
     const system = actor.system;
     const abilityLabels = {
@@ -126,28 +118,6 @@ export class CharacterSheet extends BaseActorSheet() {
       return false;
     }
     return undefined;
-  }
-
-  /**
-   * Default tab navigation handler — ApplicationV2 doesn't ship one. Manages
-   * the `.active` class on both the nav `.item` and the matching `.tab`
-   * section directly instead of delegating to `changeTab`, which couples to
-   * an HTML structure not yet matched by this template.
-   */
-  static _onTab(_event, target) {
-    // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time — capturing into a local prevents the noThisInStatic auto-fix from rewriting downstream `this.X` to `CharacterSheet.X`
-    const sheet = this;
-    const group = target.dataset.group;
-    const tab = target.dataset.tab;
-    if (!group || !tab) return;
-    sheet.tabGroups[group] = tab;
-    const root = sheet.element;
-    for (const link of root.querySelectorAll(`nav[data-group="${group}"] [data-tab]`)) {
-      link.classList.toggle('active', link.dataset.tab === tab);
-    }
-    for (const section of root.querySelectorAll(`section.tab[data-group="${group}"]`)) {
-      section.classList.toggle('active', section.dataset.tab === tab);
-    }
   }
 
   static async _onRollAbility(_event, target) {

--- a/examples/simple-system/scripts/sheets/gear-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/gear-sheet.mjs
@@ -21,29 +21,9 @@ export class GearSheet extends BaseItemSheet() {
         icon: 'fa-solid fa-sack',
       },
       position: { width: 480, height: 420 },
-      actions: {
-        tab: GearSheet._onTab,
-      },
     },
     { inplace: false },
   );
-
-  /** Default tab navigation handler — ApplicationV2 doesn't ship one. */
-  static _onTab(_event, target) {
-    // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
-    const sheet = this;
-    const group = target.dataset.group;
-    const tab = target.dataset.tab;
-    if (!group || !tab) return;
-    sheet.tabGroups[group] = tab;
-    const root = sheet.element;
-    for (const link of root.querySelectorAll(`nav[data-group="${group}"] [data-tab]`)) {
-      link.classList.toggle('active', link.dataset.tab === tab);
-    }
-    for (const section of root.querySelectorAll(`section.tab[data-group="${group}"]`)) {
-      section.classList.toggle('active', section.dataset.tab === tab);
-    }
-  }
 
   static PARTS = {
     sheet: {
@@ -74,10 +54,6 @@ export class GearSheet extends BaseItemSheet() {
   /** @override */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    // Same single-group tabs unwrap as CharacterSheet — see comment there.
-    if (context.tabs?.primary && Object.keys(context.tabs).length === 1) {
-      context.tabs = context.tabs.primary;
-    }
     const item = this.document;
     context.item = item;
     context.system = item.system;

--- a/examples/simple-system/templates/actor/character-sheet.hbs
+++ b/examples/simple-system/templates/actor/character-sheet.hbs
@@ -53,7 +53,7 @@
       <button type="button" class="item {{tab.cssClass}}"
               data-tab="{{tab.id}}"
               data-group="primary"
-              data-action="tab"
+              data-action="vttforgeTab"
               title="{{localize tab.label}}">
         {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
         <span>{{localize tab.label}}</span>

--- a/examples/simple-system/templates/item/gear-sheet.hbs
+++ b/examples/simple-system/templates/item/gear-sheet.hbs
@@ -12,7 +12,7 @@
       <button type="button" class="item {{tab.cssClass}}"
               data-tab="{{tab.id}}"
               data-group="primary"
-              data-action="tab"
+              data-action="vttforgeTab"
               title="{{localize tab.label}}">
         {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
         <span>{{localize tab.label}}</span>

--- a/packages/core/src/__tests__/base-actor-sheet.test.ts
+++ b/packages/core/src/__tests__/base-actor-sheet.test.ts
@@ -134,6 +134,55 @@ describe('BaseActorSheet — _prepareContext tab auto-population', () => {
     expect(ctx.fromSuper).toBe(true);
     expect(ctx.tabs).toBeUndefined();
   });
+
+  it('leaves single-group sheets to ApplicationV2 (no wrap, no _prepareTabs call)', async () => {
+    const Base = BaseActorSheet();
+    const prepareTabs = vi.fn();
+    class Sheet extends Base {
+      static TABS = {
+        primary: { tabs: [{ id: 'a', group: 'primary', label: 'A' }], initial: 'a' },
+      };
+      _prepareTabs = prepareTabs;
+    }
+    const instance = new Sheet();
+    const ctx = (await instance._prepareContext({})) as Record<string, unknown>;
+    expect(prepareTabs).not.toHaveBeenCalled();
+    expect(ctx.tabs).toBeUndefined();
+  });
+});
+
+describe('BaseActorSheet — default `tab` action', () => {
+  it('registers a `vttforgeTab` handler on DEFAULT_OPTIONS.actions', () => {
+    const Sub = BaseActorSheet();
+    const handler = (Sub as unknown as { DEFAULT_OPTIONS: { actions: { vttforgeTab?: unknown } } })
+      .DEFAULT_OPTIONS.actions.vttforgeTab;
+    expect(handler).toBeTypeOf('function');
+  });
+
+  it('toggles .active on matching nav button and content section, updates tabGroups', () => {
+    const Sub = BaseActorSheet();
+    const handler = (
+      Sub as unknown as {
+        DEFAULT_OPTIONS: { actions: { vttforgeTab: (event: Event, target: HTMLElement) => void } };
+      }
+    ).DEFAULT_OPTIONS.actions.vttforgeTab;
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <nav data-group="primary">
+        <button data-action="vttforgeTab" data-tab="a" data-group="primary" class="active"></button>
+        <button data-action="vttforgeTab" data-tab="b" data-group="primary"></button>
+      </nav>
+      <section class="tab" data-tab="a" data-group="primary"></section>
+      <section class="tab" data-tab="b" data-group="primary"></section>
+    `;
+    const sheet = { tabGroups: { primary: 'a' }, element: root };
+    const target = root.querySelector('[data-tab="b"]') as HTMLElement;
+    handler.call(sheet as unknown as object, new Event('click'), target);
+    expect(sheet.tabGroups.primary).toBe('b');
+    expect(root.querySelector('[data-tab="a"]')?.classList.contains('active')).toBe(false);
+    expect(root.querySelector('[data-tab="b"]')?.classList.contains('active')).toBe(true);
+    expect(root.querySelector('section[data-tab="b"]')?.classList.contains('active')).toBe(true);
+  });
 });
 
 describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {

--- a/packages/core/src/__tests__/base-item-sheet.test.ts
+++ b/packages/core/src/__tests__/base-item-sheet.test.ts
@@ -78,7 +78,7 @@ describe('BaseItemSheet', () => {
     expect(opts.position.width).toBeLessThan(600);
   });
 
-  it('auto-fills context.tabs for every TABS group', async () => {
+  it('leaves single-group sheets to ApplicationV2 (no wrap, no _prepareTabs calls)', async () => {
     const Base = BaseItemSheet();
     const prepareTabs = vi.fn((group: string) => ({ group }));
     class Sheet extends Base {
@@ -90,8 +90,36 @@ describe('BaseItemSheet', () => {
     const instance = new Sheet();
     const ctx = (await instance._prepareContext({})) as Record<string, unknown>;
     expect(ctx.fromSuper).toBe(true);
+    expect(prepareTabs).not.toHaveBeenCalled();
+    expect(ctx.tabs).toBeUndefined();
+  });
+
+  it('auto-wraps multi-group TABS so each group is keyed under context.tabs[group]', async () => {
+    const Base = BaseItemSheet();
+    const prepareTabs = vi.fn((group: string) => ({ group, active: 'first' }));
+    class Sheet extends Base {
+      static TABS = {
+        primary: { tabs: [{ id: 'a', group: 'primary', label: 'A' }], initial: 'a' },
+        secondary: { tabs: [{ id: 'b', group: 'secondary', label: 'B' }], initial: 'b' },
+      };
+      _prepareTabs = prepareTabs;
+    }
+    const instance = new Sheet();
+    const ctx = (await instance._prepareContext({})) as Record<string, unknown>;
     expect(prepareTabs).toHaveBeenCalledWith('primary');
-    expect(ctx.tabs).toEqual({ primary: { group: 'primary' } });
+    expect(prepareTabs).toHaveBeenCalledWith('secondary');
+    expect(ctx.tabs).toEqual({
+      primary: { group: 'primary', active: 'first' },
+      secondary: { group: 'secondary', active: 'first' },
+    });
+  });
+
+  it('registers a default `vttforgeTab` action that swaps .active classes', () => {
+    const Base = BaseItemSheet();
+    expect(
+      (Base as unknown as { DEFAULT_OPTIONS: { actions: { vttforgeTab?: unknown } } })
+        .DEFAULT_OPTIONS.actions.vttforgeTab,
+    ).toBeTypeOf('function');
   });
 
   it('binds DragDrop entries declared via static DRAG_DROP', () => {

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -159,7 +159,7 @@ export function BaseActorSheet(): AnyConstructor {
       position: { width: 600, height: 700 },
       tag: 'form',
       form: { submitOnChange: true, closeOnSubmit: false },
-      actions: {},
+      actions: { vttforgeTab: VttforgeBaseActorSheet._onTab },
     } as const;
 
     /**
@@ -170,9 +170,13 @@ export function BaseActorSheet(): AnyConstructor {
     static readonly DRAG_DROP: ReadonlyArray<DragDropConfig> = [];
 
     /**
-     * Augment ApplicationV2's context with `tabs[group]` for every group
-     * declared in `static TABS`, so subclasses can render tabs without
-     * having to call `_prepareTabs(group)` manually.
+     * Augment ApplicationV2's context with `tabs[group]` for sheets that
+     * declare **multiple** `static TABS` groups. ApplicationV2 already
+     * auto-populates `context.tabs` (keyed by tab id) for single-group
+     * sheets — overriding that flat shape would force every consumer to
+     * either unwrap or write `context.tabs.<group>.<tabId>` in templates.
+     * Multi-group sheets get nested `context.tabs.<group>.<tabId>` because
+     * ApplicationV2 returns `{}` for them by default.
      */
     async _prepareContext(options: unknown): Promise<Record<string, unknown>> {
       const superPrepare = (
@@ -187,7 +191,7 @@ export function BaseActorSheet(): AnyConstructor {
       const tabsConfig = (this.constructor as { TABS?: Record<string, unknown> }).TABS;
       if (tabsConfig && typeof tabsConfig === 'object') {
         const groups = Object.keys(tabsConfig);
-        if (groups.length > 0) {
+        if (groups.length > 1) {
           const prepareTabs = (this as { _prepareTabs?: (group: string) => unknown })._prepareTabs;
           const tabs: Record<string, unknown> = {};
           for (const group of groups) {
@@ -197,6 +201,39 @@ export function BaseActorSheet(): AnyConstructor {
         }
       }
       return context;
+    }
+
+    /**
+     * Default `tab` action handler. ApplicationV2 doesn't ship one, so every
+     * sheet that uses `<button data-action="tab" data-tab=… data-group=…>`
+     * has to wire its own. We toggle the `.active` class on the matching
+     * nav element (`[data-action="tab"][data-tab=…][data-group=…]`) and
+     * on `section.tab[data-tab=…][data-group=…]`, then update
+     * `sheet.tabGroups[group]` so subsequent re-renders pick the right
+     * initial tab.
+     *
+     * ApplicationV2's action dispatcher binds `this` to the sheet instance
+     * at call time even though the handler is declared `static`.
+     */
+    static _onTab(_event: Event, target: HTMLElement): void {
+      // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time — wrap the cast in a single line so biome's auto-fix can't rewrite downstream references to the class name
+      const sheet = this as unknown as { tabGroups: Record<string, string>; element?: HTMLElement };
+      const group = target.dataset?.group;
+      const tab = target.dataset?.tab;
+      if (!group || !tab) return;
+      sheet.tabGroups[group] = tab;
+      const root = sheet.element;
+      if (!root) return;
+      for (const link of root.querySelectorAll<HTMLElement>(
+        `[data-action="vttforgeTab"][data-group="${group}"]`,
+      )) {
+        link.classList.toggle('active', link.dataset.tab === tab);
+      }
+      for (const section of root.querySelectorAll<HTMLElement>(
+        `section.tab[data-group="${group}"]`,
+      )) {
+        section.classList.toggle('active', section.dataset.tab === tab);
+      }
     }
 
     /**

--- a/packages/core/src/base-item-sheet.ts
+++ b/packages/core/src/base-item-sheet.ts
@@ -104,11 +104,17 @@ export function BaseItemSheet(): AnyConstructor {
       position: { width: 520, height: 480 },
       tag: 'form',
       form: { submitOnChange: true, closeOnSubmit: false },
-      actions: {},
+      actions: { vttforgeTab: VttforgeBaseItemSheet._onTab },
     } as const;
 
     static readonly DRAG_DROP: ReadonlyArray<DragDropConfig> = [];
 
+    /**
+     * Multi-group sheets get nested `context.tabs.<group>.<tabId>` because
+     * ApplicationV2 returns `{}` for them by default; single-group sheets
+     * use ApplicationV2's flat `context.tabs.<tabId>` shape untouched. See
+     * BaseActorSheet for the long version.
+     */
     async _prepareContext(options: unknown): Promise<Record<string, unknown>> {
       const superPrepare = (
         Mixed.prototype as {
@@ -122,7 +128,7 @@ export function BaseItemSheet(): AnyConstructor {
       const tabsConfig = (this.constructor as { TABS?: Record<string, unknown> }).TABS;
       if (tabsConfig && typeof tabsConfig === 'object') {
         const groups = Object.keys(tabsConfig);
-        if (groups.length > 0) {
+        if (groups.length > 1) {
           const prepareTabs = (this as { _prepareTabs?: (group: string) => unknown })._prepareTabs;
           const tabs: Record<string, unknown> = {};
           for (const group of groups) {
@@ -132,6 +138,27 @@ export function BaseItemSheet(): AnyConstructor {
         }
       }
       return context;
+    }
+
+    static _onTab(_event: Event, target: HTMLElement): void {
+      // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
+      const sheet = this as unknown as { tabGroups: Record<string, string>; element?: HTMLElement };
+      const group = target.dataset?.group;
+      const tab = target.dataset?.tab;
+      if (!group || !tab) return;
+      sheet.tabGroups[group] = tab;
+      const root = sheet.element;
+      if (!root) return;
+      for (const link of root.querySelectorAll<HTMLElement>(
+        `[data-action="vttforgeTab"][data-group="${group}"]`,
+      )) {
+        link.classList.toggle('active', link.dataset.tab === tab);
+      }
+      for (const section of root.querySelectorAll<HTMLElement>(
+        `section.tab[data-group="${group}"]`,
+      )) {
+        section.classList.toggle('active', section.dataset.tab === tab);
+      }
     }
 
     _onRender(context: unknown, options: unknown): void {


### PR DESCRIPTION
## Summary

Follow-up to PR #16 that flattens out the two SDK-side issues we worked around in the example.

Two issues surfaced when running `examples/simple-system` inside a live Foundry v13 instance; both lived in `BaseActorSheet` / `BaseItemSheet` and forced consumers to write per-sheet workarounds.

## What changed

### 1. `context.tabs` double-wrap on single-group sheets
The previous `_prepareContext` override unconditionally set `context.tabs[group]`, even when ApplicationV2 already populated a flat `context.tabs[tabId]` for single-group sheets. Templates ended up needing `tabs.<group>.<tabId>` while ApplicationV2 itself wanted `tabs.<tabId>`.

**Fixed**: only wrap when the sheet declares multiple TABS groups. Single-group sheets use ApplicationV2's flat shape untouched.

### 2. No default tab navigation action
ApplicationV2 doesn't ship a built-in click handler for tab-style buttons, and the bare action name `tab` is reserved by the framework (custom handlers under that name never fire — discovered the hard way).

**Fixed**: both base sheets now register a `vttforgeTab` action that:
- toggles `.active` on the matching nav button (`[data-action=\"vttforgeTab\"][data-group=…][data-tab=…]`)
- toggles `.active` on the matching content section (`section.tab[data-group=…][data-tab=…]`)
- updates `sheet.tabGroups[group]` so subsequent re-renders pick the right initial tab

## Migration

Templates that use the SDK-provided tab nav need to swap `data-action=\"tab\"` for `data-action=\"vttforgeTab\"`. The example does this in the same PR.

## Example cleanup

- Drop the `tabs.primary` unwrap from both sheet `_prepareContext` overrides (no longer needed)
- Drop the per-sheet `_onTab` static + its `tab` action registration (now in the base)
- Templates rename `data-action=\"tab\"` → `data-action=\"vttforgeTab\"`

## Where these issues came from

All discovered during local development/testing against the live Foundry container. The reserved-name behavior, the single-group flat shape, and ApplicationV2's pointer-event delegation specifics were found by booting the example, observing what didn't behave, and inspecting at runtime in the browser.

## Test plan

- [x] `pnpm typecheck` — 10 tasks green
- [x] `pnpm test` — core: 97 → 102 (+5 new); example boot smoke (7) still green
- [x] `pnpm build` — clean
- [x] `pnpm lint` + `pnpm format` — clean
- [x] `pnpm --filter @vttforge/core publint` — all good
- [x] **Live Foundry smoke**: real clicks on Abilities → Inventory → Biography tabs in the rendered character sheet switch panes correctly; no per-sheet workaround in the example sheet code

🤖 Generated with [Claude Code](https://claude.com/claude-code)