### PR TITLE
feat(styles): primitives, sheet, themes, Storybook-lite preview

### DIFF
--- a/.changeset/styles-primitives.md
+++ b/.changeset/styles-primitives.md
@@ -1,0 +1,15 @@
+---
+'@vttforge/styles': minor
+---
+
+Ship the full primitive set adapted from the Design System spec:
+
+- `reset.css`: scoped reset for `.vttf-app`, `.vttf-sheet`, `form[data-vttf]` (does not override Foundry's `reset` layer).
+- `base.css`: element baselines, focus-ring rendering, `.vttf-sr-only` utility.
+- `components.css`: buttons (primary/secondary/ghost/danger), badges (7 hues), code block with syntax tokens (`.vttf-tk-*`), inputs/textarea/select with ARIA invalid state, checkbox/radio/switch/range/segmented control, tabs with ARIA selected, sheet primitives (`.vttf-sheet`, `.vttf-sheet__head`, `.vttf-sheet__body`, `.vttf-portrait`, `.vttf-stat-pill`, `.vttf-dropzone`, `.vttf-item-row`).
+- `themes/forge.css`: adds `@media (prefers-color-scheme: light) [data-theme="auto"]` so `data-theme="auto"` follows the GM's OS preference. Explicit `data-theme="light"` and `data-theme="foundry"` continue to be handled by `tokens.css`.
+- `preview/index.html`: Storybook-lite page that renders every primitive with a theme toggle (dark → light → foundry → auto).
+
+Translucent tints use `color-mix(in oklch, var(--vttf-ember) 8%, transparent)` (HANDOFF §5) so re-theming the ember token propagates automatically. States use ARIA attributes first (`aria-selected`, `aria-invalid`, `aria-pressed`) with `.is-*` classes as fallback. `:focus-visible` is owned by the base layer.
+
+Adds the `vttforge.themes` cascade sub-layer and bumps the layer order in both entry points.

--- a/examples/themes/README.md
+++ b/examples/themes/README.md
@@ -1,0 +1,36 @@
+# Example themes
+
+Forge is `@vttforge/styles`'s official theme. The four files in this folder are documented examples that show how to compose a custom theme on top of `@vttforge/styles` by overriding `--vttf-*` tokens.
+
+| File | Reference |
+| --- | --- |
+| `codex.css` | D&D 5e modern — burgundy + cream serif. |
+| `parchment.css` | OGL / OSR print-style — walnut ink, square edges. |
+| `grimdark.css` | Warhammer / Mörk Borg / CoC — near-black, condensed sans, dried-blood accent. |
+| `neon.css` | Shadowrun / Cyberpunk — deep blue, magenta + cyan, mono display. |
+
+## Usage
+
+```html
+<link rel="stylesheet" href="@vttforge/styles" />
+<link rel="stylesheet" href="examples/themes/codex.css" />
+
+<div class="vttf-sheet vttf-theme-codex">
+  <!-- sheet content uses Codex token values automatically -->
+</div>
+```
+
+Each file is one CSS class. Drop it on the sheet root, the components re-theme. No other markup changes required.
+
+## Authoring your own theme
+
+1. Copy any of the four files.
+2. Rename the class (`.vttf-theme-yourname`).
+3. Replace token values. The ones to override:
+   - Surfaces: `--vttf-bg`, `--vttf-bg-elevated`, `--vttf-bg-sunken`, `--vttf-surface`, `--vttf-surface-2`, `--vttf-border`, `--vttf-border-strong`.
+   - Text: `--vttf-text`, `--vttf-text-muted`, `--vttf-text-faint`, `--vttf-text-inverse`.
+   - Accent: `--vttf-ember`, `--vttf-ember-deep`, `--vttf-ember-glow`.
+   - Optional: semantic accents (`--vttf-steel`, `--vttf-mint`, `--vttf-gold`, `--vttf-rose`, `--vttf-violet`), fonts (`--vttf-font-display`, `--vttf-font-body`, `--vttf-font-mono`), radii (`--vttf-radius-sm`/`-md`/`-lg`/`-xl`).
+4. Drop the class on a sheet root and verify in your system.
+
+Do not touch component CSS. Re-theming via tokens is the whole point.

--- a/examples/themes/codex.css
+++ b/examples/themes/codex.css
@@ -1,0 +1,31 @@
+/*!
+ * examples/themes/codex.css — recipe theme · D&D 5e modern
+ *
+ * Burgundy + cream + serif. Apply by adding `.vttf-theme-codex` to a sheet root.
+ * Documented example only — Forge is the official theme; this file ships in
+ * examples/ to show how a consumer composes their own theme on top of
+ * `@vttforge/styles` by overriding `--vttf-*` tokens.
+ */
+
+.vttf-theme-codex {
+  --vttf-bg: #f5efe2;
+  --vttf-bg-elevated: #fbf7ec;
+  --vttf-bg-sunken: #ede4d0;
+  --vttf-surface: #fbf7ec;
+  --vttf-surface-2: #f0e8d2;
+  --vttf-border: #d6c8a8;
+  --vttf-border-strong: #b7a47a;
+  --vttf-text: #2a1a14;
+  --vttf-text-muted: #6b554a;
+  --vttf-text-faint: #8a7868;
+  --vttf-text-inverse: #fbf7ec;
+  --vttf-ember: #8a1a1f;
+  --vttf-ember-deep: #5a1115;
+  --vttf-ember-glow: #b03238;
+  --vttf-font-display: "Cinzel", "Times New Roman", serif;
+  --vttf-font-body: "Cormorant Garamond", "Times New Roman", serif;
+  --vttf-font-mono: "DM Mono", ui-monospace, monospace;
+  --vttf-radius-sm: 2px;
+  --vttf-radius-md: 3px;
+  --vttf-radius-lg: 4px;
+}

--- a/examples/themes/grimdark.css
+++ b/examples/themes/grimdark.css
@@ -1,0 +1,30 @@
+/*!
+ * examples/themes/grimdark.css — recipe theme · Warhammer / Mörk Borg / CoC
+ *
+ * Near-black + dried-blood accent + condensed sans. Apply by adding
+ * `.vttf-theme-grimdark` to a sheet root. Documented example only — see
+ * examples/themes/codex.css for context.
+ */
+
+.vttf-theme-grimdark {
+  --vttf-bg: #0a0908;
+  --vttf-bg-elevated: #141210;
+  --vttf-bg-sunken: #050403;
+  --vttf-surface: #141210;
+  --vttf-surface-2: #1e1b18;
+  --vttf-border: #2a2520;
+  --vttf-border-strong: #4a4238;
+  --vttf-text: #d0c8b8;
+  --vttf-text-muted: #807868;
+  --vttf-text-faint: #4a4238;
+  --vttf-text-inverse: #0a0908;
+  --vttf-ember: #b8330d;
+  --vttf-ember-deep: #781f06;
+  --vttf-ember-glow: #d04818;
+  --vttf-font-display: "Oswald", "Impact", sans-serif;
+  --vttf-font-body: "Cormorant Unicase", "Georgia", serif;
+  --vttf-font-mono: "Special Elite", ui-monospace, monospace;
+  --vttf-radius-sm: 0;
+  --vttf-radius-md: 0;
+  --vttf-radius-lg: 0;
+}

--- a/examples/themes/neon.css
+++ b/examples/themes/neon.css
@@ -1,0 +1,34 @@
+/*!
+ * examples/themes/neon.css — recipe theme · Shadowrun / Cyberpunk / sci-fi
+ *
+ * Deep blue + magenta + cyan + mono display. Apply by adding `.vttf-theme-neon`
+ * to a sheet root. Documented example only — see examples/themes/codex.css for
+ * context.
+ */
+
+.vttf-theme-neon {
+  --vttf-bg: #06080d;
+  --vttf-bg-elevated: #0e1320;
+  --vttf-bg-sunken: #02040a;
+  --vttf-surface: #0e1320;
+  --vttf-surface-2: #161e30;
+  --vttf-border: #2a3550;
+  --vttf-border-strong: #4a5878;
+  --vttf-text: #e8eaf0;
+  --vttf-text-muted: #8090b0;
+  --vttf-text-faint: #4a5878;
+  --vttf-text-inverse: #06080d;
+  --vttf-ember: #ff3aa8;
+  --vttf-ember-deep: #c01880;
+  --vttf-ember-glow: #ff70c0;
+  --vttf-steel: #00ffe6;
+  --vttf-mint: #00ffa0;
+  --vttf-gold: #ffd000;
+  --vttf-violet: #a040ff;
+  --vttf-font-display: "Major Mono Display", "Courier New", monospace;
+  --vttf-font-body: "Space Grotesk", system-ui, sans-serif;
+  --vttf-font-mono: "DM Mono", ui-monospace, monospace;
+  --vttf-radius-sm: 2px;
+  --vttf-radius-md: 4px;
+  --vttf-radius-lg: 6px;
+}

--- a/examples/themes/parchment.css
+++ b/examples/themes/parchment.css
@@ -1,0 +1,30 @@
+/*!
+ * examples/themes/parchment.css — recipe theme · OGL/OSR print-style
+ *
+ * Walnut ink on aged paper. Apply by adding `.vttf-theme-parchment` to a sheet
+ * root. Documented example only — see examples/themes/codex.css for context.
+ */
+
+.vttf-theme-parchment {
+  --vttf-bg: #e8dcb8;
+  --vttf-bg-elevated: #f0e4c0;
+  --vttf-bg-sunken: #d8caa0;
+  --vttf-surface: #f0e4c0;
+  --vttf-surface-2: #e0d2a8;
+  --vttf-border: #b8a878;
+  --vttf-border-strong: #8a7a4a;
+  --vttf-text: #2a200d;
+  --vttf-text-muted: #5a4a28;
+  --vttf-text-faint: #7a6a48;
+  --vttf-text-inverse: #f0e4c0;
+  --vttf-ember: #7a2d10;
+  --vttf-ember-deep: #4a1d08;
+  --vttf-ember-glow: #a04020;
+  --vttf-font-display: "IM Fell English SC", "Georgia", serif;
+  --vttf-font-body: "IM Fell English", "Georgia", serif;
+  --vttf-font-mono: "IM Fell English", ui-monospace, monospace;
+  --vttf-radius-sm: 0;
+  --vttf-radius-md: 0;
+  --vttf-radius-lg: 0;
+  --vttf-radius-xl: 0;
+}

--- a/packages/styles/base.css
+++ b/packages/styles/base.css
@@ -1,9 +1,69 @@
 /*!
  * @vttforge/styles — base.css
  *
- * Baseline element styling on top of `tokens` + `reset`. Real ruleset lands in v0.1.0.
+ * Element baselines and shared utilities on top of `tokens` + `reset`.
+ * Owns `--vttf-focus-ring` rendering; component layers MUST NOT override `:focus-visible`.
  */
 
 @layer vttforge.base {
-  /* intentionally empty placeholder */
+  .vttf-app,
+  .vttf-sheet {
+    font-family: var(--vttf-font-body);
+    font-size: var(--vttf-text-size-body);
+    line-height: 1.5;
+    color: var(--vttf-text);
+    background: var(--vttf-bg);
+  }
+
+  .vttf-app :focus-visible,
+  .vttf-sheet :focus-visible,
+  form[data-vttf] :focus-visible {
+    outline: none;
+    box-shadow: var(--vttf-focus-ring);
+  }
+
+  .vttf-app a,
+  .vttf-sheet a {
+    color: var(--vttf-ember);
+    text-decoration: none;
+    transition: color var(--vttf-duration-fast) var(--vttf-ease-out);
+  }
+
+  .vttf-app a:hover,
+  .vttf-sheet a:hover {
+    color: var(--vttf-ember-glow);
+    text-decoration: underline;
+  }
+
+  .vttf-app h1,
+  .vttf-app h2,
+  .vttf-app h3,
+  .vttf-sheet h1,
+  .vttf-sheet h2,
+  .vttf-sheet h3 {
+    font-family: var(--vttf-font-display);
+    font-weight: var(--vttf-text-weight-semibold);
+    letter-spacing: -0.02em;
+    margin: 0;
+  }
+
+  .vttf-app code,
+  .vttf-app pre,
+  .vttf-sheet code,
+  .vttf-sheet pre {
+    font-family: var(--vttf-font-mono);
+  }
+
+  /* Utility: visually hidden but accessible to screen readers */
+  .vttf-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 }

--- a/packages/styles/components.css
+++ b/packages/styles/components.css
@@ -1,10 +1,746 @@
 /*!
  * @vttforge/styles — components.css
  *
- * Sheet primitives (drag/drop affordances, tab strips, image picker). Real ruleset
- * lands in v0.1.0 alongside @vttforge/core sheet base classes.
+ * Sheet primitives consumed via .vttf-* classes. Tokens-only — every color,
+ * radius, shadow, and timing comes from `--vttf-*` (see tokens.css). Translucent
+ * tints use color-mix() against ember/rose tokens so re-themes propagate.
+ *
+ * BEM-light: .vttf-name (root), .vttf-name__part (parts), .vttf-name--variant
+ * (modifiers). ARIA states preferred (aria-selected, aria-invalid); .is-*
+ * classes as legacy fallbacks.
  */
 
 @layer vttforge.components {
-  /* intentionally empty placeholder */
+  /* ════════ BUTTONS ════════ */
+
+  .vttf-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--vttf-space-2);
+    padding: 10px 16px;
+    border-radius: var(--vttf-radius-md);
+    font-family: var(--vttf-font-body);
+    font-weight: var(--vttf-text-weight-semibold);
+    font-size: 14px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition:
+      transform var(--vttf-duration-fast) var(--vttf-ease-out),
+      box-shadow var(--vttf-duration-fast) var(--vttf-ease-out),
+      background var(--vttf-duration-fast) var(--vttf-ease-out),
+      border-color var(--vttf-duration-fast) var(--vttf-ease-out);
+  }
+
+  .vttf-btn:active {
+    transform: translateY(1px);
+  }
+
+  .vttf-btn[disabled],
+  .vttf-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .vttf-btn--primary {
+    background: var(--vttf-ember);
+    color: var(--vttf-text-inverse);
+    box-shadow:
+      0 1px 0 rgb(255 255 255 / 0.2) inset,
+      var(--vttf-shadow-sm);
+  }
+  .vttf-btn--primary:hover {
+    background: var(--vttf-ember-glow);
+  }
+
+  .vttf-btn--secondary {
+    background: var(--vttf-surface);
+    color: var(--vttf-text);
+    border-color: var(--vttf-border-strong);
+  }
+  .vttf-btn--secondary:hover {
+    background: var(--vttf-surface-2);
+    border-color: var(--vttf-text-faint);
+  }
+
+  .vttf-btn--ghost {
+    background: transparent;
+    color: var(--vttf-text-muted);
+  }
+  .vttf-btn--ghost:hover {
+    color: var(--vttf-text);
+    background: var(--vttf-surface);
+  }
+
+  .vttf-btn--danger {
+    background: transparent;
+    color: var(--vttf-rose);
+    border-color: color-mix(in oklch, var(--vttf-rose) 40%, transparent);
+  }
+  .vttf-btn--danger:hover {
+    background: color-mix(in oklch, var(--vttf-rose) 10%, transparent);
+  }
+
+  .vttf-btn .vttf-kbd {
+    font-family: var(--vttf-font-mono);
+    font-size: 11px;
+    padding: 1px 5px;
+    border-radius: var(--vttf-radius-sm);
+    background: rgb(0 0 0 / 0.25);
+    color: inherit;
+    opacity: 0.7;
+  }
+
+  /* ════════ BADGES ════════ */
+
+  .vttf-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    border-radius: var(--vttf-radius-full);
+    font-family: var(--vttf-font-mono);
+    font-size: 11px;
+    font-weight: 500;
+    border: 1px solid;
+    line-height: 1.5;
+  }
+
+  .vttf-badge__blip {
+    width: 6px;
+    height: 6px;
+    border-radius: var(--vttf-radius-full);
+    background: currentColor;
+  }
+
+  .vttf-badge--ember {
+    color: var(--vttf-ember);
+    border-color: color-mix(in oklch, var(--vttf-ember) 40%, transparent);
+    background: color-mix(in oklch, var(--vttf-ember) 8%, transparent);
+  }
+  .vttf-badge--steel {
+    color: var(--vttf-steel);
+    border-color: color-mix(in oklch, var(--vttf-steel) 40%, transparent);
+    background: color-mix(in oklch, var(--vttf-steel) 8%, transparent);
+  }
+  .vttf-badge--mint {
+    color: var(--vttf-mint);
+    border-color: color-mix(in oklch, var(--vttf-mint) 40%, transparent);
+    background: color-mix(in oklch, var(--vttf-mint) 8%, transparent);
+  }
+  .vttf-badge--gold {
+    color: var(--vttf-gold);
+    border-color: color-mix(in oklch, var(--vttf-gold) 40%, transparent);
+    background: color-mix(in oklch, var(--vttf-gold) 8%, transparent);
+  }
+  .vttf-badge--rose {
+    color: var(--vttf-rose);
+    border-color: color-mix(in oklch, var(--vttf-rose) 40%, transparent);
+    background: color-mix(in oklch, var(--vttf-rose) 8%, transparent);
+  }
+  .vttf-badge--violet {
+    color: var(--vttf-violet);
+    border-color: color-mix(in oklch, var(--vttf-violet) 40%, transparent);
+    background: color-mix(in oklch, var(--vttf-violet) 8%, transparent);
+  }
+  .vttf-badge--muted {
+    color: var(--vttf-text-muted);
+    border-color: var(--vttf-border);
+    background: var(--vttf-surface);
+  }
+
+  /* ════════ CODE BLOCK + SYNTAX TOKENS ════════ */
+
+  .vttf-codeblock {
+    background: var(--vttf-bg-sunken);
+    border: 1px solid var(--vttf-border);
+    border-radius: var(--vttf-radius-lg);
+    overflow: hidden;
+    font-family: var(--vttf-font-mono);
+  }
+
+  .vttf-codeblock__head {
+    display: flex;
+    align-items: center;
+    gap: var(--vttf-space-3);
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--vttf-border);
+    background: color-mix(in oklch, var(--vttf-bg-elevated) 70%, transparent);
+    font-size: 12px;
+    color: var(--vttf-text-muted);
+  }
+
+  .vttf-codeblock__dots {
+    display: flex;
+    gap: 6px;
+  }
+  .vttf-codeblock__dots span {
+    width: 10px;
+    height: 10px;
+    border-radius: var(--vttf-radius-full);
+    background: var(--vttf-border-strong);
+  }
+
+  .vttf-codeblock__file {
+    color: var(--vttf-text);
+    background: var(--vttf-surface);
+    padding: 4px 10px;
+    border-radius: var(--vttf-radius-sm);
+    border: 1px solid var(--vttf-border);
+  }
+
+  .vttf-codeblock__lang {
+    margin-left: auto;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--vttf-text-faint);
+  }
+
+  .vttf-codeblock pre {
+    margin: 0;
+    padding: var(--vttf-space-5);
+    font-size: 13.5px;
+    line-height: 1.6;
+    color: var(--vttf-text);
+    overflow-x: auto;
+  }
+
+  .vttf-tk-com {
+    color: var(--vttf-text-faint);
+    font-style: italic;
+  }
+  .vttf-tk-kw {
+    color: var(--vttf-violet);
+  }
+  .vttf-tk-fn {
+    color: var(--vttf-ember-glow);
+  }
+  .vttf-tk-str {
+    color: var(--vttf-mint);
+  }
+  .vttf-tk-num {
+    color: var(--vttf-gold);
+  }
+  .vttf-tk-ty {
+    color: var(--vttf-steel);
+  }
+  .vttf-tk-pun {
+    color: var(--vttf-text-muted);
+  }
+  .vttf-tk-prop {
+    color: var(--vttf-text);
+  }
+
+  /* ════════ FORM GRID + FIELD ════════ */
+
+  .vttf-form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--vttf-space-6);
+  }
+
+  .vttf-form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .vttf-form-field > label {
+    font-family: var(--vttf-font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--vttf-text-faint);
+  }
+
+  .vttf-form-field .vttf-hint {
+    font-size: 12px;
+    color: var(--vttf-text-muted);
+  }
+
+  /* ════════ TEXT INPUTS ════════ */
+
+  .vttf-input,
+  .vttf-textarea,
+  .vttf-select {
+    background: var(--vttf-bg-sunken);
+    border: 1px solid var(--vttf-border);
+    color: var(--vttf-text);
+    padding: 9px 12px;
+    border-radius: var(--vttf-radius-sm);
+    font-family: var(--vttf-font-body);
+    font-size: 14px;
+    width: 100%;
+    transition:
+      border-color var(--vttf-duration-fast) var(--vttf-ease-out),
+      box-shadow var(--vttf-duration-fast) var(--vttf-ease-out);
+  }
+
+  .vttf-input:focus-visible,
+  .vttf-textarea:focus-visible,
+  .vttf-select:focus-visible {
+    border-color: var(--vttf-ember);
+  }
+
+  .vttf-input[aria-invalid="true"],
+  .vttf-input.is-invalid,
+  .vttf-textarea[aria-invalid="true"],
+  .vttf-textarea.is-invalid,
+  .vttf-select[aria-invalid="true"],
+  .vttf-select.is-invalid {
+    border-color: var(--vttf-rose);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--vttf-rose) 18%, transparent);
+  }
+
+  .vttf-textarea {
+    min-height: 96px;
+    resize: vertical;
+    font-family: var(--vttf-font-mono);
+    font-size: 13px;
+  }
+
+  .vttf-select {
+    appearance: none;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M3 5l3 3 3-3' stroke='%23999' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    padding-right: 32px;
+  }
+
+  /* ════════ CHECKBOXES + RADIOS ════════ */
+
+  .vttf-check,
+  .vttf-radio {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--vttf-space-2);
+    cursor: pointer;
+    font-size: 14px;
+  }
+
+  .vttf-check input,
+  .vttf-radio input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .vttf-check__box,
+  .vttf-radio__box {
+    width: 16px;
+    height: 16px;
+    background: var(--vttf-bg-sunken);
+    border: 1.5px solid var(--vttf-border-strong);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    transition:
+      background var(--vttf-duration-fast) var(--vttf-ease-out),
+      border-color var(--vttf-duration-fast) var(--vttf-ease-out);
+  }
+
+  .vttf-check__box {
+    border-radius: var(--vttf-radius-sm);
+  }
+  .vttf-radio__box {
+    border-radius: var(--vttf-radius-full);
+  }
+
+  .vttf-check input:checked + .vttf-check__box {
+    background: var(--vttf-ember);
+    border-color: var(--vttf-ember);
+  }
+  .vttf-check input:checked + .vttf-check__box::after {
+    content: "";
+    width: 9px;
+    height: 5px;
+    border-left: 2px solid var(--vttf-text-inverse);
+    border-bottom: 2px solid var(--vttf-text-inverse);
+    transform: rotate(-45deg) translate(1px, -1px);
+  }
+
+  .vttf-radio input:checked + .vttf-radio__box {
+    border-color: var(--vttf-ember);
+  }
+  .vttf-radio input:checked + .vttf-radio__box::after {
+    content: "";
+    width: 8px;
+    height: 8px;
+    border-radius: var(--vttf-radius-full);
+    background: var(--vttf-ember);
+  }
+
+  .vttf-check input:focus-visible + .vttf-check__box,
+  .vttf-radio input:focus-visible + .vttf-radio__box {
+    box-shadow: var(--vttf-focus-ring);
+  }
+
+  /* ════════ SWITCH ════════ */
+
+  .vttf-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--vttf-space-3);
+    cursor: pointer;
+    font-size: 14px;
+  }
+
+  .vttf-switch input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .vttf-switch__track {
+    width: 36px;
+    height: 20px;
+    border-radius: var(--vttf-radius-full);
+    background: var(--vttf-surface-2);
+    border: 1px solid var(--vttf-border-strong);
+    position: relative;
+    transition:
+      background var(--vttf-duration-base) var(--vttf-ease-out),
+      border-color var(--vttf-duration-base) var(--vttf-ease-out);
+  }
+
+  .vttf-switch__track::after {
+    content: "";
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    top: 2px;
+    left: 2px;
+    background: var(--vttf-text-muted);
+    border-radius: var(--vttf-radius-full);
+    transition:
+      transform var(--vttf-duration-base) var(--vttf-ease-out),
+      background var(--vttf-duration-base) var(--vttf-ease-out);
+  }
+
+  .vttf-switch input:checked + .vttf-switch__track {
+    background: var(--vttf-ember);
+    border-color: var(--vttf-ember);
+  }
+
+  .vttf-switch input:checked + .vttf-switch__track::after {
+    transform: translateX(16px);
+    background: var(--vttf-text-inverse);
+  }
+
+  .vttf-switch input:focus-visible + .vttf-switch__track {
+    box-shadow: var(--vttf-focus-ring);
+  }
+
+  /* ════════ RANGE ════════ */
+
+  .vttf-range {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 100%;
+    height: 4px;
+    background: var(--vttf-surface-2);
+    border-radius: var(--vttf-radius-full);
+    outline: none;
+  }
+
+  .vttf-range::-webkit-slider-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: var(--vttf-radius-full);
+    background: var(--vttf-ember);
+    border: 2px solid var(--vttf-bg);
+    box-shadow: var(--vttf-shadow-sm);
+    cursor: pointer;
+  }
+
+  .vttf-range::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: var(--vttf-radius-full);
+    background: var(--vttf-ember);
+    border: 2px solid var(--vttf-bg);
+    cursor: pointer;
+  }
+
+  /* ════════ SEGMENTED CONTROL ════════ */
+
+  .vttf-segment {
+    display: inline-flex;
+    padding: 3px;
+    background: var(--vttf-surface);
+    border: 1px solid var(--vttf-border);
+    border-radius: var(--vttf-radius-md);
+  }
+
+  .vttf-segment button {
+    border: none;
+    background: transparent;
+    color: var(--vttf-text-muted);
+    font-family: var(--vttf-font-body);
+    font-size: 13px;
+    font-weight: 500;
+    padding: 6px 12px;
+    border-radius: var(--vttf-radius-sm);
+    cursor: pointer;
+    transition:
+      background var(--vttf-duration-fast) var(--vttf-ease-out),
+      color var(--vttf-duration-fast) var(--vttf-ease-out),
+      box-shadow var(--vttf-duration-fast) var(--vttf-ease-out);
+  }
+
+  .vttf-segment button:hover {
+    color: var(--vttf-text);
+  }
+
+  .vttf-segment button[aria-pressed="true"],
+  .vttf-segment button[aria-selected="true"],
+  .vttf-segment button.is-active {
+    background: var(--vttf-bg-sunken);
+    color: var(--vttf-text);
+    box-shadow: var(--vttf-shadow-sm);
+  }
+
+  /* ════════ TABS ════════ */
+
+  .vttf-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 0 var(--vttf-space-4);
+    border-bottom: 1px solid var(--vttf-border);
+    background: var(--vttf-bg-elevated);
+  }
+
+  .vttf-tab {
+    padding: 10px 14px;
+    font-family: var(--vttf-font-body);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--vttf-text-muted);
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    cursor: pointer;
+    transition:
+      color var(--vttf-duration-fast) var(--vttf-ease-out),
+      border-color var(--vttf-duration-fast) var(--vttf-ease-out);
+  }
+
+  .vttf-tab:hover {
+    color: var(--vttf-text);
+  }
+
+  .vttf-tab[aria-selected="true"],
+  .vttf-tab.is-active {
+    color: var(--vttf-text);
+    border-bottom-color: var(--vttf-ember);
+  }
+
+  .vttf-tab__count {
+    font-family: var(--vttf-font-mono);
+    font-size: 10px;
+    margin-left: 6px;
+    color: var(--vttf-text-faint);
+  }
+
+  /* ════════ SHEET CONTAINER ════════ */
+
+  .vttf-sheet {
+    background: var(--vttf-bg-elevated);
+    border: 1px solid var(--vttf-border);
+    border-radius: var(--vttf-radius-lg);
+    overflow: hidden;
+  }
+
+  .vttf-sheet__head {
+    padding: var(--vttf-space-4);
+    display: flex;
+    align-items: center;
+    gap: var(--vttf-space-4);
+    border-bottom: 1px solid var(--vttf-border);
+    background: var(--vttf-surface);
+  }
+
+  .vttf-sheet__title {
+    font-family: var(--vttf-font-display);
+    font-size: 22px;
+    font-weight: var(--vttf-text-weight-semibold);
+    letter-spacing: -0.02em;
+  }
+
+  .vttf-sheet__sub {
+    font-family: var(--vttf-font-mono);
+    font-size: 11px;
+    color: var(--vttf-text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  .vttf-sheet__body {
+    padding: var(--vttf-space-5);
+    display: grid;
+    gap: var(--vttf-space-3);
+  }
+
+  .vttf-portrait {
+    width: 56px;
+    height: 56px;
+    border-radius: var(--vttf-radius-md);
+    background:
+      repeating-linear-gradient(
+        45deg,
+        color-mix(in oklch, var(--vttf-ember-deep) 18%, transparent) 0 6px,
+        color-mix(in oklch, var(--vttf-ember-deep) 8%, transparent) 6px 12px
+      ),
+      var(--vttf-surface-2);
+    border: 1px dashed var(--vttf-border-strong);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--vttf-font-mono);
+    font-size: 10px;
+    color: var(--vttf-text-faint);
+  }
+
+  .vttf-field-row {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: var(--vttf-space-4);
+    align-items: center;
+  }
+
+  .vttf-field-label {
+    font-family: var(--vttf-font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--vttf-text-faint);
+  }
+
+  /* ════════ STAT PILL ════════ */
+
+  .vttf-stat-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--vttf-space-2);
+    padding: 4px 10px 4px 4px;
+    background: var(--vttf-surface);
+    border-radius: var(--vttf-radius-full);
+    border: 1px solid var(--vttf-border);
+  }
+
+  .vttf-stat-pill__n {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--vttf-radius-full);
+    background: var(--vttf-ember);
+    color: var(--vttf-text-inverse);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--vttf-font-mono);
+    font-weight: var(--vttf-text-weight-bold);
+    font-size: 13px;
+  }
+
+  .vttf-stat-pill__label {
+    font-size: 12px;
+    color: var(--vttf-text-muted);
+    font-family: var(--vttf-font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  /* ════════ DROPZONE ════════ */
+
+  .vttf-dropzone {
+    border: 1.5px dashed var(--vttf-border-strong);
+    border-radius: var(--vttf-radius-md);
+    padding: var(--vttf-space-6);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--vttf-space-2);
+    color: var(--vttf-text-muted);
+    background: color-mix(in oklch, var(--vttf-bg) 40%, transparent);
+    transition:
+      background var(--vttf-duration-fast) var(--vttf-ease-out),
+      border-color var(--vttf-duration-fast) var(--vttf-ease-out);
+  }
+
+  .vttf-dropzone.is-active,
+  .vttf-dropzone[data-drop-effect] {
+    border-color: var(--vttf-ember);
+    color: var(--vttf-ember);
+    background: color-mix(in oklch, var(--vttf-ember) 6%, transparent);
+    box-shadow: var(--vttf-glow-ember);
+  }
+
+  .vttf-dropzone__icon {
+    font-family: var(--vttf-font-mono);
+    font-size: 24px;
+  }
+
+  .vttf-dropzone__title {
+    font-family: var(--vttf-font-body);
+    font-weight: var(--vttf-text-weight-semibold);
+    font-size: 14px;
+    color: var(--vttf-text);
+  }
+
+  .vttf-dropzone__sub {
+    font-family: var(--vttf-font-mono);
+    font-size: 11px;
+  }
+
+  /* ════════ ITEM ROW ════════ */
+
+  .vttf-item-row {
+    display: grid;
+    grid-template-columns: 24px 32px 1fr auto auto;
+    align-items: center;
+    gap: var(--vttf-space-3);
+    padding: 8px 10px;
+    border: 1px solid var(--vttf-border);
+    border-radius: var(--vttf-radius-sm);
+    background: var(--vttf-surface);
+  }
+
+  .vttf-item-row + .vttf-item-row {
+    margin-top: -1px;
+  }
+
+  .vttf-item-row__grip {
+    color: var(--vttf-text-faint);
+    cursor: grab;
+    font-family: var(--vttf-font-mono);
+    font-size: 14px;
+  }
+
+  .vttf-item-row__thumb {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--vttf-radius-sm);
+    background: var(--vttf-surface-2);
+    border: 1px solid var(--vttf-border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--vttf-font-mono);
+    font-size: 12px;
+    color: var(--vttf-text-faint);
+  }
+
+  .vttf-item-row__name {
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  .vttf-item-row__meta {
+    font-family: var(--vttf-font-mono);
+    font-size: 11px;
+    color: var(--vttf-text-faint);
+  }
 }

--- a/packages/styles/index.css
+++ b/packages/styles/index.css
@@ -6,13 +6,14 @@
  *
  *   @import '@vttforge/styles';
  *
- * Layer order matches Foundry v13's outer layer: tokens → reset → base → components.
+ * Layer order matches Foundry v13's outer layer: tokens → reset → base → components → themes.
  * Foundry's own runtime wraps system CSS in its top-level `system` layer.
  */
 
-@layer vttforge.tokens, vttforge.reset, vttforge.base, vttforge.components;
+@layer vttforge.tokens, vttforge.reset, vttforge.base, vttforge.components, vttforge.themes;
 
 @import "./dist/tokens.css";
 @import "./reset.css";
 @import "./base.css";
 @import "./components.css";
+@import "./themes/forge.css";

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -24,12 +24,14 @@
     "./base.css": "./base.css",
     "./components.css": "./components.css",
     "./styles.layer.css": "./styles.layer.css",
+    "./themes/forge.css": "./themes/forge.css",
     "./tokens.json": "./tokens.json",
     "./package.json": "./package.json"
   },
   "files": [
     "*.css",
     "dist/*.css",
+    "themes/*.css",
     "tokens.json",
     "README.md",
     "CHANGELOG.md"

--- a/packages/styles/preview/index.html
+++ b/packages/styles/preview/index.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@vttforge/styles — preview</title>
+    <link rel="stylesheet" href="../index.css" />
+    <style>
+      body {
+        margin: 0;
+        padding: 32px;
+        max-width: 1100px;
+        margin-inline: auto;
+      }
+      .header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: 32px;
+        padding-bottom: 16px;
+        border-bottom: 1px solid var(--vttf-border);
+      }
+      h1 {
+        font-family: var(--vttf-font-display);
+        font-size: 36px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        margin: 0;
+      }
+      h1 em {
+        font-style: normal;
+        color: var(--vttf-ember);
+      }
+      .toggle {
+        font-family: var(--vttf-font-mono);
+        font-size: 12px;
+        padding: 6px 12px;
+        background: var(--vttf-surface);
+        border: 1px solid var(--vttf-border);
+        border-radius: var(--vttf-radius-md);
+        color: var(--vttf-text);
+        cursor: pointer;
+      }
+      .toggle:hover {
+        background: var(--vttf-surface-2);
+      }
+      section {
+        margin-bottom: 48px;
+      }
+      h2 {
+        font-family: var(--vttf-font-mono);
+        font-size: 11px;
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.15em;
+        color: var(--vttf-text-faint);
+        margin: 0 0 16px;
+      }
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+      }
+      .stack {
+        display: grid;
+        gap: 12px;
+      }
+    </style>
+  </head>
+  <body class="vttf-app">
+    <div class="header">
+      <h1><em>{</em> d20 <em>}</em> · @vttforge/styles</h1>
+      <button class="toggle" type="button" data-theme-toggle>
+        theme · <span data-theme-label>dark</span>
+      </button>
+    </div>
+
+    <section>
+      <h2>Buttons</h2>
+      <div class="row">
+        <button class="vttf-btn vttf-btn--primary" type="button">Primary <span class="vttf-kbd">⌘K</span></button>
+        <button class="vttf-btn vttf-btn--secondary" type="button">Secondary</button>
+        <button class="vttf-btn vttf-btn--ghost" type="button">Ghost</button>
+        <button class="vttf-btn vttf-btn--danger" type="button">Delete</button>
+        <button class="vttf-btn vttf-btn--primary" type="button" disabled>Disabled</button>
+      </div>
+    </section>
+
+    <section>
+      <h2>Badges</h2>
+      <div class="row">
+        <span class="vttf-badge vttf-badge--ember"><span class="vttf-badge__blip"></span>ember</span>
+        <span class="vttf-badge vttf-badge--steel"><span class="vttf-badge__blip"></span>steel</span>
+        <span class="vttf-badge vttf-badge--mint"><span class="vttf-badge__blip"></span>mint</span>
+        <span class="vttf-badge vttf-badge--gold"><span class="vttf-badge__blip"></span>gold</span>
+        <span class="vttf-badge vttf-badge--rose"><span class="vttf-badge__blip"></span>rose</span>
+        <span class="vttf-badge vttf-badge--violet"><span class="vttf-badge__blip"></span>violet</span>
+        <span class="vttf-badge vttf-badge--muted"><span class="vttf-badge__blip"></span>muted</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>Forms</h2>
+      <div class="vttf-form-grid">
+        <div class="vttf-form-field">
+          <label>Character name</label>
+          <input class="vttf-input" type="text" value="Vex Halloran" />
+          <span class="vttf-hint">Visible in the sheet header.</span>
+        </div>
+        <div class="vttf-form-field">
+          <label>Class</label>
+          <select class="vttf-select">
+            <option>Rogue</option>
+            <option>Fighter</option>
+            <option>Wizard</option>
+          </select>
+        </div>
+        <div class="vttf-form-field">
+          <label>Notes</label>
+          <textarea class="vttf-textarea">Stealthy. Owes a favour to the harbourmaster.</textarea>
+        </div>
+        <div class="vttf-form-field">
+          <label>Invalid input</label>
+          <input class="vttf-input" type="text" aria-invalid="true" value="too long" />
+          <span class="vttf-hint">Aria-invalid demo.</span>
+        </div>
+        <div class="vttf-form-field">
+          <label>Toggles</label>
+          <div class="stack">
+            <label class="vttf-check"><input type="checkbox" checked /><span class="vttf-check__box"></span>Inspiration</label>
+            <label class="vttf-radio"><input type="radio" name="r" checked /><span class="vttf-radio__box"></span>Active</label>
+            <label class="vttf-switch"><input type="checkbox" checked /><span class="vttf-switch__track"></span>Auto-roll</label>
+          </div>
+        </div>
+        <div class="vttf-form-field">
+          <label>Range</label>
+          <input class="vttf-range" type="range" min="0" max="100" value="64" />
+        </div>
+        <div class="vttf-form-field">
+          <label>Segmented</label>
+          <div class="vttf-segment" role="tablist">
+            <button type="button" aria-pressed="true">Abilities</button>
+            <button type="button">Inventory</button>
+            <button type="button">Spells</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Code block</h2>
+      <div class="vttf-codeblock">
+        <div class="vttf-codeblock__head">
+          <div class="vttf-codeblock__dots"><span></span><span></span><span></span></div>
+          <span class="vttf-codeblock__file">character-sheet.ts</span>
+          <span class="vttf-codeblock__lang">TypeScript</span>
+        </div>
+        <pre><span class="vttf-tk-com">// Twelve lines, same behaviour.</span>
+<span class="vttf-tk-kw">export class</span> <span class="vttf-tk-ty">CharacterSheet</span> <span class="vttf-tk-kw">extends</span> <span class="vttf-tk-fn">BaseActorSheet</span>(<span class="vttf-tk-ty">CharacterData</span>) {
+  <span class="vttf-tk-prop">static</span> <span class="vttf-tk-prop">PARTS</span> = {
+    <span class="vttf-tk-prop">header</span>: { <span class="vttf-tk-prop">template</span>: <span class="vttf-tk-str">"systems/x/templates/header.hbs"</span> },
+    <span class="vttf-tk-prop">stats</span>:  { <span class="vttf-tk-prop">template</span>: <span class="vttf-tk-str">"systems/x/templates/stats.hbs"</span> },
+  };
+
+  <span class="vttf-tk-fn">prepareDerived</span>(<span class="vttf-tk-prop">data</span>) {
+    <span class="vttf-tk-prop">data</span>.<span class="vttf-tk-prop">mod</span> = <span class="vttf-tk-fn">Math</span>.<span class="vttf-tk-fn">floor</span>((<span class="vttf-tk-prop">data</span>.<span class="vttf-tk-prop">score</span> - <span class="vttf-tk-num">10</span>) / <span class="vttf-tk-num">2</span>);
+  }
+}</pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Sheet primitive</h2>
+      <div class="vttf-sheet">
+        <div class="vttf-sheet__head">
+          <div class="vttf-portrait">img</div>
+          <div>
+            <div class="vttf-sheet__title">Vex Halloran</div>
+            <div class="vttf-sheet__sub">half-elf · rogue · level 4</div>
+          </div>
+          <div style="margin-left: auto; display: flex; gap: 8px;">
+            <span class="vttf-stat-pill"><span class="vttf-stat-pill__n">28</span><span class="vttf-stat-pill__label">HP</span></span>
+            <span class="vttf-stat-pill"><span class="vttf-stat-pill__n">15</span><span class="vttf-stat-pill__label">AC</span></span>
+          </div>
+        </div>
+        <div class="vttf-tabs" role="tablist">
+          <button class="vttf-tab" type="button" aria-selected="true">Abilities</button>
+          <button class="vttf-tab" type="button">Inventory <span class="vttf-tab__count">12</span></button>
+          <button class="vttf-tab" type="button">Spells</button>
+        </div>
+        <div class="vttf-sheet__body">
+          <div class="vttf-item-row">
+            <div class="vttf-item-row__grip">⋮</div>
+            <div class="vttf-item-row__thumb">⚔</div>
+            <div>
+              <div class="vttf-item-row__name">Shortsword +1</div>
+              <div class="vttf-item-row__meta">finesse · equipped</div>
+            </div>
+            <span class="vttf-badge vttf-badge--mint"><span class="vttf-badge__blip"></span>equipped</span>
+            <span class="vttf-item-row__meta">×1</span>
+          </div>
+          <div class="vttf-item-row">
+            <div class="vttf-item-row__grip">⋮</div>
+            <div class="vttf-item-row__thumb">◇</div>
+            <div>
+              <div class="vttf-item-row__name">Pouch of opals</div>
+              <div class="vttf-item-row__meta">valued · stowed</div>
+            </div>
+            <span class="vttf-badge vttf-badge--gold"><span class="vttf-badge__blip"></span>valued</span>
+            <span class="vttf-item-row__meta">×3</span>
+          </div>
+          <div class="vttf-dropzone">
+            <div class="vttf-dropzone__icon">+</div>
+            <div class="vttf-dropzone__title">Drop items here</div>
+            <div class="vttf-dropzone__sub">or click to browse</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <script type="module" src="./preview.js"></script>
+  </body>
+</html>

--- a/packages/styles/preview/preview.js
+++ b/packages/styles/preview/preview.js
@@ -1,0 +1,35 @@
+/**
+ * Storybook-lite theme toggle for the @vttforge/styles preview page.
+ * Cycles dark → light → foundry → auto and persists to localStorage.
+ */
+
+const KEY = 'vttf-theme';
+const ORDER = ['dark', 'light', 'foundry', 'auto'];
+
+function apply(theme) {
+  if (theme === 'dark') {
+    document.documentElement.removeAttribute('data-theme');
+  } else {
+    document.documentElement.setAttribute('data-theme', theme);
+  }
+  const label = document.querySelector('[data-theme-label]');
+  if (label) label.textContent = theme;
+}
+
+function init() {
+  const saved = localStorage.getItem(KEY);
+  apply(saved && ORDER.includes(saved) ? saved : 'dark');
+
+  document.querySelector('[data-theme-toggle]')?.addEventListener('click', () => {
+    const current = localStorage.getItem(KEY) ?? 'dark';
+    const next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
+    localStorage.setItem(KEY, next);
+    apply(next);
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/packages/styles/reset.css
+++ b/packages/styles/reset.css
@@ -2,9 +2,60 @@
  * @vttforge/styles — reset.css
  *
  * Scoped reset that complements Foundry's own `reset` layer without overriding it.
- * Real ruleset lands in v0.1.0.
+ * Targets only VTTForge-marked roots: `.vttf-app`, `.vttf-sheet`, `form[data-vttf]`.
+ * Outside those scopes, Foundry's reset is untouched.
  */
 
 @layer vttforge.reset {
-  /* intentionally empty placeholder */
+  .vttf-app,
+  .vttf-app *,
+  .vttf-app *::before,
+  .vttf-app *::after,
+  .vttf-sheet,
+  .vttf-sheet *,
+  .vttf-sheet *::before,
+  .vttf-sheet *::after,
+  form[data-vttf],
+  form[data-vttf] *,
+  form[data-vttf] *::before,
+  form[data-vttf] *::after {
+    box-sizing: border-box;
+  }
+
+  .vttf-app,
+  .vttf-sheet {
+    margin: 0;
+  }
+
+  .vttf-app button,
+  .vttf-sheet button,
+  form[data-vttf] button {
+    font: inherit;
+    color: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+  }
+
+  .vttf-app input,
+  .vttf-sheet input,
+  .vttf-app textarea,
+  .vttf-sheet textarea,
+  .vttf-app select,
+  .vttf-sheet select,
+  form[data-vttf] input,
+  form[data-vttf] textarea,
+  form[data-vttf] select {
+    font: inherit;
+    color: inherit;
+  }
+
+  .vttf-app ul,
+  .vttf-app ol,
+  .vttf-sheet ul,
+  .vttf-sheet ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 }

--- a/packages/styles/styles.layer.css
+++ b/packages/styles/styles.layer.css
@@ -2,9 +2,9 @@
  * @vttforge/styles — styles.layer.css
  *
  * Mantine-style variant: wraps `index.css` inside an explicit `@layer vttforge`
- * for consumers that want a single namespaced layer instead of the four
+ * for consumers that want a single namespaced layer instead of the five
  * sub-layers (`vttforge.tokens`, `vttforge.reset`, `vttforge.base`,
- * `vttforge.components`).
+ * `vttforge.components`, `vttforge.themes`).
  *
  * Use this entry when you need to control VTTForge's cascade position relative
  * to your own layers; use the default `index.css` otherwise.
@@ -15,4 +15,5 @@
   @import "./reset.css";
   @import "./base.css";
   @import "./components.css";
+  @import "./themes/forge.css";
 }

--- a/packages/styles/themes/forge.css
+++ b/packages/styles/themes/forge.css
@@ -1,0 +1,31 @@
+/*!
+ * @vttforge/styles — themes/forge.css
+ *
+ * Auto-light support for the Forge theme. When a consumer sets
+ * `data-theme="auto"` on the sheet root, the GM's OS-level light/dark
+ * preference takes over. Explicit `data-theme="light"` and
+ * `data-theme="foundry"` are handled by tokens.css.
+ *
+ * Imported by `index.css` and `styles.layer.css` after components, so theme
+ * overrides win cleanly inside `@layer vttforge.themes`.
+ */
+
+@layer vttforge.themes {
+  @media (prefers-color-scheme: light) {
+    :where([data-theme="auto"]) {
+      --vttf-bg: oklch(0.985 0.004 80);
+      --vttf-bg-elevated: oklch(0.972 0.006 78);
+      --vttf-bg-sunken: oklch(0.945 0.01 72);
+      --vttf-surface: oklch(0.962 0.008 75);
+      --vttf-surface-2: oklch(0.928 0.012 68);
+      --vttf-border: oklch(0.88 0.014 62);
+      --vttf-border-strong: oklch(0.76 0.016 58);
+      --vttf-text: oklch(0.215 0.02 42);
+      --vttf-text-muted: oklch(0.43 0.018 48);
+      --vttf-text-faint: oklch(0.595 0.014 55);
+      --vttf-ember: oklch(0.565 0.18 36);
+      --vttf-ember-deep: oklch(0.43 0.16 30);
+      --vttf-ember-glow: oklch(0.67 0.17 42);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Stacked on [#20](https://github.com/vttforge/vttforge/pull/20) (tokens pipeline). Fills the four empty layers in `@vttforge/styles` with the full primitive set adapted from `Design System.html`, plus a Storybook-lite preview and four recipe themes.

- **`reset.css`** — scoped reset for `.vttf-app`, `.vttf-sheet`, `form[data-vttf]`. Does not override Foundry's `reset` layer.
- **`base.css`** — element baselines, focus-ring rendering, `.vttf-sr-only` utility.
- **`components.css`** — buttons (primary/secondary/ghost/danger), badges (7 hues), code block + syntax tokens (`.vttf-tk-*`), inputs/textarea/select with `aria-invalid`, checkbox/radio/switch/range/segmented control, tabs with `aria-selected`, sheet primitives (`.vttf-sheet`, `.vttf-sheet__head`/`__body`, `.vttf-portrait`, `.vttf-stat-pill`, `.vttf-dropzone`, `.vttf-item-row`).
- **`themes/forge.css`** — `@media (prefers-color-scheme: light) [data-theme="auto"]`. Adds the `vttforge.themes` cascade sub-layer.
- **`preview/index.html` + `preview.js`** — renders every primitive with a `dark → light → foundry → auto` toggle.
- **`examples/themes/`** — four recipe themes (`codex`, `parchment`, `grimdark`, `neon`) + a `README.md` showing the `.vttf-theme-name { --vttf-* }` override pattern.

## Conventions used

- BEM-light: `.vttf-name` root, `.vttf-name__part` parts, `.vttf-name--variant` modifiers.
- ARIA states first (`aria-selected`, `aria-invalid`, `aria-pressed`); `.is-*` classes only as fallback.
- `:focus-visible` owned by the base layer; components never override.
- Translucent tints via `color-mix(in oklch, var(--vttf-ember) 8%, transparent)` so re-theming the ember token propagates automatically (HANDOFF §5).
- Transitions use `--vttf-duration-*` and `--vttf-ease-*` tokens.

## Test plan

- [ ] Open `packages/styles/preview/index.html` in a browser. Toggle theme (dark / light / foundry / auto). Confirm every primitive responds to the token swap.
- [ ] Compare visually with `Design System.html` (the original spec).
- [ ] `pnpm typecheck && pnpm test && pnpm lint && pnpm build && pnpm -F @vttforge/styles publint` — all green.
- [ ] (After PR #20 merges) verify in the `examples/simple-system` Docker boot that the sheet still renders correctly and cascade layers stay scoped.

## Out of scope

- Tooltip / popover / toolbar / context-menu / table / progress — listed as "still needed" in HANDOFF.md §7 but require runtime behaviour decisions (positioning strategy, focus trap). Will land as follow-ups when the consumer system needs them.