### PR TITLE
fix(core,vite-plugin): align with Foundry v13 manifest schema and add prepareBaseData hook

### DIFF
--- a/.changeset/foundry-v13-manifest-shapes.md
+++ b/.changeset/foundry-v13-manifest-shapes.md
@@ -1,0 +1,43 @@
+---
+'@vttforge/core': minor
+'@vttforge/vite-plugin': minor
+'@vttforge-examples/simple-system': patch
+---
+
+fix: align with Foundry v13 manifest schema and add `prepareBaseData` hook
+
+Three coordinated changes:
+
+**`@vttforge/core`** — `BaseTypeDataModel()` now ships a `prepareBaseData()`
+no-op stub alongside `prepareDerivedData()`. Use `prepareBaseData()` to
+initialize fields that Active Effects need to mutate (base max HP, base AC),
+since AEs apply between `prepareBaseData()` and `prepareDerivedData()`.
+`prepareDerivedData()` stays the place for values that depend on the
+AE-mutated state.
+
+The misleading `_addDataFieldMigrations()` static stub is removed. The real
+field-rename API is `_addDataFieldMigration(source, oldKey, newKey, apply?)`
+called inside a `static migrateData(source)` override — consumers who need
+it can call it directly on the Foundry-provided base via `super`.
+
+**`@vttforge/vite-plugin`** — emits the canonical v13 `styles` form
+(`[{ src: "styles/foo.css" }]`) in the built manifest. Still accepts the
+legacy string form (`["styles/foo.css"]`) and the v13 object form as input,
+so existing consumers don't need to change their source manifest. Additional
+metadata declared on object entries (e.g. `layer` for cascade layer
+placement) is preserved through the rewrite — only `src` is rewritten to
+point at the bundled output.
+
+**`@vttforge-examples/simple-system`** — manifest aligned with v13 schema:
+`gridDistance` / `gridUnits` collapsed into the `grid` object; `styles`
+declared in object form; `flags.hotReload` declared at the root of `flags`
+(not under the package namespace) and switched to the object form
+(`{ extensions, paths }`) that Foundry's runtime hot-reload watcher
+actually reads. The previous shape was a double no-op — wrong location AND
+wrong form, so the watcher silently exited without registering any
+extensions.
+
+Hot-reload enablement on the Foundry server side is deferred — runtime
+configuration changes interact with felddy's `CONTAINER_PRESERVE_CONFIG`
+flag in ways that require a dedicated design pass. That work is tracked
+separately and will land alongside the developer-facing hot-reload bridge.

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -477,6 +477,7 @@
     color: var(--vttf-text-faint);
   }
 
+  /* biome-ignore lint/style/noDescendingSpecificity: this standalone `.mono` rule applies in body copy, code blocks, and pkg-table cells; the higher-specificity `.hero-meta dd .mono` above intentionally overrides only inside the hero meta block. Different scope, no actual cascade conflict. */
   .mono {
     font-family: var(--vttf-font-mono);
     font-size: 0.95em;
@@ -680,6 +681,7 @@
     max-width: 56ch;
     font-size: 17px;
   }
+  /* biome-ignore lint/style/noDescendingSpecificity: `.cta-strip .row` targets the CTA strip section; `header.top .row` above targets the sticky header. Same `.row` class, disjoint ancestor scopes — the cascade resolves correctly via context. */
   .cta-strip .row {
     margin-top: var(--vttf-space-6);
     display: flex;

--- a/docs/errors/VTTF-0001.md
+++ b/docs/errors/VTTF-0001.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0001` |
 | Name | `SystemAlreadyRegistered` |
-| Package | `@vttforge/core@0.2.0` |
+| Package | `@vttforge/core@0.3.0` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/docs/errors/VTTF-0002.md
+++ b/docs/errors/VTTF-0002.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0002` |
 | Name | `MissingFoundryGlobals` |
-| Package | `@vttforge/core@0.2.0` |
+| Package | `@vttforge/core@0.3.0` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/docs/errors/VTTF-0003.md
+++ b/docs/errors/VTTF-0003.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0003` |
 | Name | `UnknownSetting` |
-| Package | `@vttforge/core@0.2.0` |
+| Package | `@vttforge/core@0.3.0` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/docs/errors/VTTF-0004.md
+++ b/docs/errors/VTTF-0004.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0004` |
 | Name | `MigrationFailed` |
-| Package | `@vttforge/core@0.2.0` |
+| Package | `@vttforge/core@0.3.0` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/docs/errors/VTTF-0005.md
+++ b/docs/errors/VTTF-0005.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0005` |
 | Name | `WorldTooOldForMigration` |
-| Package | `@vttforge/core@0.2.0` |
+| Package | `@vttforge/core@0.3.0` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/examples/simple-system/system.json
+++ b/examples/simple-system/system.json
@@ -9,7 +9,7 @@
   },
   "authors": [{ "name": "VTTForge Contributors" }],
   "esmodules": ["main.mjs"],
-  "styles": ["styles/example.css"],
+  "styles": [{ "src": "styles/example.css" }],
   "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
   "documentTypes": {
     "Actor": {
@@ -23,15 +23,22 @@
       }
     }
   },
-  "gridDistance": 5,
-  "gridUnits": "ft",
+  "grid": {
+    "type": 1,
+    "distance": 5,
+    "units": "ft",
+    "diagonals": 0
+  },
   "primaryTokenAttribute": "health",
   "secondaryTokenAttribute": "power",
   "flags": {
+    "hotReload": {
+      "extensions": ["css", "hbs", "json"],
+      "paths": ["styles", "templates", "lang"]
+    },
     "vttforge-example": {
       "needsMigrationVersion": "0.1.0",
-      "compatibleMigrationVersion": "0.0.0",
-      "hotReload": ["css", "hbs", "json"]
+      "compatibleMigrationVersion": "0.0.0"
     }
   }
 }

--- a/packages/core/src/__tests__/base-actor-sheet.test.ts
+++ b/packages/core/src/__tests__/base-actor-sheet.test.ts
@@ -208,7 +208,8 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     (instance as { isEditable: boolean }).isEditable = true;
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(2);
-    const first = dragDropBinds[0]!;
+    const first = dragDropBinds[0];
+    if (!first) throw new Error('expected dragDropBinds[0] after length assertion');
     expect(first.element).toBe(element);
     expect(first.config.dragSelector).toBe('.item[draggable]');
     const perms = first.config.permissions as { dragstart: () => boolean; drop: () => boolean };
@@ -236,7 +237,8 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     (instance as { isEditable: boolean }).isEditable = true;
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(1);
-    const entry = dragDropBinds[0]!;
+    const entry = dragDropBinds[0];
+    if (!entry) throw new Error('expected dragDropBinds[0] after length assertion');
     const perms = entry.config.permissions as { dragstart: () => boolean; drop: () => boolean };
     expect(perms.dragstart()).toBe(false);
     expect(perms.drop()).toBe(false);
@@ -253,7 +255,9 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     (instance as { element: HTMLElement }).element = document.createElement('div');
     (instance as { isEditable: boolean }).isEditable = false;
     instance._onRender({}, {});
-    const perms = dragDropBinds[0]!.config.permissions as {
+    const lockedEntry = dragDropBinds[0];
+    if (!lockedEntry) throw new Error('expected dragDropBinds[0]');
+    const perms = lockedEntry.config.permissions as {
       dragstart: () => boolean;
       drop: () => boolean;
     };

--- a/packages/core/src/__tests__/base-item-sheet.test.ts
+++ b/packages/core/src/__tests__/base-item-sheet.test.ts
@@ -132,7 +132,9 @@ describe('BaseItemSheet', () => {
     (instance as { isEditable: boolean }).isEditable = true;
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(1);
-    const perms = dragDropBinds[0]!.config.permissions as {
+    const entry = dragDropBinds[0];
+    if (!entry) throw new Error('expected dragDropBinds[0] after length assertion');
+    const perms = entry.config.permissions as {
       dragstart: () => boolean;
       drop: () => boolean;
     };

--- a/packages/core/src/__tests__/base-type-data-model.test.ts
+++ b/packages/core/src/__tests__/base-type-data-model.test.ts
@@ -4,13 +4,11 @@ import { VttfError } from '../errors/registry.js';
 
 class FakeFoundryTypeDataModel {
   static migrateData = vi.fn((data: Record<string, unknown>) => ({ ...data, _migrated: true }));
-  static _addDataFieldMigrations = vi.fn();
   prepareBaseData(): void {}
 }
 
 beforeEach(() => {
   FakeFoundryTypeDataModel.migrateData.mockClear();
-  FakeFoundryTypeDataModel._addDataFieldMigrations.mockClear();
   (globalThis as Record<string, unknown>).foundry = {
     abstract: { TypeDataModel: FakeFoundryTypeDataModel },
   };
@@ -42,10 +40,10 @@ describe('BaseTypeDataModel', () => {
     expect(out).toEqual({ foo: 1, _migrated: true });
   });
 
-  it('default _addDataFieldMigrations() delegates to super when it exists', () => {
+  it('default prepareBaseData() is a no-op that does not crash', () => {
     const Sub = BaseTypeDataModel();
-    (Sub as unknown as { _addDataFieldMigrations(): void })._addDataFieldMigrations();
-    expect(FakeFoundryTypeDataModel._addDataFieldMigrations).toHaveBeenCalledTimes(1);
+    const instance = new Sub();
+    expect(() => (instance as { prepareBaseData(): void }).prepareBaseData()).not.toThrow();
   });
 
   it('default prepareDerivedData() is a no-op that does not crash', () => {

--- a/packages/core/src/__tests__/migrations.test.ts
+++ b/packages/core/src/__tests__/migrations.test.ts
@@ -112,7 +112,9 @@ describe('createMigrationRunner — register()', () => {
     });
     runner.register();
     expect(settings.registerSpy).toHaveBeenCalledTimes(1);
-    const [namespace, key, config] = settings.registerSpy.mock.calls[0]!;
+    const call = settings.registerSpy.mock.calls[0];
+    if (!call) throw new Error('expected registerSpy to have been called');
+    const [namespace, key, config] = call;
     expect(namespace).toBe('my-system');
     expect(key).toBe('schemaVersion');
     expect((config as { scope: string; config: boolean; default: string }).scope).toBe('world');
@@ -131,7 +133,7 @@ describe('createMigrationRunner — register()', () => {
       isNewerVersion: FOUNDRY_NEWER,
     });
     runner.register();
-    expect(settings.registerSpy.mock.calls[0]![1]).toBe('dataVersion');
+    expect(settings.registerSpy.mock.calls[0]?.[1]).toBe('dataVersion');
   });
 });
 

--- a/packages/core/src/base-type-data-model.ts
+++ b/packages/core/src/base-type-data-model.ts
@@ -5,9 +5,12 @@
  *
  * - `migrateData()` calls `super.migrateData(data)` (foundry-vtt-system-dev
  *   pitfall #8 — every TypeDataModel must do this).
- * - `_addDataFieldMigrations()` is a no-op stub so subclasses can override
- *   without needing to know that the base form exists.
- * - `prepareDerivedData()` is a no-op stub — override per type.
+ * - `prepareBaseData()` is a no-op stub — override to initialize fields that
+ *   Active Effects need to mutate (e.g. base max HP before AE bonus). Foundry
+ *   applies Active Effects between `prepareBaseData()` and `prepareDerivedData()`,
+ *   so anything you compute here is the input AEs see.
+ * - `prepareDerivedData()` is a no-op stub — override for computed values
+ *   that depend on AE-mutated state (modifiers, percentages, totals).
  *
  * Subclasses still own `defineSchema()` because there is no useful default —
  * we never invent a schema for you.
@@ -62,18 +65,25 @@ export function BaseTypeDataModel(): AnyConstructor {
     }
 
     /**
-     * No-op stub. Override to register field renames via
-     * `this._addDataFieldMigration("system.oldField", "system.newField")`.
+     * No-op stub. Override per type to initialize fields whose values Active
+     * Effects need to consume — base max HP, base AC, etc. Foundry calls this
+     * BEFORE applying Active Effects, so anything you set here is the input
+     * that AE changes (`ADD`, `MULTIPLY`, `OVERRIDE`, …) operate on.
+     *
+     * Use `prepareDerivedData()` instead for values that depend on the
+     * AE-mutated state (modifiers, percentages, totals).
+     *
+     * Never write to the database here — purely in-memory.
      */
-    static _addDataFieldMigrations(): void {
-      const superFn = (Base as { _addDataFieldMigrations?: () => void })._addDataFieldMigrations;
-      if (typeof superFn === 'function') {
-        superFn.call(VttforgeBaseTypeDataModel);
-      }
+    prepareBaseData(): void {
+      // override me
     }
 
     /**
-     * No-op stub. Override per type to compute derived values.
+     * No-op stub. Override per type to compute derived values from the
+     * AE-mutated state (modifiers, percentages, totals). Runs AFTER Active
+     * Effects apply; use `prepareBaseData()` for values that AEs need to read.
+     *
      * Never write to the database here — purely in-memory.
      */
     prepareDerivedData(): void {

--- a/packages/core/src/migrations/runner.ts
+++ b/packages/core/src/migrations/runner.ts
@@ -112,8 +112,7 @@ function resolveLogger(): MigrationLogger {
 }
 
 function lastVersion(migrations: ReadonlyArray<Migration>): string {
-  if (migrations.length === 0) return INITIAL_VERSION;
-  return migrations[migrations.length - 1]!.version;
+  return migrations.at(-1)?.version ?? INITIAL_VERSION;
 }
 
 function assertAscending(
@@ -121,12 +120,16 @@ function assertAscending(
   isNewer: (next: string, current: string) => boolean,
 ): void {
   for (let i = 1; i < migrations.length; i++) {
-    const prev = migrations[i - 1]!.version;
-    const next = migrations[i]!.version;
-    if (!isNewer(next, prev)) {
+    const prevMig = migrations[i - 1];
+    const nextMig = migrations[i];
+    // Loop bounds guarantee both indices are valid; the explicit guard
+    // exists to satisfy TypeScript's flow analysis without a non-null
+    // assertion.
+    if (prevMig === undefined || nextMig === undefined) continue;
+    if (!isNewer(nextMig.version, prevMig.version)) {
       throw new VttfError(
         'VTTF-0004',
-        `Migration list out of order: ${next} must be newer than ${prev}.`,
+        `Migration list out of order: ${nextMig.version} must be newer than ${prevMig.version}.`,
       );
     }
   }

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -189,7 +189,10 @@ describe('@vttforge/vite-plugin', () => {
       ) as Record<string, unknown>;
       expect(manifest.version).toBe('9.9.9');
       expect(manifest.esmodules).toEqual(['main.mjs']);
-      expect(manifest.styles).toEqual(['styles/main.css']);
+      // Foundry v13 manifest uses the object form `{ src }` for styles. The
+      // plugin emits this canonical shape regardless of whether the source
+      // manifest used the legacy string form or the v13 object form.
+      expect(manifest.styles).toEqual([{ src: 'styles/main.css' }]);
     });
 
     it('throws when manifest id does not match plugin option', async () => {
@@ -257,7 +260,46 @@ describe('@vttforge/vite-plugin', () => {
       const written = JSON.parse(
         readFileSync(resolve(workdir, 'dist/system.json'), 'utf8'),
       ) as Record<string, unknown>;
-      expect(written.styles).toEqual(['styles/main.css']);
+      expect(written.styles).toEqual([{ src: 'styles/main.css' }]);
+    });
+
+    it('accepts the v13 object form `{ src }` as manifest input', async () => {
+      // Backward compat: the plugin should accept both the legacy string form
+      // and the canonical v13 object form. The fixture ships strings; this
+      // test rewrites the input to the object form before invoking the plugin.
+      const manifest = JSON.parse(readFileSync(resolve(workdir, 'system.json'), 'utf8')) as Record<
+        string,
+        unknown
+      >;
+      manifest.styles = [{ src: 'styles/main.css' }];
+      writeFileSync(resolve(workdir, 'system.json'), JSON.stringify(manifest, null, 2));
+      const plugin = vttforge(defaultOptions());
+      await invokeConfigHook(plugin, workdir);
+      await invokeHook(plugin, 'writeBundle');
+      const written = JSON.parse(
+        readFileSync(resolve(workdir, 'dist/system.json'), 'utf8'),
+      ) as Record<string, unknown>;
+      expect(written.styles).toEqual([{ src: 'styles/main.css' }]);
+    });
+
+    it('preserves additional stylesheet metadata (e.g. `layer`) through the rewrite', async () => {
+      // Foundry v13's manifest schema supports `{ src, layer }` so authors
+      // can pin a stylesheet to a named CSS cascade layer. The plugin only
+      // rewrites `src` to point at the bundled output; every other key on the
+      // source entry must survive the round trip.
+      const manifest = JSON.parse(readFileSync(resolve(workdir, 'system.json'), 'utf8')) as Record<
+        string,
+        unknown
+      >;
+      manifest.styles = [{ src: 'styles/main.css', layer: 'fixture-system' }];
+      writeFileSync(resolve(workdir, 'system.json'), JSON.stringify(manifest, null, 2));
+      const plugin = vttforge(defaultOptions());
+      await invokeConfigHook(plugin, workdir);
+      await invokeHook(plugin, 'writeBundle');
+      const written = JSON.parse(
+        readFileSync(resolve(workdir, 'dist/system.json'), 'utf8'),
+      ) as Record<string, unknown>;
+      expect(written.styles).toEqual([{ src: 'styles/main.css', layer: 'fixture-system' }]);
     });
 
     it('drops a stylesheet entry that was repointed mid-watch (same basename, new source)', async () => {

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -135,14 +135,17 @@ describe('@vttforge/vite-plugin', () => {
       expect(input['main.mjs']).toContain('scripts/main.mjs');
       const output = rollup.output as {
         entryFileNames: (info: { name: string }) => string;
-        assetFileNames: (info: { name?: string }) => string;
+        assetFileNames: (info: { names: string[] }) => string;
         chunkFileNames: string;
       };
       expect(output.entryFileNames({ name: 'main.mjs' })).toBe('main.mjs');
       expect(output.entryFileNames({ name: 'styles/main.css' })).toBe('[name]');
       expect(output.chunkFileNames).toBe('chunks/[name].mjs');
-      expect(output.assetFileNames({ name: 'whatever.css' })).toBe('styles/[name][extname]');
-      expect(output.assetFileNames({ name: 'image.png' })).toBe('assets/[name][extname]');
+      expect(output.assetFileNames({ names: ['whatever.css'] })).toBe('styles/[name][extname]');
+      expect(output.assetFileNames({ names: ['image.png'] })).toBe('assets/[name][extname]');
+      // An asset with no names falls back to the generic `assets/` bucket
+      // rather than throwing.
+      expect(output.assetFileNames({ names: [] })).toBe('assets/[name][extname]');
     });
 
     it('includes CSS entries from the manifest in rollup input under flat basename keys', async () => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -100,6 +100,39 @@ function readJsonSafe(path: string): Record<string, unknown> | null {
   }
 }
 
+/**
+ * Foundry v13 accepts either a legacy string (`"styles/foo.css"`) or the
+ * canonical object form (`{ src: "styles/foo.css", layer?: "..." }`) in the
+ * manifest `styles` array. We accept both inputs and emit the object form,
+ * which is what Foundry expects natively in v13 (the string form auto-migrates
+ * with a deprecation warning). Any additional metadata declared on an object
+ * entry (e.g. `layer` for cascade layer placement) is preserved through the
+ * rewrite so consumers keep full control of stylesheet metadata.
+ */
+interface StyleEntry {
+  src: string;
+  [key: string]: unknown;
+}
+
+function normalizeStyleEntry(entry: unknown): StyleEntry | null {
+  if (typeof entry === 'string') return { src: entry };
+  if (entry && typeof entry === 'object' && 'src' in entry) {
+    const src = (entry as { src: unknown }).src;
+    if (typeof src === 'string') return { ...(entry as Record<string, unknown>), src };
+  }
+  return null;
+}
+
+function extractStyleEntries(rawStyles: unknown): StyleEntry[] {
+  if (!Array.isArray(rawStyles)) return [];
+  const result: StyleEntry[] = [];
+  for (const entry of rawStyles) {
+    const normalized = normalizeStyleEntry(entry);
+    if (normalized !== null) result.push(normalized);
+  }
+  return result;
+}
+
 async function copyStatic(opts: ResolvedOptions): Promise<void> {
   await mkdir(opts.outDir, { recursive: true });
   for (const entry of opts.staticAssets) {
@@ -164,12 +197,12 @@ function syncManifest(opts: ResolvedOptions, builtCssSources: Set<string>): Mani
     manifest.version = pkg.version;
   }
   manifest.esmodules = [JS_ENTRY_FILENAME];
-  const originalStyles = Array.isArray(manifest.styles) ? (manifest.styles as string[]) : [];
+  const originalStyles = extractStyleEntries(manifest.styles);
   const cssEntries: string[] = [];
-  const rewrittenStyles: string[] = [];
+  const rewrittenStyles: StyleEntry[] = [];
   const seenBasenames = new Set<string>();
-  for (const stylePath of originalStyles) {
-    if (typeof stylePath !== 'string') continue;
+  for (const styleEntry of originalStyles) {
+    const stylePath = styleEntry.src;
     const cssBasename = basename(stylePath);
     if (seenBasenames.has(cssBasename)) {
       throw new Error(
@@ -189,7 +222,9 @@ function syncManifest(opts: ResolvedOptions, builtCssSources: Set<string>): Mani
       continue;
     }
     cssEntries.push(stylePath);
-    rewrittenStyles.push(`styles/${cssBasename}`);
+    // Preserve any additional metadata (e.g. `layer`) declared on the source
+    // entry — only the path is rewritten to point at the bundled output.
+    rewrittenStyles.push({ ...styleEntry, src: `styles/${cssBasename}` });
   }
   manifest.styles = rewrittenStyles;
   writeFileSync(manifestDest, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
@@ -227,9 +262,7 @@ export default function vttforge(options: VttforgeOptions): Plugin {
       }
       const manifestAbs = resolve(root, resolved.manifest);
       const manifest = readJsonSafe(manifestAbs);
-      const originalStyles =
-        manifest && Array.isArray(manifest.styles) ? (manifest.styles as string[]) : [];
-      cssEntries = originalStyles.filter((s): s is string => typeof s === 'string');
+      cssEntries = extractStyleEntries(manifest?.styles).map((e) => e.src);
       const cssAbsInput = cssEntries.map((s) => resolve(root, s));
 
       // Use flat input keys so Rollup emits assets by their basename only.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -309,7 +309,11 @@ export default function vttforge(options: VttforgeOptions): Plugin {
               },
               chunkFileNames: 'chunks/[name].mjs',
               assetFileNames: (asset) => {
-                const name = asset.name ?? 'asset';
+                // Rollup 4 surfaces every name an asset can take via `names`.
+                // `name` is kept as a deprecated alias to `names[0]`; we read
+                // `names[0]` directly so the callback stays correct when
+                // Rollup eventually removes the alias.
+                const name = asset.names[0] ?? 'asset';
                 if (name.endsWith('.css')) return 'styles/[name][extname]';
                 return 'assets/[name][extname]';
               },


### PR DESCRIPTION
## Summary

Three coordinated fixes from a Foundry v13 manifest audit, plus a repo-wide lint sweep so the branch ships with zero outstanding warnings.

- **`@vttforge/core`** — `BaseTypeDataModel()` ships a new `prepareBaseData()` no-op stub for fields Active Effects need to mutate (base max HP, base AC). Use `prepareDerivedData()` for values that depend on the AE-mutated state. The misleading `_addDataFieldMigrations()` static stub is removed (the real field-rename API lives on `Document` as `_addDataFieldMigration` — singular, on the parent base — and is reached via `super` from a `migrateData(source)` override).
- **`@vttforge/vite-plugin`** — emits the canonical v13 `styles` form (`[{ src: "..." }]`) in the built manifest. Still accepts both the legacy string form and the v13 object form as input; additional metadata declared on object entries (e.g. `layer` for cascade layer placement) is preserved through the rewrite. `assetFileNames` now reads `asset.names[0]` instead of the deprecated `asset.name` alias on Rollup's `PreRenderedAsset`.
- **`examples/simple-system`** — manifest aligned with v13:
  - `gridDistance` / `gridUnits` → `grid: { type, distance, units, diagonals }`
  - `styles: ["..."]` → `styles: [{ src: "..." }]`
  - `flags.hotReload` moved out from under the package namespace to the root of `flags`, and switched from the bare-array shape to the object form `{ extensions, paths }` Foundry's hot-reload watcher actually reads.

Server-side hot-reload enablement is deferred — it interacts with `felddy/foundryvtt`'s `CONTAINER_PRESERVE_CONFIG` flag and admin-key handling in ways that need their own design pass. Tracked under the HMR track in the roadmap.

### Lint sweep

To stop carrying noise into future PRs, this branch also clears every outstanding Biome warning across the repo:

- `packages/core/src/migrations/runner.ts` — non-null assertions replaced with `at(-1)` + optional chaining and explicit index guards.
- `packages/core/src/__tests__/{base-actor-sheet,base-item-sheet,migrations}.test.ts` — inline `!` on array element / mock-call accesses replaced with explicit guards that throw a clearer message if the invariant ever breaks.
- `apps/web/src/styles.css` — the two intentionally lower-specificity rules (`.mono` in feature/table copy, `.cta-strip .row` in the CTA strip) carry an explicit comment explaining why the cascade order is deliberate.

`biome check` now reports **zero warnings** repo-wide.

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm lint` — clean, **zero Biome warnings**
- [x] `pnpm typecheck` — all 11 tasks green
- [x] `pnpm test` — 132 tests pass (+1 new test for object-form input, +1 for layer-metadata preservation, +1 for `prepareBaseData` no-op, +1 for the empty-names asset fallback)
- [x] `pnpm build` — all 9 packages build; `examples/simple-system/dist/system.json` shows the v13 shape end-to-end (`styles: [{src}]`, `grid.{...}`, `flags.hotReload.{extensions,paths}` at root)
- [x] `codex review --uncommitted` — clean ("no concrete regression was identified")