### PR TITLE
feat(examples/simple-system): align character sheet to Figma reference

### DIFF
--- a/examples/simple-system/lang/en.json
+++ b/examples/simple-system/lang/en.json
@@ -8,22 +8,32 @@
   "VTTFORGE_EXAMPLE.Sheet.Character.title": "Character",
   "VTTFORGE_EXAMPLE.Sheet.Gear.title": "Gear",
   "VTTFORGE_EXAMPLE.Sheet.NamePlaceholder": "Name…",
-  "VTTFORGE_EXAMPLE.Sheet.Level": "Level",
-  "VTTFORGE_EXAMPLE.Sheet.AC": "AC",
-  "VTTFORGE_EXAMPLE.Sheet.Health": "Health",
-  "VTTFORGE_EXAMPLE.Sheet.Power": "Power",
+  "VTTFORGE_EXAMPLE.Sheet.Level": "LV",
+  "VTTFORGE_EXAMPLE.Sheet.AbilityScores": "Ability scores",
   "VTTFORGE_EXAMPLE.Sheet.Inventory": "Inventory",
+  "VTTFORGE_EXAMPLE.Sheet.Spells": "Spells",
+  "VTTFORGE_EXAMPLE.Sheet.SpellsEmpty": "Spells slot reserved for a follow-up PR.",
+  "VTTFORGE_EXAMPLE.Sheet.Biography": "Biography",
   "VTTFORGE_EXAMPLE.Sheet.NewGear": "New gear",
   "VTTFORGE_EXAMPLE.Sheet.NewGearName": "New Gear",
   "VTTFORGE_EXAMPLE.Sheet.NoGear": "No gear yet — drag items here or click 'New gear'.",
   "VTTFORGE_EXAMPLE.Sheet.Delete": "Delete",
+
+  "VTTFORGE_EXAMPLE.Sheet.Quick.HP": "HP",
+  "VTTFORGE_EXAMPLE.Sheet.Quick.AC": "AC",
+  "VTTFORGE_EXAMPLE.Sheet.Quick.SPD": "SPD",
+  "VTTFORGE_EXAMPLE.Sheet.Quick.INIT": "INIT",
+
   "VTTFORGE_EXAMPLE.Sheet.Tabs.abilities": "Abilities",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.inventory": "Inventory",
+  "VTTFORGE_EXAMPLE.Sheet.Tabs.spells": "Spells",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.biography": "Biography",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.details": "Details",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.description": "Description",
+
   "VTTFORGE_EXAMPLE.Sheet.Roll.label": "Roll",
   "VTTFORGE_EXAMPLE.Sheet.Roll.flavor": "{ability} check",
+  "VTTFORGE_EXAMPLE.Sheet.Drop.label": "Drop item to add",
   "VTTFORGE_EXAMPLE.Sheet.Drop.rejected": "Cannot drop {type} items on a character — only gear is accepted.",
 
   "VTTFORGE_EXAMPLE.Ability.str": "Strength",
@@ -34,5 +44,11 @@
   "VTTFORGE_EXAMPLE.Ability.cha": "Charisma",
 
   "VTTFORGE_EXAMPLE.Gear.Quantity": "Quantity",
-  "VTTFORGE_EXAMPLE.Gear.Weight": "Weight (lb)"
+  "VTTFORGE_EXAMPLE.Gear.Weight": "Weight (lb)",
+  "VTTFORGE_EXAMPLE.Gear.Kind.equipped": "equipped",
+  "VTTFORGE_EXAMPLE.Gear.Kind.valued": "valued",
+  "VTTFORGE_EXAMPLE.Gear.Kind.stowed": "stowed",
+
+  "VTTFORGE_EXAMPLE.Settings.showTutorial.name": "Show tutorial",
+  "VTTFORGE_EXAMPLE.Settings.showTutorial.hint": "Display the example-system tutorial banner on world load."
 }

--- a/examples/simple-system/scripts/data/character-data.mjs
+++ b/examples/simple-system/scripts/data/character-data.mjs
@@ -1,14 +1,11 @@
 /**
  * CharacterData — typed schema for the `character` Actor type.
  *
- * Demonstrates @vttforge/core's `fields()` + `BaseTypeDataModel()` working
- * together: one `defineSchema()` call drives runtime validation,
- * `system.json` migration, AND the TypeScript `system` shape (via
- * `InferSchema<typeof CharacterData.defineSchema>` in any TS consumer).
+ * Schema mirrors the canonical Figma reference (character-sheet.jsx): quick
+ * stats are HP / AC / SPD / INIT, abilities are the six D&D-style scores,
+ * derived state (modifiers, max HP, AC, initiative) is computed in-memory.
  *
- * Derived state (ability modifiers, computed max HP, armor class) is computed
- * in-memory only — never persisted. Matches foundry-vtt-system-dev rule
- * "Never write to the database in prepareDerivedData()".
+ * Never write to the database in prepareDerivedData — only assign onto `this`.
  */
 
 import { BaseTypeDataModel, fields } from '@vttforge/core';
@@ -23,6 +20,12 @@ export class CharacterData extends BaseTypeDataModel() {
         min: 1,
         max: 20,
         initial: 1,
+      }),
+      speed: new f.NumberField({
+        required: true,
+        integer: true,
+        min: 0,
+        initial: 30,
       }),
       abilities: new f.SchemaField({
         str: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
@@ -45,18 +48,18 @@ export class CharacterData extends BaseTypeDataModel() {
   }
 
   prepareDerivedData() {
-    // Ability modifiers: D&D 5e style.
     for (const [key, value] of Object.entries(this.abilities)) {
       const score = typeof value === 'number' ? value : (value?.value ?? 10);
       const mod = Math.floor((score - 10) / 2);
       this.abilities[key] = { value: score, mod };
     }
 
-    // Derived max HP: 10 + level + Constitution modifier.
     const conMod = this.abilities.con.mod;
     this.health.max = 10 + this.level + conMod;
 
-    // Armor class: 10 + Dex modifier.
     this.armorClass = 10 + this.abilities.dex.mod;
+
+    // INIT mirrors DEX modifier — matches the Figma reference (.qv +4 with DEX 18).
+    this.initiative = this.abilities.dex.mod;
   }
 }

--- a/examples/simple-system/scripts/data/gear-data.mjs
+++ b/examples/simple-system/scripts/data/gear-data.mjs
@@ -1,12 +1,14 @@
 /**
  * GearData — typed schema for the `gear` Item type.
  *
- * Trivial schema (quantity, weight, description) — the point isn't the data
- * model but the drag-drop path: a `gear` Item can be dragged from the sidebar
- * onto a CharacterSheet, and the sheet's typed `onDropItem` accepts it.
+ * Carries a `kind` enum that drives the `.sh-tag` pill on the character sheet:
+ * `equipped` / `valued` render with the ember accent pill, `stowed` renders
+ * muted. Mirrors the items column in character-sheet.jsx.
  */
 
 import { BaseTypeDataModel, fields } from '@vttforge/core';
+
+export const GEAR_KINDS = /** @type {const} */ (['equipped', 'valued', 'stowed']);
 
 export class GearData extends BaseTypeDataModel() {
   static defineSchema() {
@@ -22,6 +24,11 @@ export class GearData extends BaseTypeDataModel() {
         required: true,
         min: 0,
         initial: 0,
+      }),
+      kind: new f.StringField({
+        required: true,
+        choices: GEAR_KINDS,
+        initial: 'stowed',
       }),
       description: new f.HTMLField(),
     };

--- a/examples/simple-system/scripts/sheets/character-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/character-sheet.mjs
@@ -62,6 +62,12 @@ export class CharacterSheet extends BaseActorSheet() {
           icon: 'fa-solid fa-sack',
         },
         {
+          id: 'spells',
+          group: 'primary',
+          label: 'VTTFORGE_EXAMPLE.Sheet.Tabs.spells',
+          icon: 'fa-solid fa-wand-magic-sparkles',
+        },
+        {
           id: 'biography',
           group: 'primary',
           label: 'VTTFORGE_EXAMPLE.Sheet.Tabs.biography',
@@ -74,8 +80,8 @@ export class CharacterSheet extends BaseActorSheet() {
 
   static DRAG_DROP = [
     {
-      dragSelector: '.item[draggable=true]',
-      dropSelector: '.sheet-body',
+      dragSelector: '.sh-item[draggable=true]',
+      dropSelector: '.sh-body',
     },
   ];
 
@@ -101,7 +107,17 @@ export class CharacterSheet extends BaseActorSheet() {
       value: data?.value ?? data,
       mod: data?.mod ?? 0,
     }));
-    context.gear = actor.items.filter((item) => item.type === 'gear');
+    context.gear = actor.items
+      .filter((item) => item.type === 'gear')
+      .map((item) => ({
+        id: item.id,
+        name: item.name,
+        img: item.img,
+        kind: item.system?.kind ?? 'stowed',
+        quantity: item.system?.quantity ?? 1,
+        weight: item.system?.weight ?? 0,
+        description: item.system?.description ?? '',
+      }));
     context.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
       system.biography ?? '',
       { relativeTo: actor, secrets: actor.isOwner },

--- a/examples/simple-system/styles/example.css
+++ b/examples/simple-system/styles/example.css
@@ -1,220 +1,495 @@
 @import "@vttforge/styles";
 
 /*
+ * vttforge-example styles — implements the .sh-* class system from the
+ * canonical Figma reference (character-sheet.jsx + Theme Explorations.html)
+ * on top of @vttforge/styles. Tokens come from the Forge theme; no other
+ * theme is hand-rolled here (consumers swap themes by overriding --vttf-*).
+ *
  * Per foundry-vtt-system-dev "Styling & Themes" rule #3, component CSS stays
  * UNLAYERED so it wins over Foundry's @layer applications without specificity
- * wars. Only token / variable definitions belong in @layer variables.
- *
- * Scoped under .vttforge-example (our system marker class) AND .vttforge
- * (the marker every BaseActorSheet/BaseItemSheet adds via VTTFORGE_SHEET_CLASS),
- * so nothing leaks into core Foundry UI.
+ * wars. Scoped under .vttforge-example so nothing leaks into core Foundry UI.
  */
 
-/* Force an opaque sheet background — without this, Foundry's ApplicationV2
- * default is transparent in many themes and the canvas bleeds through.
- * Falls back to a dark slate before Foundry's tokens load. */
+/* Opaque sheet bg — Foundry's ApplicationV2 default is transparent. */
 .vttforge-example.sheet,
 .vttforge-example .window-content {
-  background: var(--color-bg-primary, #1c1c22);
+  background: var(--vttf-bg);
   opacity: 1;
 }
 
 .vttforge-example.sheet {
+  color: var(--vttf-text);
+  font-family: var(--vttf-font-body, system-ui, sans-serif);
+}
+
+.vttforge-example.sheet form {
   display: flex;
   flex-direction: column;
-  gap: var(--vttf-space-4, 0.75rem);
-  padding: var(--vttf-space-4, 0.75rem);
-  color: var(--vttf-color-text, var(--color-text-primary));
-  font-family: var(--vttf-font-family, var(--font-primary));
+  min-height: 0;
+  height: 100%;
 }
 
-.vttforge-example .sheet-header {
+/* ════════ HEAD (.sh-head) ════════ */
+.vttforge-example .sh-head {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: var(--vttf-space-4, 0.75rem);
-  align-items: center;
-  padding-bottom: var(--vttf-space-3, 0.5rem);
-  border-bottom: 1px solid var(--vttf-color-border, var(--color-border));
+  grid-template-columns: 88px 1fr;
+  gap: var(--vttf-space-4);
+  padding: var(--vttf-space-4);
+  background: var(--vttf-surface);
+  border-bottom: 1px solid var(--vttf-border);
 }
 
-.vttforge-example .portrait {
-  width: 72px;
-  height: 72px;
-  border-radius: var(--vttf-radius-md, 6px);
+.vttforge-example .sh-portrait {
+  width: 88px;
+  height: 110px;
+  border-radius: var(--vttf-radius-md);
+  background: var(--vttf-surface-2);
   object-fit: cover;
   cursor: pointer;
 }
 
-.vttforge-example .title {
+.vttforge-example .sh-id {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  justify-content: space-between;
   min-width: 0;
 }
 
-.vttforge-example .title input[name="name"] {
-  font-size: 1.25rem;
-  font-weight: 600;
+.vttforge-example .sh-id-top {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.vttforge-example .sh-name {
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--vttf-text);
   background: transparent;
   border: none;
   border-bottom: 1px solid transparent;
+  padding: 0;
 }
 
-.vttforge-example .title input[name="name"]:focus {
-  border-bottom-color: var(--vttf-color-border, var(--color-border));
+.vttforge-example .sh-name:focus {
+  border-bottom-color: var(--vttf-border-strong);
+  outline: none;
 }
 
-.vttforge-example .title-meta {
-  display: flex;
-  gap: var(--vttf-space-4, 0.75rem);
-  font-size: 0.85rem;
-  opacity: 0.85;
-}
-
-.vttforge-example .title-meta input {
-  width: 3rem;
-  text-align: center;
-}
-
-.vttforge-example .resources {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  align-items: end;
-}
-
-.vttforge-example .resource {
-  display: grid;
-  grid-template-columns: auto auto;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.vttforge-example .resource .bar {
-  display: flex;
-  gap: 0.25rem;
-  align-items: center;
-}
-
-.vttforge-example .resource input[type="number"] {
-  width: 3.5rem;
-  text-align: center;
-}
-
-.vttforge-example .sheet-tabs {
-  display: flex;
-  gap: 0.25rem;
-  border-bottom: 1px solid var(--vttf-color-border, var(--color-border));
-}
-
-.vttforge-example .sheet-tabs .item {
+.vttforge-example .sh-sub {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 0.75rem;
+  gap: var(--vttf-space-2);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-muted);
+}
+
+.vttforge-example .sh-sub input {
+  width: 3.5rem;
+  text-align: center;
+  background: transparent;
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  color: var(--vttf-text);
+  font: inherit;
+  padding: 2px 6px;
+}
+
+.vttforge-example .sh-quick {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--vttf-space-3);
+}
+
+.vttforge-example .sh-quick .q {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.vttforge-example .sh-quick .qv {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--vttf-ember-glow);
+}
+
+.vttforge-example .sh-quick .qv input {
+  width: 2.5rem;
+  font: inherit;
+  color: inherit;
+  text-align: center;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.vttforge-example .sh-quick .qv-sep {
+  font-size: 14px;
+  color: var(--vttf-text-faint);
+}
+
+.vttforge-example .sh-quick .qv-max {
+  font-size: 14px;
+  color: var(--vttf-text-muted);
+}
+
+.vttforge-example .sh-quick .qk {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+}
+
+/* ════════ TABS (.sh-tabs) ════════ */
+.vttforge-example .sh-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 var(--vttf-space-4);
+  background: var(--vttf-bg-elevated);
+  border-bottom: 1px solid var(--vttf-border);
+}
+
+.vttforge-example .sh-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 14px;
   cursor: pointer;
+  color: var(--vttf-text-muted);
+  background: transparent;
+  border: none;
   border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  font-family: var(--vttf-font-body);
+  font-size: 13px;
+  font-weight: 600;
   text-decoration: none;
 }
 
-.vttforge-example .sheet-tabs .item.active {
-  border-bottom-color: var(--vttf-color-accent, var(--color-warm-2));
-  font-weight: 600;
+.vttforge-example .sh-tab:hover {
+  color: var(--vttf-text);
 }
 
-.vttforge-example .sheet-body {
+.vttforge-example .sh-tab.on,
+.vttforge-example .sh-tab.active {
+  color: var(--vttf-text);
+  border-bottom-color: var(--vttf-ember);
+}
+
+/* ════════ BODY (.sh-body) ════════ */
+.vttforge-example .sh-body {
   flex: 1;
   overflow: auto;
+  padding: var(--vttf-space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--vttf-space-4);
   min-height: 320px;
 }
 
-.vttforge-example .tab {
+.vttforge-example .sh-body .tab {
   display: none;
+  flex-direction: column;
+  gap: var(--vttf-space-3);
 }
 
-.vttforge-example .tab.active {
-  display: block;
+.vttforge-example .sh-body .tab.active {
+  display: flex;
 }
 
-/* abilities */
-.vttforge-example .ability-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--vttf-space-3, 0.5rem);
-}
-
-.vttforge-example .ability {
-  display: grid;
-  grid-template-columns: auto 1fr auto auto;
-  gap: 0.4rem;
+.vttforge-example .sh-section-title {
+  display: inline-flex;
   align-items: center;
-  padding: 0.4rem;
-  background: var(--vttf-color-surface-alt, var(--color-bg-secondary));
-  border-radius: var(--vttf-radius-sm, 4px);
-}
-
-.vttforge-example .ability input {
-  width: 3rem;
-  text-align: center;
-}
-
-.vttforge-example .ability .mod {
+  gap: var(--vttf-space-3);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
   font-weight: 600;
-  min-width: 1.75rem;
-  text-align: center;
+  margin: 0;
 }
 
-.vttforge-example .ability-roll {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0.2rem;
+.vttforge-example .sh-section-title::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--vttf-border);
 }
 
-/* inventory */
-.vttforge-example .inventory-header {
+.vttforge-example .sh-section-head {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--vttf-space-3, 0.5rem);
+  gap: var(--vttf-space-3);
 }
 
-.vttforge-example .items-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.vttforge-example .sh-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: var(--vttf-radius-sm);
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border-strong);
+  color: var(--vttf-text);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.vttforge-example .sh-action:hover {
+  background: var(--vttf-surface-2);
+}
+
+.vttforge-example .sh-action i {
+  color: var(--vttf-ember);
+}
+
+/* ─── Abilities ─── */
+.vttforge-example .sh-abilities {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--vttf-space-2);
+}
+
+.vttforge-example .sh-abil {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 8px;
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-md);
 }
 
-.vttforge-example .items-list .item {
+.vttforge-example .sh-abil .lbl {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+  font-weight: 600;
+}
+
+.vttforge-example .sh-abil .val {
+  width: 100%;
+  text-align: center;
+  background: transparent;
+  border: none;
+  color: var(--vttf-text);
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0;
+}
+
+.vttforge-example .sh-abil .val:focus {
+  outline: 1px solid var(--vttf-ember);
+  border-radius: var(--vttf-radius-sm);
+}
+
+.vttforge-example .sh-abil .mod {
+  background: transparent;
+  border: none;
+  color: var(--vttf-ember-glow);
+  font-family: var(--vttf-font-body);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 2px 8px;
+  border-radius: var(--vttf-radius-full);
+}
+
+.vttforge-example .sh-abil .mod:hover {
+  background: color-mix(in oklch, var(--vttf-ember) 12%, transparent);
+}
+
+/* ─── Items ─── */
+.vttforge-example .sh-items {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.vttforge-example .sh-item {
   display: grid;
-  grid-template-columns: auto 1fr auto auto auto;
-  gap: 0.5rem;
+  grid-template-columns: 32px 1fr auto auto auto;
+  gap: var(--vttf-space-3);
   align-items: center;
-  padding: 0.4rem 0.5rem;
-  background: var(--vttf-color-surface-alt, var(--color-bg-secondary));
-  border-radius: var(--vttf-radius-sm, 4px);
+  padding: 8px 10px;
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
   cursor: grab;
 }
 
-.vttforge-example .items-list .item:active {
+.vttforge-example .sh-item:active {
   cursor: grabbing;
 }
 
-.vttforge-example .items-list .empty {
+.vttforge-example .sh-item-ico {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: var(--vttf-surface-2);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  color: var(--vttf-text-muted);
+  font-size: 16px;
+  overflow: hidden;
+}
+
+.vttforge-example .sh-item-ico img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.vttforge-example .sh-item-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--vttf-text);
+}
+
+.vttforge-example .sh-item-meta {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  color: var(--vttf-text-faint);
+}
+
+.vttforge-example .sh-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: var(--vttf-radius-full);
+  background: color-mix(in oklch, var(--vttf-ember) 10%, transparent);
+  color: var(--vttf-ember);
+  border: 1px solid color-mix(in oklch, var(--vttf-ember) 40%, transparent);
+}
+
+.vttforge-example .sh-tag.muted {
+  background: var(--vttf-bg-sunken);
+  color: var(--vttf-text-muted);
+  border-color: var(--vttf-border);
+}
+
+.vttforge-example .sh-qty {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 12px;
+  color: var(--vttf-text-muted);
+}
+
+.vttforge-example .sh-item-delete {
+  background: transparent;
+  border: none;
+  color: var(--vttf-text-faint);
+  cursor: pointer;
+  padding: 4px 6px;
+}
+
+.vttforge-example .sh-item-delete:hover {
+  color: var(--vttf-rose);
+}
+
+.vttforge-example .sh-items-empty {
   text-align: center;
-  padding: var(--vttf-space-4, 0.75rem);
-  opacity: 0.6;
+  padding: var(--vttf-space-4);
+  color: var(--vttf-text-faint);
   font-style: italic;
 }
 
-/* gear sheet */
+/* ─── Drop affordance ─── */
+.vttforge-example .sh-drop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 20px;
+  border: 1.5px dashed var(--vttf-border-strong);
+  border-radius: var(--vttf-radius-md);
+  background: color-mix(in oklch, var(--vttf-ember) 6%, transparent);
+  text-align: center;
+}
+
+.vttforge-example .sh-drop .lbl {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--vttf-text);
+}
+
+.vttforge-example .sh-drop .sub {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  color: var(--vttf-text-faint);
+}
+
+/* ─── Empty placeholder (Spells tab) ─── */
+.vttforge-example .sh-empty {
+  padding: var(--vttf-space-6);
+  text-align: center;
+  color: var(--vttf-text-faint);
+  font-style: italic;
+}
+
+/* ─── Biography (readonly fallback) ─── */
+.vttforge-example .sh-biography-readonly {
+  padding: var(--vttf-space-4);
+  background: var(--vttf-bg-sunken);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-md);
+  color: var(--vttf-text-muted);
+  line-height: 1.6;
+}
+
+/* ════════ FOOT (.sh-foot) ════════ */
+.vttforge-example .sh-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--vttf-space-4);
+  padding: 12px var(--vttf-space-4);
+  background: var(--vttf-surface);
+  border-top: 1px solid var(--vttf-border);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+}
+
+.vttforge-example .sh-foot .nm {
+  color: var(--vttf-ember);
+  font-weight: 600;
+}
+
+/* ════════ Gear sheet (unchanged structurally) ════════ */
 .vttforge-example.item .field {
   display: grid;
   grid-template-columns: 8rem 1fr;
-  gap: var(--vttf-space-3, 0.5rem);
+  gap: var(--vttf-space-3);
   align-items: center;
   padding: 0.35rem 0;
 }

--- a/examples/simple-system/templates/actor/character-sheet.hbs
+++ b/examples/simple-system/templates/actor/character-sheet.hbs
@@ -1,56 +1,59 @@
 {{!--
-  Character sheet — exercises every PR 5–8 deliverable end-to-end.
+  Character sheet — markup mirrors the canonical Figma reference
+  (character-sheet.jsx + Theme Explorations .sh-* classes).
 
-  Tabs nav uses `data-tab`/`data-group` so ApplicationV2's tab state machine
-  routes clicks. `context.tabs.primary` was auto-populated by BaseActorSheet's
-  _prepareContext (no _prepareTabs call in user code).
+  Tabs nav uses `data-tab`/`data-group` + `data-action="vttforgeTab"` so
+  BaseActorSheet's default tab action routes clicks. `context.tabs.primary`
+  is auto-populated by BaseActorSheet's _prepareContext.
 
   `<img data-edit="img">` is handled by DocumentSheetV2's built-in editImage
-  action — we never wire a portrait picker ourselves.
-
-  `<prose-mirror>` is the v13 rich text element (replaces the legacy
-  {{editor}} helper).
+  action. `<prose-mirror>` is the v13 rich text element for biography.
 --}}
 <form autocomplete="off">
 
-  <header class="sheet-header">
-    <img class="portrait" src="{{actor.img}}" alt="{{actor.name}}" data-edit="img" />
-    <div class="title">
-      <input type="text" name="name" value="{{actor.name}}"
-             placeholder="{{localize 'VTTFORGE_EXAMPLE.Sheet.NamePlaceholder'}}" />
-      <div class="title-meta">
-        <label>
-          {{localize "VTTFORGE_EXAMPLE.Sheet.Level"}}
+  {{!-- ════════ HEAD (.sh-head) ════════ --}}
+  <div class="sh-head">
+    <img class="sh-portrait" src="{{actor.img}}" alt="{{actor.name}}" data-edit="img" />
+    <div class="sh-id">
+      <div class="sh-id-top">
+        <input class="sh-name" type="text" name="name" value="{{actor.name}}"
+               placeholder="{{localize 'VTTFORGE_EXAMPLE.Sheet.NamePlaceholder'}}" />
+        <div class="sh-sub">
+          <span>{{localize "VTTFORGE_EXAMPLE.Sheet.Level"}}</span>
           <input type="number" name="system.level" value="{{system.level}}" min="1" max="20" />
-        </label>
-        <span class="ac">
-          {{localize "VTTFORGE_EXAMPLE.Sheet.AC"}}: <strong>{{system.armorClass}}</strong>
-        </span>
-      </div>
-    </div>
-    <div class="resources">
-      <div class="resource health">
-        <label>{{localize "VTTFORGE_EXAMPLE.Sheet.Health"}}</label>
-        <div class="bar">
-          <input type="number" name="system.health.value" value="{{system.health.value}}" min="0" />
-          <span class="sep">/</span>
-          <span class="max">{{system.health.max}}</span>
         </div>
       </div>
-      <div class="resource power">
-        <label>{{localize "VTTFORGE_EXAMPLE.Sheet.Power"}}</label>
-        <div class="bar">
-          <input type="number" name="system.power.value" value="{{system.power.value}}" min="0" />
-          <span class="sep">/</span>
-          <input type="number" name="system.power.max" value="{{system.power.max}}" min="0" />
+      <div class="sh-quick">
+        <div class="q">
+          <div class="qv">
+            <input type="number" name="system.health.value" value="{{system.health.value}}" min="0" />
+            <span class="qv-sep">/</span>
+            <span class="qv-max">{{system.health.max}}</span>
+          </div>
+          <div class="qk">{{localize "VTTFORGE_EXAMPLE.Sheet.Quick.HP"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">{{system.armorClass}}</div>
+          <div class="qk">{{localize "VTTFORGE_EXAMPLE.Sheet.Quick.AC"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">
+            <input type="number" name="system.speed" value="{{system.speed}}" min="0" />
+          </div>
+          <div class="qk">{{localize "VTTFORGE_EXAMPLE.Sheet.Quick.SPD"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">{{numberFormat system.initiative sign=true}}</div>
+          <div class="qk">{{localize "VTTFORGE_EXAMPLE.Sheet.Quick.INIT"}}</div>
         </div>
       </div>
     </div>
-  </header>
+  </div>
 
-  <nav class="sheet-tabs" data-group="primary">
+  {{!-- ════════ TABS (.sh-tabs) ════════ --}}
+  <nav class="sh-tabs" data-group="primary">
     {{#each tabs as |tab|}}
-      <button type="button" class="item {{tab.cssClass}}"
+      <button type="button" class="sh-tab {{#if tab.active}}on{{/if}}"
               data-tab="{{tab.id}}"
               data-group="primary"
               data-action="vttforgeTab"
@@ -61,22 +64,25 @@
     {{/each}}
   </nav>
 
-  <section class="sheet-body">
+  {{!-- ════════ BODY (.sh-body) ════════ --}}
+  <section class="sh-body">
+
     {{!-- ABILITIES --}}
     <section class="tab abilities {{tabs.abilities.cssClass}}"
              data-tab="abilities" data-group="primary">
-      <div class="ability-grid">
+      <h3 class="sh-section-title">{{localize "VTTFORGE_EXAMPLE.Sheet.AbilityScores"}}</h3>
+      <div class="sh-abilities">
         {{#each abilities as |ability|}}
-          <div class="ability">
-            <button type="button" class="ability-roll"
+          <div class="sh-abil">
+            <div class="lbl" title="{{ability.label}}">{{ability.key}}</div>
+            <input class="val" type="number"
+                   name="system.abilities.{{ability.key}}.value"
+                   value="{{ability.value}}" min="1" max="30" />
+            <button type="button" class="mod sh-abil-roll"
                     data-action="rollAbility" data-ability="{{ability.key}}"
                     title="{{localize 'VTTFORGE_EXAMPLE.Sheet.Roll.label'}}">
-              <i class="fa-solid fa-dice-d20"></i>
+              {{numberFormat ability.mod sign=true}}
             </button>
-            <label>{{ability.label}}</label>
-            <input type="number" name="system.abilities.{{ability.key}}.value"
-                   value="{{ability.value}}" min="1" max="30" />
-            <span class="mod">{{numberFormat ability.mod sign=true}}</span>
           </div>
         {{/each}}
       </div>
@@ -85,35 +91,59 @@
     {{!-- INVENTORY --}}
     <section class="tab inventory {{tabs.inventory.cssClass}}"
              data-tab="inventory" data-group="primary">
-      <header class="inventory-header">
-        <h3>{{localize "VTTFORGE_EXAMPLE.Sheet.Inventory"}}</h3>
-        <button type="button" data-action="createGear"
+      <header class="sh-section-head">
+        <h3 class="sh-section-title">{{localize "VTTFORGE_EXAMPLE.Sheet.Inventory"}}</h3>
+        <button type="button" class="sh-action" data-action="createGear"
                 title="{{localize 'VTTFORGE_EXAMPLE.Sheet.NewGear'}}">
           <i class="fa-solid fa-plus"></i>
           <span>{{localize "VTTFORGE_EXAMPLE.Sheet.NewGear"}}</span>
         </button>
       </header>
-      <ul class="items-list">
+      <div class="sh-items">
         {{#each gear as |item|}}
-          <li class="item" data-item-id="{{item.id}}" draggable="true">
-            <img src="{{item.img}}" alt="{{item.name}}" width="32" height="32" />
-            <span class="item-name">{{item.name}}</span>
-            <span class="item-quantity">×{{item.system.quantity}}</span>
-            <span class="item-weight">{{item.system.weight}} lb</span>
-            <button type="button" data-action="deleteItem"
+          <div class="sh-item" data-item-id="{{item.id}}" draggable="true">
+            <div class="sh-item-ico">
+              {{#if item.img}}
+                <img src="{{item.img}}" alt="{{item.name}}" />
+              {{else}}
+                <i class="fa-solid fa-box"></i>
+              {{/if}}
+            </div>
+            <div>
+              <div class="sh-item-name">{{item.name}}</div>
+              <div class="sh-item-meta">{{numberFormat item.weight}} lb</div>
+            </div>
+            <span class="sh-tag {{#if (eq item.kind "stowed")}}muted{{/if}}">
+              {{localize (concat "VTTFORGE_EXAMPLE.Gear.Kind." item.kind)}}
+            </span>
+            <span class="sh-qty">×{{item.quantity}}</span>
+            <button type="button" class="sh-item-delete" data-action="deleteItem"
                     title="{{localize 'VTTFORGE_EXAMPLE.Sheet.Delete'}}">
               <i class="fa-solid fa-trash"></i>
             </button>
-          </li>
+          </div>
         {{else}}
-          <li class="empty">{{localize "VTTFORGE_EXAMPLE.Sheet.NoGear"}}</li>
+          <div class="sh-items-empty">{{localize "VTTFORGE_EXAMPLE.Sheet.NoGear"}}</div>
         {{/each}}
-      </ul>
+      </div>
+
+      <div class="sh-drop">
+        <div class="lbl">{{localize "VTTFORGE_EXAMPLE.Sheet.Drop.label"}}</div>
+        <div class="sub">onDropItem(item, event)</div>
+      </div>
+    </section>
+
+    {{!-- SPELLS (placeholder) --}}
+    <section class="tab spells {{tabs.spells.cssClass}}"
+             data-tab="spells" data-group="primary">
+      <h3 class="sh-section-title">{{localize "VTTFORGE_EXAMPLE.Sheet.Spells"}}</h3>
+      <div class="sh-empty">{{localize "VTTFORGE_EXAMPLE.Sheet.SpellsEmpty"}}</div>
     </section>
 
     {{!-- BIOGRAPHY --}}
     <section class="tab biography {{tabs.biography.cssClass}}"
              data-tab="biography" data-group="primary">
+      <h3 class="sh-section-title">{{localize "VTTFORGE_EXAMPLE.Sheet.Biography"}}</h3>
       {{#if isEditable}}
         <prose-mirror name="system.biography"
                       button="true"
@@ -123,9 +153,16 @@
           {{{enrichedBiography}}}
         </prose-mirror>
       {{else}}
-        <div class="biography-readonly">{{{enrichedBiography}}}</div>
+        <div class="sh-biography-readonly">{{{enrichedBiography}}}</div>
       {{/if}}
     </section>
+
   </section>
+
+  {{!-- ════════ FOOT (.sh-foot) ════════ --}}
+  <footer class="sh-foot">
+    <span class="nm">VTTFORGE · FORGE</span>
+    <span>@vttforge/styles · v0.2</span>
+  </footer>
 
 </form>


### PR DESCRIPTION
## Summary

Make `examples/simple-system` render the canonical `character-sheet.jsx` layout when booted in Foundry v13. The Figma file's **📜 Foundry Sheet** page is now the spec — this PR brings the actual Handlebars markup, data model and styling in line with it.

## What changes

**Data**
- `CharacterData` gains `speed` (initial 30) and a derived `initiative` (= dex.mod). Together with the existing `armorClass` and `health`, these drive the four `.sh-quick` cells (HP / AC / SPD / INIT).
- `GearData` gains a `kind` enum (`equipped` | `valued` | `stowed`, default `stowed`) that maps to the `.sh-tag` pill on each item row.

**Sheet**
- `TABS` gains a `spells` placeholder tab. Total four tabs matching the reference: abilities / inventory / spells / biography.
- `DRAG_DROP` selectors updated to `.sh-item` / `.sh-body`.
- Gear context mapped to a flat shape so the template renders the new `.sh-item` grid cleanly.

**Template (character-sheet.hbs)**
- Full rewrite using `.sh-*` class names from the reference (`.sh-head`, `.sh-portrait`, `.sh-id`, `.sh-name`, `.sh-sub`, `.sh-quick` / `.q` / `.qv` / `.qk`, `.sh-tabs` / `.sh-tab.on`, `.sh-body`, `.sh-section-title`, `.sh-abilities` / `.sh-abil` / `.lbl` / `.val` / `.mod`, `.sh-items` / `.sh-item` / `.sh-item-ico` / `.sh-item-name` / `.sh-item-meta`, `.sh-tag.muted`, `.sh-qty`, `.sh-drop`, `.sh-foot`).
- Quick stats grid renders `HP value/max`, `AC`, `SPD`, `INIT` with ember-glow values + faint labels.
- New "spells" placeholder section.
- Foot strip with "VTTFORGE · FORGE" + version.

**Styles**
- Complete rewrite of `example.css` against `--vttf-*` tokens, no hardcoded colors. Forge theme comes from `@vttforge/styles` default; consumers swap themes by overriding tokens, not these rules. Stays unlayered so component CSS wins over Foundry's `@layer applications` without specificity wars.

**Localization**
- New: `Sheet.Quick.{HP,AC,SPD,INIT}`, `Sheet.Tabs.spells`, `Sheet.Spells`, `Sheet.SpellsEmpty`, `Sheet.AbilityScores`, `Sheet.Biography`, `Sheet.Drop.label`, `Gear.Kind.{equipped,valued,stowed}`, `Settings.showTutorial.{name,hint}`.
- `Sheet.Level` simplified to "LV".
- Removed unused: `Sheet.AC`, `Sheet.Health`, `Sheet.Power` (replaced by `.sh-quick`).

## What's NOT in this PR

- No changeset — `examples/simple-system` is private (`@vttforge-examples` scope, not `@vttforge/*`).
- No data migration: the new `system.speed` and item `kind` fields default in via `DataModel` initial values, so existing characters/gear stay valid.
- Pre-existing lint findings in `packages/core` and `apps/web/src/styles.css` are unchanged.

## Test plan

- [ ] `pnpm typecheck && pnpm test && pnpm build` — all green (verified locally).
- [ ] Boot Docker compose, open a Character — visually compare against `📜 Foundry Sheet` in Figma. Header should show portrait + name + LV input + HP/AC/SPD/INIT pills with ember-glow values. Four tabs at the top.
- [ ] Create a gear item, set `kind` to each of `equipped` / `valued` / `stowed` — verify the `.sh-tag` renders accent for the first two, muted for stowed.
- [ ] Drag a gear item from sidebar onto the sheet — `onDropItem` still accepts.
- [ ] Click the ability mod button — `rollAbility` action still fires.