### PR TITLE
chore(worktree): add .worktreeinclude so new worktrees pick up agent skills

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,13 @@
+# Files to copy into new git worktrees.
+#
+# Uses .gitignore syntax. Only matches files that are ALSO gitignored —
+# tracked files are already in the worktree via `git worktree add`.
+#
+# See ~/.claude/rules/git-worktrees.md for the convention.
+
+# Skills bundle: foundry-vtt-system-dev, foundry-vtt-module-dev
+# Pulled via skills-lock.json on the main checkout; needed by the
+# Skill tool in every worktree so agents can invoke them without
+# falling back to direct SKILL.md reads.
+.agents/
+.claude/skills/


### PR DESCRIPTION
## Summary

- Adds `.worktreeinclude` at the repo root listing the gitignored agent-tooling bundles (`.agents/` and `.claude/skills/`).
- New worktrees created via `git worktree add` (or `claude --worktree`) now automatically replicate the local tooling bundle, so the `Skill` tool finds the project's helper skills immediately in fresh worktrees.

## Why

The project ships local-only agent tooling under `.agents/` and `.claude/skills/`, both gitignored. Worktrees only inherit tracked content, so each fresh worktree booted with broken tooling symlinks. Caught while reviewing a Figma sheet mock — the agent fell back to direct file reads because the tools weren't resolvable.

## Test plan

- [ ] Create a fresh worktree (`claude --worktree skills-smoke-test` or `git worktree add`) and confirm `.agents/skills/` and `.claude/skills/` populate.
- [ ] Open a Claude Code session in the new worktree and invoke the `Skill` tool — local skills should load.