### PR TITLE
feat(cli): ship vttforge init + four templates + create-vttforge wrapper

### DIFF
--- a/.changeset/cli-init.md
+++ b/.changeset/cli-init.md
@@ -1,0 +1,50 @@
+---
+'@vttforge/cli': minor
+'create-vttforge': minor
+---
+
+feat(cli): ship the `vttforge init` scaffolder + four built-in templates
+
+`@vttforge/cli` now provides a real, interactive scaffolder. `vttforge init`
+(or `pnpm create vttforge` via the new `create-vttforge` package) walks the
+user through naming the project, picking system/module + TypeScript/JavaScript,
+and writing a complete VTTForge starter into a new directory.
+
+**Bin commands:**
+
+- `vttforge init [name]` — interactive scaffolder. Honors `--type`, `--lang`,
+  `--no-install`, `--no-git` flags; everything else is prompted for via
+  `@clack/prompts`. Detects the calling package manager via
+  `npm_config_user_agent` (pnpm / npm / bun / yarn) and offers to run
+  `<pm> install` after writing files. Optionally initializes a git repo
+  with an initial commit.
+- `vttforge dev`, `vttforge build`, `vttforge audit` — reserved subcommands
+  that print a discoverable next-step message until their real
+  implementations land in a later release.
+
+**Four built-in templates** under `packages/cli/templates/`:
+
+- `system-ts` / `system-js` — realistic Foundry v13+ system that mirrors
+  the reference `examples/simple-system`. Ships `CharacterData` + `GearData`
+  TypeDataModels, `CharacterSheet` + `GearSheet` extending `BaseActorSheet`
+  / `BaseItemSheet`, a `createMigrationRunner` with one example migration,
+  Handlebars templates for both sheets, the four v13 manifest shapes
+  (`grid`, `styles: [{src}]`, `flags.hotReload` at the root of `flags`,
+  per-subtype `htmlFields`), and a tagged-release GitHub Actions workflow
+  that builds + zips + publishes to a GitHub Release.
+- `module-ts` / `module-js` — minimal but realistic module. Registers a
+  client-scope setting via `SystemConfig` from `@vttforge/core`, listens on
+  `renderActorSheetV2` to tag the rendered sheet with a discreet badge,
+  exposes a tiny API on `game.modules.get(id).api`, and ships the same
+  tag-driven release workflow.
+
+**New package — `create-vttforge`** — thin wrapper around `@vttforge/cli init`
+that enables the `pnpm create vttforge my-system` / `npm create vttforge@latest my-system`
+UX familiar from the `create-vite` / `create-next-app` ecosystem.
+
+44 unit tests cover the substitution logic, the package-manager detector, and
+a per-template integration suite that scaffolds every variant into a temporary
+directory and asserts shape (no leftover placeholders, valid manifest,
+expected files). Templates are excluded from biome and vitest scanning since
+they contain `{{PLACEHOLDER}}` strings that aren't valid TypeScript/JSON until
+substitution.

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "!**/node_modules",
       "!**/coverage",
       "!plans",
-      "!packages/styles/tokens.json"
+      "!packages/styles/tokens.json",
+      "!packages/cli/templates"
     ]
   },
   "formatter": {

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,11 @@
     "packages/*": {
       "ignoreDependencies": ["@arethetypeswrong/cli"]
     },
+    "packages/cli": {
+      "ignore": ["templates/**"],
+      "ignoreDependencies": ["@arethetypeswrong/cli"]
+    },
+    "packages/create-vttforge": {},
     "packages/styles": {
       "entry": ["preview/index.html", "preview/preview.js"],
       "project": ["preview/**/*.js"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,10 @@
     "publint": "publint",
     "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output \u2014 re-enable later'"
   },
+  "dependencies": {
+    "@clack/prompts": "catalog:",
+    "citty": "catalog:"
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
     "@types/node": "catalog:",

--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectPackageManager,
+  scaffold,
+  substitute,
+  templatesRoot,
+  VTTFORGE_CLI_VERSION,
+} from '../index.js';
+
+describe('@vttforge/cli public surface', () => {
+  it('exports the substitute helper', () => {
+    expect(typeof substitute).toBe('function');
+  });
+
+  it('exports the scaffold function', () => {
+    expect(typeof scaffold).toBe('function');
+  });
+
+  it('exports the templatesRoot resolver', () => {
+    expect(typeof templatesRoot).toBe('function');
+    expect(templatesRoot()).toContain('templates');
+  });
+
+  it('exports the package-manager helpers', () => {
+    expect(typeof detectPackageManager).toBe('function');
+  });
+
+  it('exports the version constant', () => {
+    expect(VTTFORGE_CLI_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/packages/cli/src/__tests__/package-manager.test.ts
+++ b/packages/cli/src/__tests__/package-manager.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { detectPackageManager, installCommand } from '../package-manager.js';
+
+describe('detectPackageManager', () => {
+  it('returns "pnpm" when the user agent starts with pnpm', () => {
+    expect(
+      detectPackageManager({ npm_config_user_agent: 'pnpm/8.0.0 node/v22.0.0 darwin arm64' }),
+    ).toBe('pnpm');
+  });
+
+  it('returns "npm" when the user agent starts with npm', () => {
+    expect(
+      detectPackageManager({ npm_config_user_agent: 'npm/10.0.0 node/v22.0.0 darwin arm64' }),
+    ).toBe('npm');
+  });
+
+  it('returns "bun" when the user agent starts with bun', () => {
+    expect(
+      detectPackageManager({ npm_config_user_agent: 'bun/1.1.0 node/v22.0.0 darwin arm64' }),
+    ).toBe('bun');
+  });
+
+  it('returns "yarn" when the user agent starts with yarn', () => {
+    expect(
+      detectPackageManager({ npm_config_user_agent: 'yarn/4.0.0 npm/? node/v22.0.0 darwin arm64' }),
+    ).toBe('yarn');
+  });
+
+  it('defaults to pnpm when no user agent is set', () => {
+    expect(detectPackageManager({})).toBe('pnpm');
+  });
+
+  it('defaults to pnpm when the user agent is empty', () => {
+    expect(detectPackageManager({ npm_config_user_agent: '' })).toBe('pnpm');
+  });
+
+  it('defaults to pnpm when the user agent is an unknown manager', () => {
+    expect(detectPackageManager({ npm_config_user_agent: 'someTool/1.0.0' })).toBe('pnpm');
+  });
+});
+
+describe('installCommand', () => {
+  it('returns the install command for each manager', () => {
+    expect(installCommand('pnpm')).toBe('pnpm install');
+    expect(installCommand('npm')).toBe('npm install');
+    expect(installCommand('bun')).toBe('bun install');
+    expect(installCommand('yarn')).toBe('yarn install');
+  });
+});

--- a/packages/cli/src/__tests__/scaffold.test.ts
+++ b/packages/cli/src/__tests__/scaffold.test.ts
@@ -1,0 +1,120 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type ScaffoldVars, scaffold, substitute } from '../scaffold.js';
+
+const FIXTURE_VARS: ScaffoldVars = {
+  ID: 'my-system',
+  TITLE: 'My System',
+  DESCRIPTION: 'A test system',
+  AUTHOR: 'Daisy',
+  LICENSE: 'MIT',
+  FOUNDRY_MIN_VERSION: '13',
+  FOUNDRY_VERIFIED_VERSION: '13.341',
+  LOCALE_PREFIX: 'MY_SYSTEM',
+  YEAR: '2026',
+};
+
+describe('substitute', () => {
+  it('replaces single placeholders', () => {
+    expect(substitute('Hello, {{TITLE}}', FIXTURE_VARS)).toBe('Hello, My System');
+  });
+
+  it('replaces multiple placeholders in one pass', () => {
+    expect(substitute('{{ID}} by {{AUTHOR}} ({{LICENSE}})', FIXTURE_VARS)).toBe(
+      'my-system by Daisy (MIT)',
+    );
+  });
+
+  it('passes unknown placeholders through unchanged', () => {
+    expect(substitute('{{ID}} and {{UNKNOWN}}', FIXTURE_VARS)).toBe('my-system and {{UNKNOWN}}');
+  });
+
+  it('handles content with no placeholders', () => {
+    expect(substitute('just plain text', FIXTURE_VARS)).toBe('just plain text');
+  });
+
+  it('replaces repeated placeholders', () => {
+    expect(substitute('{{ID}} {{ID}} {{ID}}', FIXTURE_VARS)).toBe('my-system my-system my-system');
+  });
+});
+
+describe('scaffold', () => {
+  let templateDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    templateDir = mkdtempSync(join(tmpdir(), 'vttforge-template-'));
+    destDir = mkdtempSync(join(tmpdir(), 'vttforge-dest-'));
+    // Remove the destDir so scaffold can create it fresh (mkdtempSync makes it).
+    rmSync(destDir, { recursive: true, force: true });
+
+    // Populate the template with a representative file tree.
+    await mkdir(join(templateDir, 'scripts'), { recursive: true });
+    await writeFile(
+      join(templateDir, 'package.json'),
+      JSON.stringify({ name: '{{ID}}', author: '{{AUTHOR}}' }, null, 2),
+    );
+    await writeFile(
+      join(templateDir, 'system.json'),
+      JSON.stringify({ id: '{{ID}}', title: '{{TITLE}}' }, null, 2),
+    );
+    await writeFile(
+      join(templateDir, 'scripts', 'main.mjs'),
+      "const SYSTEM_ID = '{{ID}}';\nconsole.log(SYSTEM_ID);\n",
+    );
+    await writeFile(join(templateDir, '.gitignore'), 'node_modules\ndist\n');
+  });
+
+  afterEach(() => {
+    rmSync(templateDir, { recursive: true, force: true });
+    rmSync(destDir, { recursive: true, force: true });
+  });
+
+  it('copies every template file into the destination', async () => {
+    await scaffold({ templateDir, destDir, vars: FIXTURE_VARS });
+    expect(existsSync(join(destDir, 'package.json'))).toBe(true);
+    expect(existsSync(join(destDir, 'system.json'))).toBe(true);
+    expect(existsSync(join(destDir, 'scripts', 'main.mjs'))).toBe(true);
+    expect(existsSync(join(destDir, '.gitignore'))).toBe(true);
+  });
+
+  it('substitutes placeholders in JSON files', async () => {
+    await scaffold({ templateDir, destDir, vars: FIXTURE_VARS });
+    const pkg = JSON.parse(readFileSync(join(destDir, 'package.json'), 'utf8'));
+    expect(pkg.name).toBe('my-system');
+    expect(pkg.author).toBe('Daisy');
+  });
+
+  it('substitutes placeholders in JS source files', async () => {
+    await scaffold({ templateDir, destDir, vars: FIXTURE_VARS });
+    const main = readFileSync(join(destDir, 'scripts', 'main.mjs'), 'utf8');
+    expect(main).toContain("const SYSTEM_ID = 'my-system';");
+  });
+
+  it('preserves files without placeholders byte-for-byte', async () => {
+    await scaffold({ templateDir, destDir, vars: FIXTURE_VARS });
+    expect(readFileSync(join(destDir, '.gitignore'), 'utf8')).toBe('node_modules\ndist\n');
+  });
+
+  it('throws when the template directory does not exist', async () => {
+    await expect(
+      scaffold({
+        templateDir: join(tmpdir(), `vttforge-missing-${Date.now()}`),
+        destDir,
+        vars: FIXTURE_VARS,
+      }),
+    ).rejects.toThrow(/template directory does not exist/);
+  });
+
+  it('creates nested directories as needed', async () => {
+    await mkdir(join(templateDir, 'a', 'b', 'c'), { recursive: true });
+    await writeFile(join(templateDir, 'a', 'b', 'c', 'deep.txt'), 'hello {{ID}}\n');
+    await scaffold({ templateDir, destDir, vars: FIXTURE_VARS });
+    expect(readFileSync(join(destDir, 'a', 'b', 'c', 'deep.txt'), 'utf8')).toBe(
+      'hello my-system\n',
+    );
+  });
+});

--- a/packages/cli/src/__tests__/templates.integration.test.ts
+++ b/packages/cli/src/__tests__/templates.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration test — scaffold every shipped template end-to-end and assert
+ * the basic shape of the generated project. Catches template drift early
+ * (missing files, broken JSON syntax, unresolved placeholders, etc.).
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type ScaffoldVars, scaffold, templatesRoot } from '../scaffold.js';
+
+const VARS: ScaffoldVars = {
+  ID: 'my-pack',
+  TITLE: 'My Pack',
+  DESCRIPTION: 'Integration test fixture.',
+  AUTHOR: 'Test Author',
+  LICENSE: 'MIT',
+  FOUNDRY_MIN_VERSION: '13',
+  FOUNDRY_VERIFIED_VERSION: '13.341',
+  LOCALE_PREFIX: 'MY_PACK',
+  YEAR: '2026',
+};
+
+const SYSTEM_VARIANTS = ['system-ts', 'system-js'] as const;
+const MODULE_VARIANTS = ['module-ts', 'module-js'] as const;
+const ALL_VARIANTS = [...SYSTEM_VARIANTS, ...MODULE_VARIANTS];
+
+describe('scaffolded templates', () => {
+  let destDir: string;
+
+  beforeEach(() => {
+    destDir = mkdtempSync(join(tmpdir(), 'vttforge-integration-'));
+    rmSync(destDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(destDir, { recursive: true, force: true });
+  });
+
+  for (const variant of ALL_VARIANTS) {
+    describe(variant, () => {
+      it('scaffolds a complete project', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+
+        // Every variant ships these files.
+        expect(existsSync(join(destDir, 'package.json'))).toBe(true);
+        expect(existsSync(join(destDir, 'vite.config.mjs'))).toBe(true);
+        expect(existsSync(join(destDir, 'README.md'))).toBe(true);
+        expect(existsSync(join(destDir, '.gitignore'))).toBe(true);
+        expect(existsSync(join(destDir, '.github', 'workflows', 'release.yml'))).toBe(true);
+        expect(existsSync(join(destDir, 'lang', 'en.json'))).toBe(true);
+        expect(existsSync(join(destDir, 'styles', 'main.css'))).toBe(true);
+      });
+
+      it('produces a valid package.json with substituted fields', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+        const pkg = JSON.parse(readFileSync(join(destDir, 'package.json'), 'utf8'));
+        expect(pkg.name).toBe('my-pack');
+        expect(pkg.description).toBe('Integration test fixture.');
+        expect(pkg.author).toBe('Test Author');
+        expect(pkg.license).toBe('MIT');
+      });
+
+      it('leaves no `{{PLACEHOLDER}}` strings in the output', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+        // Spot-check the manifest and main script for any leftover placeholders.
+        const manifestName = variant.startsWith('system-') ? 'system.json' : 'module.json';
+        const manifest = readFileSync(join(destDir, manifestName), 'utf8');
+        expect(manifest).not.toMatch(/\{\{[A-Z_]+\}\}/);
+
+        const mainExt = variant.endsWith('-ts') ? 'ts' : 'mjs';
+        const main = readFileSync(join(destDir, 'scripts', `main.${mainExt}`), 'utf8');
+        expect(main).not.toMatch(/\{\{[A-Z_]+\}\}/);
+      });
+    });
+  }
+
+  for (const variant of SYSTEM_VARIANTS) {
+    describe(`${variant} (system-specific)`, () => {
+      it('produces a v13-shaped system.json', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+        const manifest = JSON.parse(readFileSync(join(destDir, 'system.json'), 'utf8'));
+        expect(manifest.id).toBe('my-pack');
+        expect(manifest.title).toBe('My Pack');
+        expect(manifest.compatibility.minimum).toBe('13');
+        expect(manifest.styles).toEqual([{ src: 'styles/main.css' }]);
+        expect(manifest.grid).toEqual({ type: 1, distance: 5, units: 'ft', diagonals: 0 });
+        expect(manifest.flags.hotReload).toEqual({
+          extensions: ['css', 'hbs', 'json'],
+          paths: ['styles', 'templates', 'lang'],
+        });
+        expect(manifest.documentTypes.Actor.character.htmlFields).toEqual(['biography']);
+      });
+
+      it('ships template.json with declared types', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+        const template = JSON.parse(readFileSync(join(destDir, 'template.json'), 'utf8'));
+        expect(template.Actor.types).toContain('character');
+        expect(template.Item.types).toContain('gear');
+      });
+
+      it('ships Handlebars sheet templates', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+        expect(existsSync(join(destDir, 'templates', 'actor', 'character-sheet.hbs'))).toBe(true);
+        expect(existsSync(join(destDir, 'templates', 'item', 'gear-sheet.hbs'))).toBe(true);
+      });
+    });
+  }
+
+  for (const variant of MODULE_VARIANTS) {
+    describe(`${variant} (module-specific)`, () => {
+      it('produces a v13-shaped module.json without documentTypes', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+        const manifest = JSON.parse(readFileSync(join(destDir, 'module.json'), 'utf8'));
+        expect(manifest.id).toBe('my-pack');
+        expect(manifest.title).toBe('My Pack');
+        expect(manifest.styles).toEqual([{ src: 'styles/main.css' }]);
+        expect(manifest.flags.hotReload).toEqual({
+          extensions: ['css', 'json'],
+          paths: ['styles', 'lang'],
+        });
+        expect(manifest.documentTypes).toBeUndefined();
+      });
+    });
+  }
+});

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,4 +1,119 @@
 #!/usr/bin/env node
-// Placeholder entry point. Replaced by the real CLI (Citty + Giget + Clack) in v0.3.0.
-console.error('vttforge CLI v0.0.1 — placeholder. Real CLI ships in v0.3.0.');
-process.exit(1);
+/**
+ * vttforge bin — CLI entry.
+ *
+ * `vttforge init` is the only fully-implemented subcommand in this version.
+ * `dev`, `build`, and `audit` are reserved so users get a discoverable error
+ * pointing at the right workaround until the real implementations land.
+ */
+import { defineCommand, runMain } from 'citty';
+import { runInit, ScaffoldError } from './commands/init.js';
+import { VTTFORGE_CLI_VERSION } from './index.js';
+
+const init = defineCommand({
+  meta: {
+    name: 'init',
+    description: 'Scaffold a new Foundry VTT system or module from a VTTForge template',
+  },
+  args: {
+    name: {
+      type: 'positional',
+      description: 'Directory name for the new system/module (also the default manifest id)',
+      required: false,
+    },
+    type: {
+      type: 'string',
+      description: 'Package type: system | module',
+    },
+    lang: {
+      type: 'string',
+      description: 'Language: ts | js',
+    },
+    // Citty parses `--no-X` as `args.X === false`, so define affirmative
+    // flags with a true default. `--no-install` then yields `install: false`
+    // which we forward as `noInstall: true`.
+    install: {
+      type: 'boolean',
+      default: true,
+      description: 'Install dependencies after scaffold (use --no-install to skip)',
+    },
+    git: {
+      type: 'boolean',
+      default: true,
+      description: 'Initialize a git repository after scaffold (use --no-git to skip)',
+    },
+  },
+  async run({ args }) {
+    try {
+      await runInit({
+        name: typeof args.name === 'string' ? args.name : undefined,
+        type: typeof args.type === 'string' ? (args.type as 'system' | 'module') : undefined,
+        lang: typeof args.lang === 'string' ? (args.lang as 'ts' | 'js') : undefined,
+        noInstall: args.install === false,
+        noGit: args.git === false,
+      });
+    } catch (err) {
+      // ScaffoldError already surfaced its message via `p.cancel`; anything
+      // else is a real crash worth showing. Either way the bin exits 1.
+      if (!(err instanceof ScaffoldError)) {
+        console.error(err instanceof Error ? err.message : String(err));
+      }
+      process.exit(1);
+    }
+  },
+});
+
+const dev = defineCommand({
+  meta: {
+    name: 'dev',
+    description:
+      'Run vite build --watch + symlink dist/ into Foundry Data (coming in a later release)',
+  },
+  run() {
+    console.error(
+      'vttforge dev is not implemented yet. For now: run `vite build --watch` from your project and symlink `dist/` into your Foundry Data/systems/<id>/ (or use the dev compose mount).',
+    );
+    process.exit(1);
+  },
+});
+
+const build = defineCommand({
+  meta: {
+    name: 'build',
+    description: 'Run vite build + emit a foundryvtt.com release zip (coming in a later release)',
+  },
+  run() {
+    console.error(
+      'vttforge build is not implemented yet. For now: run `vite build`. The release workflow already shipped in your scaffold zips dist/ automatically on tag push.',
+    );
+    process.exit(1);
+  },
+});
+
+const audit = defineCommand({
+  meta: {
+    name: 'audit',
+    description:
+      'Scan a system/module source tree for v13 manifest footguns (coming in a later release)',
+  },
+  run() {
+    console.error('vttforge audit is not implemented yet. Coming after the build pipeline lands.');
+    process.exit(1);
+  },
+});
+
+const main = defineCommand({
+  meta: {
+    name: 'vttforge',
+    version: VTTFORGE_CLI_VERSION,
+    description: 'VTTForge CLI — scaffold, dev, build for Foundry v13+ systems and modules',
+  },
+  subCommands: {
+    init,
+    dev,
+    build,
+    audit,
+  },
+});
+
+runMain(main);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,349 @@
+/**
+ * `vttforge init` — interactive scaffolder.
+ *
+ * Honors CLI flags first, prompts for everything missing, then copies the
+ * matching template into the destination directory. Optionally `git init`s
+ * and runs the detected package manager's install command at the end.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import * as p from '@clack/prompts';
+import { initGitRepo, readGitAuthorName } from '../git.js';
+import { detectPackageManager, installCommand } from '../package-manager.js';
+import { type ScaffoldVars, scaffold, templatesRoot } from '../scaffold.js';
+
+export interface InitOptions {
+  name?: string;
+  type?: 'system' | 'module';
+  lang?: 'ts' | 'js';
+  noInstall?: boolean;
+  noGit?: boolean;
+  /** Override the working directory (test hook). Defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
+export interface ResolvedInitOptions extends Required<Omit<InitOptions, 'cwd'>> {
+  cwd: string;
+  dest: string;
+  id: string;
+  title: string;
+  description: string;
+  author: string;
+  license: string;
+  foundryMinVersion: string;
+  foundryVerifiedVersion: string;
+  templateVariant: TemplateVariant;
+}
+
+export type TemplateVariant = 'system-ts' | 'system-js' | 'module-ts' | 'module-js';
+
+const PACKAGE_ID_RE = /^[a-z][a-z0-9-]*$/;
+const UNSAFE_METADATA_CHARS_RE = /["\\\r\n\t]/;
+
+function validateMetadata(value: string): string | undefined {
+  // Reject characters that would break JSON string contexts in the
+  // generated manifests/i18n catalogues. Apostrophes are fine — every JS
+  // string literal in the templates is double-quoted, every JSON value is
+  // double-quoted. Backslashes and double quotes need explicit escaping
+  // we don't perform during substitution, so we reject them at the
+  // prompt instead of producing broken scaffolds.
+  if (UNSAFE_METADATA_CHARS_RE.test(value)) {
+    return 'Avoid backslashes, double quotes, and line breaks — they break the generated manifest.';
+  }
+  // Reject `*/` because metadata is interpolated into JS/CSS block-comment
+  // headers in the generated files; a stray comment terminator there
+  // closes the header early and leaves trailing source garbage.
+  if (value.includes('*/')) {
+    return 'Avoid `*/` — it closes block comments in the generated source headers.';
+  }
+  return undefined;
+}
+
+function validateRequiredMetadata(value: string): string | undefined {
+  if (!value || value.trim().length === 0) {
+    return 'Required — Foundry rejects packages with a blank title.';
+  }
+  return validateMetadata(value);
+}
+
+/**
+ * Thrown when the scaffolder cannot continue — bad input, an existing
+ * destination, a cancelled prompt, etc. `runInit` propagates these instead
+ * of calling `process.exit`, so library consumers (tests, other CLIs) can
+ * catch and recover. The `vttforge` bin wraps `runInit` in a top-level
+ * handler that prints the message and exits with code 1.
+ */
+export class ScaffoldError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ScaffoldError';
+  }
+}
+
+function isCancelled(value: unknown): boolean {
+  return p.isCancel(value);
+}
+
+function bail(message: string): never {
+  p.cancel(message);
+  throw new ScaffoldError(message);
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+function localePrefix(id: string): string {
+  return id.toUpperCase().replace(/-/g, '_');
+}
+
+function titleCase(input: string): string {
+  return input
+    .split(/[-_\s]+/)
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function templateVariantFor(type: 'system' | 'module', lang: 'ts' | 'js'): TemplateVariant {
+  return `${type}-${lang}` as TemplateVariant;
+}
+
+export async function runInit(options: InitOptions = {}): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  p.intro('🜲 vttforge init — scaffold a Foundry v13+ system or module');
+
+  // --- name ------------------------------------------------------------------
+  let name = options.name?.trim();
+  if (!name) {
+    const answer = await p.text({
+      message: 'Directory name (also the default manifest id)',
+      placeholder: 'my-system',
+      validate: (value: string) => {
+        const trimmed = value?.trim() ?? '';
+        if (trimmed.length === 0) return 'Name is required';
+        if (!PACKAGE_ID_RE.test(trimmed)) {
+          return 'Use only lowercase letters, digits, and dashes (no spaces, slashes, dots).';
+        }
+        return undefined;
+      },
+    });
+    if (isCancelled(answer)) bail('Scaffold cancelled.');
+    name = String(answer).trim();
+  } else if (!PACKAGE_ID_RE.test(name)) {
+    bail(
+      `Invalid name "${name}": use only lowercase letters, digits, and dashes (no spaces, slashes, dots).`,
+    );
+  }
+  const dest = resolve(cwd, name);
+  if (existsSync(dest)) {
+    bail(`Directory already exists: ${dest}`);
+  }
+
+  // --- type ------------------------------------------------------------------
+  let type = options.type;
+  if (type !== 'system' && type !== 'module') {
+    const answer = await p.select({
+      message: 'What are you building?',
+      options: [
+        { value: 'system', label: 'system — defines the game rules (Actor/Item types, sheets)' },
+        {
+          value: 'module',
+          label: 'module — extends an existing system or adds cross-system features',
+        },
+      ],
+      initialValue: 'system',
+    });
+    if (isCancelled(answer)) bail('Scaffold cancelled.');
+    type = answer as 'system' | 'module';
+  }
+
+  // --- lang ------------------------------------------------------------------
+  let lang = options.lang;
+  if (lang !== 'ts' && lang !== 'js') {
+    const answer = await p.select({
+      message: 'Language',
+      options: [
+        { value: 'ts', label: 'TypeScript' },
+        { value: 'js', label: 'JavaScript (.mjs)' },
+      ],
+      initialValue: 'ts',
+    });
+    if (isCancelled(answer)) bail('Scaffold cancelled.');
+    lang = answer as 'ts' | 'js';
+  }
+
+  // --- id / title / description / author ------------------------------------
+  const defaultId = slugify(name);
+  const idAnswer = await p.text({
+    message: 'Package id (used as the folder Foundry serves under /<systems|modules>/<id>/)',
+    initialValue: defaultId,
+    validate: (value: string) => {
+      if (!PACKAGE_ID_RE.test(value)) {
+        return 'Package id must start with a letter and contain only lowercase letters, digits, dashes';
+      }
+      return undefined;
+    },
+  });
+  if (isCancelled(idAnswer)) bail('Scaffold cancelled.');
+  const id = String(idAnswer);
+
+  const titleAnswer = await p.text({
+    message: 'Title (human-readable, shown in Foundry setup screens)',
+    initialValue: titleCase(id),
+    validate: validateRequiredMetadata,
+  });
+  if (isCancelled(titleAnswer)) bail('Scaffold cancelled.');
+  const title = String(titleAnswer).trim();
+
+  const descriptionAnswer = await p.text({
+    message: 'One-line description',
+    placeholder: 'A Foundry v13+ system built with VTTForge',
+    initialValue: `A Foundry v13+ ${type} built with VTTForge`,
+    validate: validateMetadata,
+  });
+  if (isCancelled(descriptionAnswer)) bail('Scaffold cancelled.');
+  const description = String(descriptionAnswer);
+
+  const rawDetectedAuthor = await readGitAuthorName();
+  // The git fallback bypasses Clack validation, so apply the same metadata
+  // safety check before letting it through. If the local git config has
+  // something we'd reject from a prompt, drop the suggestion and let the
+  // user type a clean value (or land on the 'Anonymous' default).
+  const detectedAuthor =
+    rawDetectedAuthor && validateMetadata(rawDetectedAuthor) === undefined
+      ? rawDetectedAuthor
+      : undefined;
+  const authorAnswer = await p.text({
+    message: 'Author name (used in the manifest)',
+    placeholder: detectedAuthor ?? 'Your Name',
+    initialValue: detectedAuthor ?? '',
+    validate: validateMetadata,
+  });
+  if (isCancelled(authorAnswer)) bail('Scaffold cancelled.');
+  const author = String(authorAnswer).trim() || (detectedAuthor ?? 'Anonymous');
+
+  const licenseAnswer = await p.select({
+    message: 'License',
+    options: [
+      { value: 'MIT', label: 'MIT (recommended for Foundry community packages)' },
+      { value: 'Apache-2.0', label: 'Apache-2.0' },
+      { value: 'GPL-3.0-or-later', label: 'GPL-3.0-or-later' },
+      { value: 'UNLICENSED', label: 'UNLICENSED (private use only)' },
+    ],
+    initialValue: 'MIT',
+  });
+  if (isCancelled(licenseAnswer)) bail('Scaffold cancelled.');
+  const license = String(licenseAnswer);
+
+  const foundryMinVersion = '13';
+  const foundryVerifiedVersion = '13.341';
+
+  // --- scaffold --------------------------------------------------------------
+  const templateVariant = templateVariantFor(type, lang);
+  const templateDir = resolve(templatesRoot(), templateVariant);
+  if (!existsSync(templateDir)) {
+    bail(`Template "${templateVariant}" not found at ${templateDir}`);
+  }
+
+  const vars: ScaffoldVars = {
+    ID: id,
+    TITLE: title,
+    DESCRIPTION: description,
+    AUTHOR: author,
+    LICENSE: license,
+    FOUNDRY_MIN_VERSION: foundryMinVersion,
+    FOUNDRY_VERIFIED_VERSION: foundryVerifiedVersion,
+    LOCALE_PREFIX: localePrefix(id),
+    YEAR: String(new Date().getFullYear()),
+  };
+
+  const scaffoldSpinner = p.spinner();
+  scaffoldSpinner.start(`Scaffolding ${templateVariant} into ${name}/`);
+  try {
+    await scaffold({ templateDir, destDir: dest, vars });
+    scaffoldSpinner.stop(`Scaffold written to ${dest}`);
+  } catch (err) {
+    scaffoldSpinner.stop('Scaffold failed.');
+    throw err;
+  }
+
+  // --- install ---------------------------------------------------------------
+  // Install runs BEFORE git init so the lockfile lands in the initial commit
+  // — generated repos that ship with a lockfile install reproducibly and
+  // the working tree stays clean after scaffold.
+  const pm = detectPackageManager();
+  let shouldInstall = !options.noInstall;
+  if (shouldInstall) {
+    const confirm = await p.confirm({
+      message: `Install dependencies now with ${pm}?`,
+      initialValue: true,
+    });
+    if (isCancelled(confirm))
+      bail('Scaffold cancelled at install prompt (your scaffold is intact).');
+    shouldInstall = confirm === true;
+  }
+
+  if (shouldInstall) {
+    const installSpinner = p.spinner();
+    installSpinner.start(`Running ${installCommand(pm)}`);
+    try {
+      await runInstall(pm, dest);
+      installSpinner.stop(`Dependencies installed (${pm}).`);
+    } catch (err) {
+      installSpinner.stop(`Install failed: ${err instanceof Error ? err.message : String(err)}`);
+      p.note(
+        `Run \`${installCommand(pm)}\` inside ${name}/ to retry.`,
+        'Continuing without install.',
+      );
+    }
+  }
+
+  // --- git -------------------------------------------------------------------
+  // Runs AFTER install so the resulting lockfile is captured by the first
+  // commit and the working tree stays clean.
+  if (!options.noGit) {
+    const gitSpinner = p.spinner();
+    gitSpinner.start('Initializing git repository');
+    const gitResult = await initGitRepo(dest);
+    if (gitResult.ok) {
+      gitSpinner.stop('Git initialized (branch: main, initial commit landed).');
+    } else {
+      gitSpinner.stop(`Skipped git init: ${gitResult.reason ?? 'unknown error'}`);
+    }
+  }
+
+  // --- outro -----------------------------------------------------------------
+  const nextSteps = [
+    `cd ${name}`,
+    !shouldInstall ? installCommand(pm) : null,
+    `${pm} run build`,
+    'Symlink dist/ into your Foundry Data/<systems|modules>/<id>/ (or use the dev compose mount)',
+  ]
+    .filter((line): line is string => line !== null)
+    .map((line, idx) => `  ${idx + 1}. ${line}`)
+    .join('\n');
+  p.note(nextSteps, 'Next steps');
+  p.outro('Have fun building.');
+}
+
+function runInstall(pm: string, cwd: string): Promise<void> {
+  return new Promise((resolveInstall, rejectInstall) => {
+    const child = spawn(pm, ['install'], {
+      cwd,
+      stdio: 'inherit',
+      env: process.env,
+    });
+    child.on('error', rejectInstall);
+    child.on('exit', (code) => {
+      if (code === 0) resolveInstall();
+      else rejectInstall(new Error(`${pm} install exited with code ${code}`));
+    });
+  });
+}

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -1,0 +1,42 @@
+/**
+ * Git helpers for the init scaffolder. Optional: every step degrades to a
+ * warning, never throws. The scaffold completes even if git is missing or
+ * the user has no global git config — the user can still `git init`
+ * themselves later.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Read `git config user.name` to pre-fill the author prompt. Returns
+ * `undefined` if git is missing or the value is unset.
+ */
+export async function readGitAuthorName(): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync('git', ['config', '--get', 'user.name']);
+    const value = stdout.trim();
+    return value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Initialize a fresh git repository in `cwd`, run an initial commit. Errors
+ * are swallowed and converted to a return value so the caller can decide
+ * whether to warn or move on.
+ */
+export async function initGitRepo(cwd: string): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    await execFileAsync('git', ['init', '--initial-branch=main'], { cwd });
+    await execFileAsync('git', ['add', '.'], { cwd });
+    await execFileAsync('git', ['commit', '-m', 'chore: initial scaffold from @vttforge/cli'], {
+      cwd,
+    });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,16 @@
 /**
- * @vttforge/cli — placeholder. Real CLI ships in v0.3.0.
+ * @vttforge/cli — public library exports.
+ *
+ * The CLI is intended to be used as a bin (`vttforge` command). These
+ * exports exist for consumers who want to programmatically invoke the
+ * scaffolder (e.g. from another CLI, a test harness, or a custom tool).
  */
-export const VTTFORGE_CLI_VERSION = '0.0.1';
+
+export type { InitOptions, ResolvedInitOptions, TemplateVariant } from './commands/init.js';
+export { runInit, ScaffoldError } from './commands/init.js';
+export type { PackageManager } from './package-manager.js';
+export { detectPackageManager, installCommand } from './package-manager.js';
+export type { ScaffoldOptions, ScaffoldVars } from './scaffold.js';
+export { scaffold, substitute, templatesRoot } from './scaffold.js';
+
+export const VTTFORGE_CLI_VERSION = '0.1.0';

--- a/packages/cli/src/package-manager.ts
+++ b/packages/cli/src/package-manager.ts
@@ -1,0 +1,26 @@
+/**
+ * Detect which package manager invoked the CLI so we can run the right
+ * `install` command after scaffolding.
+ *
+ * Strategy: read `npm_config_user_agent`, which pnpm/npm/bun/yarn all set when
+ * they spawn a child process (including `pnpm dlx`, `pnpm create`, etc.).
+ * Falls back to `pnpm` because that's the VTTForge house default and the
+ * most common Foundry-developer choice — but any concrete signal in the
+ * environment wins over the default.
+ */
+export type PackageManager = 'pnpm' | 'npm' | 'bun' | 'yarn';
+
+export function detectPackageManager(env: NodeJS.ProcessEnv = process.env): PackageManager {
+  const ua = env.npm_config_user_agent;
+  if (typeof ua === 'string' && ua.length > 0) {
+    if (ua.startsWith('pnpm')) return 'pnpm';
+    if (ua.startsWith('bun')) return 'bun';
+    if (ua.startsWith('yarn')) return 'yarn';
+    if (ua.startsWith('npm')) return 'npm';
+  }
+  return 'pnpm';
+}
+
+export function installCommand(pm: PackageManager): string {
+  return `${pm} install`;
+}

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -1,0 +1,155 @@
+/**
+ * Template copy with `{{var}}` placeholder substitution.
+ *
+ * Templates live under `packages/cli/templates/<variant>/` and are shipped
+ * inside the published tarball (see the `files` array in package.json).
+ * Each file is read, substituted, and written to the destination directory
+ * preserving the relative path. Directories are created lazily on first
+ * write.
+ *
+ * We intentionally avoid Handlebars or any other template engine — the
+ * substitution surface is small (a flat string-to-string map), and bundling
+ * a dependency for ten lines of regex would be wasteful in a tool whose
+ * value is being fast to invoke.
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface ScaffoldVars {
+  ID: string;
+  TITLE: string;
+  DESCRIPTION: string;
+  AUTHOR: string;
+  LICENSE: string;
+  FOUNDRY_MIN_VERSION: string;
+  FOUNDRY_VERIFIED_VERSION: string;
+  LOCALE_PREFIX: string;
+  YEAR: string;
+}
+
+export interface ScaffoldOptions {
+  /** Absolute path to the template root (e.g. `<cli-pkg>/templates/system-ts`). */
+  templateDir: string;
+  /** Absolute path to the destination directory. Created if it doesn't exist. */
+  destDir: string;
+  /** Variables to substitute into `{{NAME}}` placeholders inside template files. */
+  vars: ScaffoldVars;
+}
+
+const PLACEHOLDER_RE = /\{\{(\w+)\}\}/g;
+
+/**
+ * Replace `{{NAME}}` placeholders in `content` using the `vars` map.
+ * Unknown placeholders are passed through unchanged so partially-templated
+ * files (e.g. a snippet that contains `{{handlebarsLikeSyntax}}` as literal
+ * content) still scaffold without surprises.
+ */
+export function substitute(content: string, vars: ScaffoldVars): string {
+  const lookup = vars as unknown as Record<string, string>;
+  return content.replace(PLACEHOLDER_RE, (match, key: string) =>
+    Object.hasOwn(lookup, key) ? (lookup[key] ?? match) : match,
+  );
+}
+
+/**
+ * Walk `dir` recursively and yield every file path relative to `dir`.
+ */
+async function* walkRelative(dir: string, base: string = dir): AsyncGenerator<string> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkRelative(full, base);
+    } else if (entry.isFile()) {
+      yield relative(base, full);
+    }
+  }
+}
+
+/**
+ * Files that should be substituted as text. Binary assets (.png, .ico, …)
+ * bypass substitution and are copied byte-for-byte. The list of binary
+ * extensions is intentionally small — extend if we add real binary assets
+ * to templates.
+ */
+const BINARY_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+]);
+
+function isBinaryPath(path: string): boolean {
+  const dotIndex = path.lastIndexOf('.');
+  if (dotIndex < 0) return false;
+  return BINARY_EXTENSIONS.has(path.slice(dotIndex).toLowerCase());
+}
+
+/**
+ * Files whose source name in the template is rewritten at scaffold time so
+ * npm packaging doesn't strip or rename them. npm transforms `.gitignore`
+ * into `.npmignore` on publish, so templates ship `_gitignore` and the
+ * scaffolder writes `.gitignore` into the generated project.
+ */
+const SCAFFOLD_PATH_RENAMES = new Map<string, string>([['_gitignore', '.gitignore']]);
+
+function rewriteDestRelPath(relPath: string): string {
+  const base = relPath.split('/').pop() ?? relPath;
+  const replacement = SCAFFOLD_PATH_RENAMES.get(base);
+  if (replacement === undefined) return relPath;
+  return relPath.slice(0, relPath.length - base.length) + replacement;
+}
+
+export async function scaffold({ templateDir, destDir, vars }: ScaffoldOptions): Promise<void> {
+  if (!existsSync(templateDir)) {
+    throw new Error(`[vttforge] template directory does not exist: ${templateDir}`);
+  }
+  const info = await stat(templateDir);
+  if (!info.isDirectory()) {
+    throw new Error(`[vttforge] template path is not a directory: ${templateDir}`);
+  }
+
+  await mkdir(destDir, { recursive: true });
+
+  for await (const relPath of walkRelative(templateDir)) {
+    const srcPath = join(templateDir, relPath);
+    // Apply substitution to the path itself so we can name files like
+    // `{{ID}}.code-workspace` if we ever need that — today no template path
+    // uses placeholders, but the support is free. Then apply the rename map
+    // so packaging-stripped names (e.g. `_gitignore`) land at their real
+    // destination (e.g. `.gitignore`).
+    const substituted = substitute(relPath, vars);
+    const destPath = join(destDir, rewriteDestRelPath(substituted));
+    await mkdir(dirname(destPath), { recursive: true });
+
+    if (isBinaryPath(srcPath)) {
+      const bytes = await readFile(srcPath);
+      await writeFile(destPath, bytes);
+      continue;
+    }
+
+    const content = await readFile(srcPath, 'utf8');
+    await writeFile(destPath, substitute(content, vars), 'utf8');
+  }
+}
+
+/**
+ * Resolve the templates directory relative to this module's file URL. tsdown
+ * emits `dist/scaffold.mjs`, so `import.meta.url` points there at runtime;
+ * we walk up two segments to land at the package root, then descend into
+ * `templates/`.
+ */
+export function templatesRoot(): string {
+  const here = fileURLToPath(import.meta.url);
+  // dist/scaffold.mjs → ../ = dist/, ../../ = package root
+  return resolve(here, '..', '..', 'templates');
+}

--- a/packages/cli/templates/module-js/.github/workflows/release.yml
+++ b/packages/cli/templates/module-js/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: pnpm install
+
+      - name: Sync manifest version
+        run: |
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${{ steps.version.outputs.version }}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
+
+      - run: pnpm build
+
+      - name: Inject release URLs into manifest
+        run: |
+          node -e "const fs=require('fs');const path='dist/module.json';const m=JSON.parse(fs.readFileSync(path,'utf8'));m.manifest='https://github.com/${{ github.repository }}/releases/latest/download/module.json';m.download='https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/{{ID}}-${{ steps.version.outputs.version }}.zip';fs.writeFileSync(path,JSON.stringify(m,null,2)+'\n');"
+
+      - name: Build release zip
+        run: |
+          cd dist
+          zip -r ../{{ID}}-${{ steps.version.outputs.version }}.zip .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            {{ID}}-${{ steps.version.outputs.version }}.zip
+            dist/module.json
+          generate_release_notes: true
+          body: |
+            ## Foundry installation
+
+            Install via Foundry's setup wizard with this manifest URL:
+
+            ```
+            https://github.com/${{ github.repository }}/releases/latest/download/module.json
+            ```

--- a/packages/cli/templates/module-js/README.md
+++ b/packages/cli/templates/module-js/README.md
@@ -1,0 +1,64 @@
+# {{TITLE}}
+
+{{DESCRIPTION}}
+
+A Foundry VTT module built on [VTTForge](https://github.com/vttforge/vttforge) — uses `SystemConfig` from `@vttforge/core` for typed settings, ships an example hook listener, and exposes a small public API on `game.modules.get("{{ID}}").api`.
+
+> **Note** — VTTForge is currently in pre-release and not yet published to npm. Dependencies in `package.json` will resolve once VTTForge ships its first public release.
+
+## Quick start
+
+```bash
+pnpm install
+pnpm build         # bundles dist/ — the deployable artefact
+pnpm dev           # vite build --watch
+```
+
+Symlink `dist/` into your Foundry data directory:
+
+```bash
+# macOS
+ln -s "$(pwd)/dist" "$HOME/Library/Application Support/FoundryVTT/Data/modules/{{ID}}"
+
+# Linux
+ln -s "$(pwd)/dist" "$HOME/.local/share/FoundryVTT/Data/modules/{{ID}}"
+
+# Windows (PowerShell, as admin)
+New-Item -ItemType SymbolicLink -Path "$env:APPDATA\FoundryVTT\Data\modules\{{ID}}" -Target "$(pwd)\dist"
+```
+
+Enable the module in any world.
+
+## What's inside
+
+| Path | Purpose |
+|---|---|
+| `module.json` | Manifest |
+| `scripts/main.mjs` | Entry point — settings registration, hook listeners, public API |
+| `styles/main.css` | Stylesheet, scoped under `.{{ID}}` |
+| `lang/en.json` | Localization strings |
+
+## Public API
+
+The module exposes its API on `game.modules.get("{{ID}}").api`:
+
+```js
+const api = game.modules.get("{{ID}}").api;
+api.greet("world");                   // returns "Hello, world!"
+api.getSetting("showWelcome");        // returns the current value
+```
+
+Extend `scripts/main.mjs` to add real methods — the example exists to show the registration pattern.
+
+## Releasing to Foundry
+
+Tag-push triggers `.github/workflows/release.yml` to build, zip, and attach `{{ID}}-<version>.zip` + `dist/module.json` to a GitHub Release. Point Foundry at the `latest/download/module.json` URL.
+
+```bash
+git tag v0.1.0
+git push --tags
+```
+
+## License
+
+{{LICENSE}} © {{YEAR}} {{AUTHOR}}

--- a/packages/cli/templates/module-js/_gitignore
+++ b/packages/cli/templates/module-js/_gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.turbo
+.vscode
+.DS_Store
+*.log

--- a/packages/cli/templates/module-js/lang/en.json
+++ b/packages/cli/templates/module-js/lang/en.json
@@ -1,0 +1,11 @@
+{
+  "{{LOCALE_PREFIX}}": {
+    "Settings": {
+      "showWelcome": {
+        "name": "Show welcome notification",
+        "hint": "Display a one-shot toast when {{TITLE}} loads in a world."
+      }
+    },
+    "Welcome": "{{TITLE}} loaded — try `game.modules.get(\"{{ID}}\").api.greet(\"GM\")` in the console."
+  }
+}

--- a/packages/cli/templates/module-js/module.json
+++ b/packages/cli/templates/module-js/module.json
@@ -1,0 +1,20 @@
+{
+  "id": "{{ID}}",
+  "title": "{{TITLE}}",
+  "description": "{{DESCRIPTION}}",
+  "version": "0.1.0",
+  "compatibility": {
+    "minimum": "{{FOUNDRY_MIN_VERSION}}",
+    "verified": "{{FOUNDRY_VERIFIED_VERSION}}"
+  },
+  "authors": [{ "name": "{{AUTHOR}}" }],
+  "esmodules": ["main.mjs"],
+  "styles": [{ "src": "styles/main.css" }],
+  "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
+  "flags": {
+    "hotReload": {
+      "extensions": ["css", "json"],
+      "paths": ["styles", "lang"]
+    }
+  }
+}

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "{{ID}}",
+  "version": "0.1.0",
+  "private": true,
+  "description": "{{DESCRIPTION}}",
+  "type": "module",
+  "license": "{{LICENSE}}",
+  "author": "{{AUTHOR}}",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch"
+  },
+  "dependencies": {
+    "@vttforge/core": "^0.3.0"
+  },
+  "devDependencies": {
+    "@vttforge/vite-plugin": "^0.1.0",
+    "vite": "^6.3.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/cli/templates/module-js/scripts/main.mjs
+++ b/packages/cli/templates/module-js/scripts/main.mjs
@@ -1,0 +1,65 @@
+/**
+ * {{TITLE}} — entry point.
+ *
+ * Demonstrates the typical Foundry module lifecycle:
+ *
+ * - `Hooks.once("init")` — register settings (here via `SystemConfig` from
+ *   `@vttforge/core` for typed access) and expose the public API on
+ *   `game.modules.get(MODULE_ID).api`.
+ * - `Hooks.once("ready")` — surface a one-shot notification if the user
+ *   opted in via settings.
+ * - `Hooks.on("renderActorSheetV2", ...)` — example hook listener that
+ *   tags any actor sheet with a discreet `.{{ID}}-badge` so you can verify
+ *   the module is actually attached without hunting through devtools.
+ */
+import { SystemConfig } from '@vttforge/core';
+
+const MODULE_ID = '{{ID}}';
+const settings = new SystemConfig(MODULE_ID);
+
+Hooks.once('init', () => {
+  settings.register('showWelcome', {
+    name: '{{LOCALE_PREFIX}}.Settings.showWelcome.name',
+    hint: '{{LOCALE_PREFIX}}.Settings.showWelcome.hint',
+    scope: 'client',
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+
+  const api = {
+    greet(name) {
+      return `Hello, ${name}!`;
+    },
+    getSetting(key) {
+      return settings.get(key);
+    },
+  };
+
+  const moduleHandle = game.modules.get(MODULE_ID);
+  if (moduleHandle) {
+    moduleHandle.api = api;
+  }
+});
+
+Hooks.once('ready', () => {
+  const shouldWelcome = settings.get('showWelcome');
+  if (shouldWelcome) {
+    ui.notifications?.info(game.i18n.localize('{{LOCALE_PREFIX}}.Welcome'));
+  }
+});
+
+Hooks.on('renderActorSheetV2', (_app, element) => {
+  // Decorative: tag the rendered sheet so it's obvious the module is
+  // active. Remove or replace with real behaviour once you start shipping
+  // module features.
+  const header = element.querySelector('.window-header .window-title');
+  if (header && !header.querySelector(`.{{ID}}-badge`)) {
+    const badge = document.createElement('span');
+    badge.className = '{{ID}}-badge';
+    // Double-quoted because `vttforge init` rejects `"` and `\` in the
+    // title — apostrophes in titles like "Daisy's Module" stay intact.
+    badge.textContent = "{{TITLE}}";
+    header.appendChild(badge);
+  }
+});

--- a/packages/cli/templates/module-js/styles/main.css
+++ b/packages/cli/templates/module-js/styles/main.css
@@ -1,0 +1,16 @@
+/**
+ * {{TITLE}} stylesheet.
+ *
+ * Scope all rules under the `.{{ID}}` namespace so they don't leak into
+ * other modules or the host system's sheets. Foundry's CSS cascade is
+ * already layered, but namespacing makes intent explicit.
+ */
+.{{ID}}-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.15em 0.5em;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.08);
+  font-size: 0.8em;
+}

--- a/packages/cli/templates/module-js/vite.config.mjs
+++ b/packages/cli/templates/module-js/vite.config.mjs
@@ -1,0 +1,13 @@
+import vttforge from '@vttforge/vite-plugin';
+import { defineConfig } from 'vite';
+
+/**
+ * Vite config for {{TITLE}}.
+ *
+ * `@vttforge/vite-plugin` owns the build contract for both systems and
+ * modules — `kind: 'module'` tells the plugin to write `dist/module.json`
+ * (instead of `system.json`) and to base chunk URLs at `/modules/{{ID}}/`.
+ */
+export default defineConfig({
+  plugins: [vttforge({ id: '{{ID}}', kind: 'module' })],
+});

--- a/packages/cli/templates/module-ts/.github/workflows/release.yml
+++ b/packages/cli/templates/module-ts/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: pnpm install
+
+      - name: Sync manifest version
+        run: |
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${{ steps.version.outputs.version }}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
+
+      - run: pnpm build
+
+      - name: Inject release URLs into manifest
+        run: |
+          node -e "const fs=require('fs');const path='dist/module.json';const m=JSON.parse(fs.readFileSync(path,'utf8'));m.manifest='https://github.com/${{ github.repository }}/releases/latest/download/module.json';m.download='https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/{{ID}}-${{ steps.version.outputs.version }}.zip';fs.writeFileSync(path,JSON.stringify(m,null,2)+'\n');"
+
+      - name: Build release zip
+        run: |
+          cd dist
+          zip -r ../{{ID}}-${{ steps.version.outputs.version }}.zip .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            {{ID}}-${{ steps.version.outputs.version }}.zip
+            dist/module.json
+          generate_release_notes: true
+          body: |
+            ## Foundry installation
+
+            Install via Foundry's setup wizard with this manifest URL:
+
+            ```
+            https://github.com/${{ github.repository }}/releases/latest/download/module.json
+            ```

--- a/packages/cli/templates/module-ts/README.md
+++ b/packages/cli/templates/module-ts/README.md
@@ -1,0 +1,64 @@
+# {{TITLE}}
+
+{{DESCRIPTION}}
+
+A Foundry VTT module built on [VTTForge](https://github.com/vttforge/vttforge) — uses `SystemConfig` from `@vttforge/core` for typed settings, ships an example hook listener, and exposes a small public API on `game.modules.get("{{ID}}").api`.
+
+> **Note** — VTTForge is currently in pre-release and not yet published to npm. Dependencies in `package.json` will resolve once VTTForge ships its first public release.
+
+## Quick start
+
+```bash
+pnpm install
+pnpm build         # bundles dist/ — the deployable artefact
+pnpm dev           # vite build --watch
+```
+
+Symlink `dist/` into your Foundry data directory:
+
+```bash
+# macOS
+ln -s "$(pwd)/dist" "$HOME/Library/Application Support/FoundryVTT/Data/modules/{{ID}}"
+
+# Linux
+ln -s "$(pwd)/dist" "$HOME/.local/share/FoundryVTT/Data/modules/{{ID}}"
+
+# Windows (PowerShell, as admin)
+New-Item -ItemType SymbolicLink -Path "$env:APPDATA\FoundryVTT\Data\modules\{{ID}}" -Target "$(pwd)\dist"
+```
+
+Enable the module in any world.
+
+## What's inside
+
+| Path | Purpose |
+|---|---|
+| `module.json` | Manifest |
+| `scripts/main.ts` | Entry point — settings registration, hook listeners, public API |
+| `styles/main.css` | Stylesheet, scoped under `.{{ID}}` |
+| `lang/en.json` | Localization strings |
+
+## Public API
+
+The module exposes its API on `game.modules.get("{{ID}}").api`:
+
+```ts
+const api = game.modules.get("{{ID}}").api;
+api.greet("world");                   // returns "Hello, world!"
+api.getSetting("showWelcome");        // returns the current value
+```
+
+Extend `scripts/main.ts` to add real methods — the example exists to show the registration pattern.
+
+## Releasing to Foundry
+
+Tag-push triggers `.github/workflows/release.yml` to build, zip, and attach `{{ID}}-<version>.zip` + `dist/module.json` to a GitHub Release. Point Foundry at the `latest/download/module.json` URL.
+
+```bash
+git tag v0.1.0
+git push --tags
+```
+
+## License
+
+{{LICENSE}} © {{YEAR}} {{AUTHOR}}

--- a/packages/cli/templates/module-ts/_gitignore
+++ b/packages/cli/templates/module-ts/_gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.turbo
+.vscode
+.DS_Store
+*.log

--- a/packages/cli/templates/module-ts/lang/en.json
+++ b/packages/cli/templates/module-ts/lang/en.json
@@ -1,0 +1,11 @@
+{
+  "{{LOCALE_PREFIX}}": {
+    "Settings": {
+      "showWelcome": {
+        "name": "Show welcome notification",
+        "hint": "Display a one-shot toast when {{TITLE}} loads in a world."
+      }
+    },
+    "Welcome": "{{TITLE}} loaded — try `game.modules.get(\"{{ID}}\").api.greet(\"GM\")` in the console."
+  }
+}

--- a/packages/cli/templates/module-ts/module.json
+++ b/packages/cli/templates/module-ts/module.json
@@ -1,0 +1,20 @@
+{
+  "id": "{{ID}}",
+  "title": "{{TITLE}}",
+  "description": "{{DESCRIPTION}}",
+  "version": "0.1.0",
+  "compatibility": {
+    "minimum": "{{FOUNDRY_MIN_VERSION}}",
+    "verified": "{{FOUNDRY_VERIFIED_VERSION}}"
+  },
+  "authors": [{ "name": "{{AUTHOR}}" }],
+  "esmodules": ["main.mjs"],
+  "styles": [{ "src": "styles/main.css" }],
+  "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
+  "flags": {
+    "hotReload": {
+      "extensions": ["css", "json"],
+      "paths": ["styles", "lang"]
+    }
+  }
+}

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "{{ID}}",
+  "version": "0.1.0",
+  "private": true,
+  "description": "{{DESCRIPTION}}",
+  "type": "module",
+  "license": "{{LICENSE}}",
+  "author": "{{AUTHOR}}",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@vttforge/core": "^0.3.0"
+  },
+  "devDependencies": {
+    "@vttforge/vite-plugin": "^0.1.0",
+    "typescript": "^5.4.0",
+    "vite": "^6.3.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/cli/templates/module-ts/scripts/foundry-globals.ts
+++ b/packages/cli/templates/module-ts/scripts/foundry-globals.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal Foundry runtime globals.
+ *
+ * These declarations let the scaffold compile cleanly without an external
+ * type package. Replace with `fvtt-types` (community-maintained, pinned to
+ * a known-working commit SHA) or `@vttforge/types` (coming in a later
+ * VTTForge release) for full type coverage.
+ */
+
+declare global {
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const game: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const CONFIG: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const Hooks: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const ui: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const foundry: any;
+}
+
+export {};

--- a/packages/cli/templates/module-ts/scripts/main.ts
+++ b/packages/cli/templates/module-ts/scripts/main.ts
@@ -1,0 +1,71 @@
+/**
+ * {{TITLE}} — entry point.
+ *
+ * Demonstrates the typical Foundry module lifecycle:
+ *
+ * - `Hooks.once("init")` — register settings (here via `SystemConfig` from
+ *   `@vttforge/core` for typed access) and expose the public API on
+ *   `game.modules.get(MODULE_ID).api`.
+ * - `Hooks.once("ready")` — surface a one-shot notification if the user
+ *   opted in via settings.
+ * - `Hooks.on("renderActorSheetV2", ...)` — example hook listener that
+ *   tags any actor sheet with a discreet `.{{ID}}-badge` so you can verify
+ *   the module is actually attached without hunting through devtools.
+ */
+import './foundry-globals.js';
+import { SystemConfig } from '@vttforge/core';
+
+const MODULE_ID = '{{ID}}';
+const settings = new SystemConfig(MODULE_ID);
+
+interface ModuleApi {
+  greet(name: string): string;
+  getSetting<T>(key: string): T;
+}
+
+Hooks.once('init', () => {
+  settings.register('showWelcome', {
+    name: '{{LOCALE_PREFIX}}.Settings.showWelcome.name',
+    hint: '{{LOCALE_PREFIX}}.Settings.showWelcome.hint',
+    scope: 'client',
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+
+  const api: ModuleApi = {
+    greet(name: string): string {
+      return `Hello, ${name}!`;
+    },
+    getSetting<T>(key: string): T {
+      return settings.get(key) as T;
+    },
+  };
+
+  const moduleHandle = game.modules.get(MODULE_ID);
+  if (moduleHandle) {
+    moduleHandle.api = api;
+  }
+});
+
+Hooks.once('ready', () => {
+  const shouldWelcome = settings.get<boolean>('showWelcome');
+  if (shouldWelcome) {
+    ui.notifications?.info(game.i18n.localize('{{LOCALE_PREFIX}}.Welcome'));
+  }
+});
+
+Hooks.on('renderActorSheetV2', (_app: unknown, element: HTMLElement) => {
+  // Decorative: tag the rendered sheet so it's obvious the module is
+  // active. Remove or replace with real behaviour once you start shipping
+  // module features.
+  const header = element.querySelector('.window-header .window-title');
+  if (header && !header.querySelector(`.{{ID}}-badge`)) {
+    const badge = document.createElement('span');
+    badge.className = '{{ID}}-badge';
+    // Double-quoted because `vttforge init` rejects `"` and `\` in the
+    // title — apostrophes in titles like "Daisy's Module" stay intact.
+    badge.textContent = "{{TITLE}}";
+    header.appendChild(badge);
+  }
+});

--- a/packages/cli/templates/module-ts/styles/main.css
+++ b/packages/cli/templates/module-ts/styles/main.css
@@ -1,0 +1,16 @@
+/**
+ * {{TITLE}} stylesheet.
+ *
+ * Scope all rules under the `.{{ID}}` namespace so they don't leak into
+ * other modules or the host system's sheets. Foundry's CSS cascade is
+ * already layered, but namespacing makes intent explicit.
+ */
+.{{ID}}-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.15em 0.5em;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.08);
+  font-size: 0.8em;
+}

--- a/packages/cli/templates/module-ts/tsconfig.json
+++ b/packages/cli/templates/module-ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["scripts/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/templates/module-ts/vite.config.mjs
+++ b/packages/cli/templates/module-ts/vite.config.mjs
@@ -1,0 +1,13 @@
+import vttforge from '@vttforge/vite-plugin';
+import { defineConfig } from 'vite';
+
+/**
+ * Vite config for {{TITLE}}.
+ *
+ * `@vttforge/vite-plugin` owns the build contract for both systems and
+ * modules — `kind: 'module'` tells the plugin to write `dist/module.json`
+ * (instead of `system.json`) and to base chunk URLs at `/modules/{{ID}}/`.
+ */
+export default defineConfig({
+  plugins: [vttforge({ id: '{{ID}}', kind: 'module', entry: 'scripts/main.ts' })],
+});

--- a/packages/cli/templates/system-js/.github/workflows/release.yml
+++ b/packages/cli/templates/system-js/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: pnpm install
+
+      - name: Sync manifest version
+        run: |
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${{ steps.version.outputs.version }}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
+
+      - run: pnpm build
+
+      - name: Inject release URLs into manifest
+        run: |
+          node -e "const fs=require('fs');const path='dist/system.json';const m=JSON.parse(fs.readFileSync(path,'utf8'));m.manifest='https://github.com/${{ github.repository }}/releases/latest/download/system.json';m.download='https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/{{ID}}-${{ steps.version.outputs.version }}.zip';fs.writeFileSync(path,JSON.stringify(m,null,2)+'\n');"
+
+      - name: Build release zip
+        run: |
+          cd dist
+          zip -r ../{{ID}}-${{ steps.version.outputs.version }}.zip .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            {{ID}}-${{ steps.version.outputs.version }}.zip
+            dist/system.json
+          generate_release_notes: true
+          body: |
+            ## Foundry installation
+
+            Install via Foundry's setup wizard with this manifest URL:
+
+            ```
+            https://github.com/${{ github.repository }}/releases/latest/download/system.json
+            ```

--- a/packages/cli/templates/system-js/README.md
+++ b/packages/cli/templates/system-js/README.md
@@ -1,0 +1,61 @@
+# {{TITLE}}
+
+{{DESCRIPTION}}
+
+Built on [VTTForge](https://github.com/vttforge/vttforge) — typed data models, declarative sheet boilerplate, migration runner, error catalogue, and a Vite-based build pipeline.
+
+> **Note** — VTTForge is currently in pre-release and not yet published to npm. The dependencies in `package.json` (`@vttforge/core`, `@vttforge/styles`, `@vttforge/vite-plugin`) will resolve once VTTForge ships its first public release. Until then, work from a local checkout: `pnpm link --global` from each VTTForge package, then `pnpm link --global @vttforge/core @vttforge/styles @vttforge/vite-plugin` here.
+
+## Quick start
+
+```bash
+pnpm install
+pnpm build         # bundles dist/ — the deployable artefact
+pnpm dev           # vite build --watch — rebuilds dist/ on every edit
+```
+
+Symlink the built `dist/` into your Foundry data directory:
+
+```bash
+# macOS
+ln -s "$(pwd)/dist" "$HOME/Library/Application Support/FoundryVTT/Data/systems/{{ID}}"
+
+# Linux
+ln -s "$(pwd)/dist" "$HOME/.local/share/FoundryVTT/Data/systems/{{ID}}"
+
+# Windows (PowerShell, as admin)
+New-Item -ItemType SymbolicLink -Path "$env:APPDATA\FoundryVTT\Data\systems\{{ID}}" -Target "$(pwd)\dist"
+```
+
+Then launch Foundry, create a world that uses **{{TITLE}}**, and open a character — the sheet is the `CharacterSheet` shipped in `scripts/sheets/`.
+
+## What's inside
+
+| Path | Purpose |
+|---|---|
+| `system.json` | Manifest (id, compatibility, document types, manifest-side sanitization paths) |
+| `template.json` | Foundry document type declarations (Actor + Item subtypes) |
+| `scripts/main.mjs` | Entry point — one call to `registerSystem` from `@vttforge/core` |
+| `scripts/data/*.mjs` | Typed data models (`BaseTypeDataModel()` from `@vttforge/core`) |
+| `scripts/sheets/*.mjs` | Sheet boilerplate eliminators (`BaseActorSheet()` / `BaseItemSheet()`) |
+| `scripts/migrations.mjs` | `createMigrationRunner()` — versioned data migrations |
+| `templates/` | Handlebars templates for sheets |
+| `styles/main.css` | Stylesheet — imports `@vttforge/styles` as the design system base |
+| `lang/en.json` | Localization strings |
+
+## Releasing to Foundry
+
+Tag-push triggers `.github/workflows/release.yml`, which builds the system, zips `dist/`, and attaches both `{{ID}}-<version>.zip` and `dist/system.json` to a GitHub Release.
+
+```bash
+git tag v0.1.0
+git push --tags
+```
+
+Foundry installs from the `system.json` URL on the Release — point users at the `latest/download/system.json` URL in the release notes so they auto-update on every tag.
+
+For foundryvtt.com submissions, submit the same manifest URL pattern.
+
+## License
+
+{{LICENSE}} © {{YEAR}} {{AUTHOR}}

--- a/packages/cli/templates/system-js/_gitignore
+++ b/packages/cli/templates/system-js/_gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.turbo
+.vscode
+.DS_Store
+*.log

--- a/packages/cli/templates/system-js/lang/en.json
+++ b/packages/cli/templates/system-js/lang/en.json
@@ -1,0 +1,55 @@
+{
+  "TYPES.Actor.character": "Character",
+  "TYPES.Item.gear": "Gear",
+
+  "{{LOCALE_PREFIX}}.System.title": "{{TITLE}}",
+  "{{LOCALE_PREFIX}}.System.description": "{{DESCRIPTION}}",
+
+  "{{LOCALE_PREFIX}}.Sheet.Character.title": "Character",
+  "{{LOCALE_PREFIX}}.Sheet.Gear.title": "Gear",
+  "{{LOCALE_PREFIX}}.Sheet.NamePlaceholder": "Name…",
+  "{{LOCALE_PREFIX}}.Sheet.Level": "LV",
+  "{{LOCALE_PREFIX}}.Sheet.AbilityScores": "Ability scores",
+  "{{LOCALE_PREFIX}}.Sheet.Inventory": "Inventory",
+  "{{LOCALE_PREFIX}}.Sheet.Biography": "Biography",
+  "{{LOCALE_PREFIX}}.Sheet.NewGear": "New gear",
+  "{{LOCALE_PREFIX}}.Sheet.NewGearName": "New Gear",
+  "{{LOCALE_PREFIX}}.Sheet.NoGear": "No gear yet — drag items here or click New gear.",
+  "{{LOCALE_PREFIX}}.Sheet.Delete": "Delete",
+
+  "{{LOCALE_PREFIX}}.Sheet.Quick.HP": "HP",
+  "{{LOCALE_PREFIX}}.Sheet.Quick.AC": "AC",
+  "{{LOCALE_PREFIX}}.Sheet.Quick.SPD": "SPD",
+  "{{LOCALE_PREFIX}}.Sheet.Quick.INIT": "INIT",
+
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.abilities": "Abilities",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.inventory": "Inventory",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.spells": "Spells",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.biography": "Biography",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.details": "Details",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.description": "Description",
+  "{{LOCALE_PREFIX}}.Sheet.Spells": "Spells",
+  "{{LOCALE_PREFIX}}.Sheet.SpellsEmpty": "Spells slot reserved for a follow-up release.",
+
+  "{{LOCALE_PREFIX}}.Sheet.Roll.label": "Roll",
+  "{{LOCALE_PREFIX}}.Sheet.Roll.flavor": "{ability} check",
+  "{{LOCALE_PREFIX}}.Sheet.Drop.label": "Drop item to add",
+  "{{LOCALE_PREFIX}}.Sheet.Drop.rejected": "Cannot drop {type} items here — only gear is accepted.",
+
+  "{{LOCALE_PREFIX}}.Ability.str": "Strength",
+  "{{LOCALE_PREFIX}}.Ability.dex": "Dexterity",
+  "{{LOCALE_PREFIX}}.Ability.con": "Constitution",
+  "{{LOCALE_PREFIX}}.Ability.int": "Intelligence",
+  "{{LOCALE_PREFIX}}.Ability.wis": "Wisdom",
+  "{{LOCALE_PREFIX}}.Ability.cha": "Charisma",
+
+  "{{LOCALE_PREFIX}}.Gear.Quantity": "Quantity",
+  "{{LOCALE_PREFIX}}.Gear.Weight": "Weight (lb)",
+  "{{LOCALE_PREFIX}}.Gear.Kind": "Kind",
+  "{{LOCALE_PREFIX}}.Gear.Kind.equipped": "equipped",
+  "{{LOCALE_PREFIX}}.Gear.Kind.valued": "valued",
+  "{{LOCALE_PREFIX}}.Gear.Kind.stowed": "stowed",
+
+  "{{LOCALE_PREFIX}}.Settings.showTutorial.name": "Show tutorial",
+  "{{LOCALE_PREFIX}}.Settings.showTutorial.hint": "Display the welcome banner on world load."
+}

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "{{ID}}",
+  "version": "0.1.0",
+  "private": true,
+  "description": "{{DESCRIPTION}}",
+  "type": "module",
+  "license": "{{LICENSE}}",
+  "author": "{{AUTHOR}}",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch"
+  },
+  "dependencies": {
+    "@vttforge/core": "^0.3.0",
+    "@vttforge/styles": "^0.2.0"
+  },
+  "devDependencies": {
+    "@vttforge/vite-plugin": "^0.1.0",
+    "vite": "^6.3.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/cli/templates/system-js/scripts/data/character-data.mjs
+++ b/packages/cli/templates/system-js/scripts/data/character-data.mjs
@@ -1,0 +1,65 @@
+/**
+ * CharacterData — typed schema for the `character` Actor type.
+ *
+ * Quick stats are HP / AC / SPD / INIT, abilities are the six classic
+ * scores (str/dex/con/int/wis/cha). Derived state (modifiers, max HP,
+ * armor class, initiative) is computed in-memory in `prepareDerivedData`.
+ *
+ * `prepareBaseData` initialises fields that Active Effects need to mutate
+ * (base max HP before any AE bonus); `prepareDerivedData` then computes
+ * the AE-aware values (modifiers, percentages, totals). Never write to the
+ * database in either hook — they're purely in-memory derivations.
+ */
+import { BaseTypeDataModel, fields } from '@vttforge/core';
+
+export class CharacterData extends BaseTypeDataModel() {
+  static defineSchema() {
+    const f = fields();
+    return {
+      level: new f.NumberField({
+        required: true,
+        integer: true,
+        min: 1,
+        max: 20,
+        initial: 1,
+      }),
+      speed: new f.NumberField({
+        required: true,
+        integer: true,
+        min: 0,
+        initial: 30,
+      }),
+      abilities: new f.SchemaField({
+        str: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        dex: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        con: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        int: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        wis: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        cha: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+      }),
+      health: new f.SchemaField({
+        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
+        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
+      }),
+      power: new f.SchemaField({
+        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
+        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
+      }),
+      biography: new f.HTMLField(),
+    };
+  }
+
+  prepareDerivedData() {
+    for (const [key, value] of Object.entries(this.abilities)) {
+      const score = typeof value === 'number' ? value : (value?.value ?? 10);
+      const mod = Math.floor((score - 10) / 2);
+      this.abilities[key] = { value: score, mod };
+    }
+
+    const conMod = this.abilities.con.mod;
+    this.health.max = 10 + this.level + conMod;
+
+    this.armorClass = 10 + this.abilities.dex.mod;
+    this.initiative = this.abilities.dex.mod;
+  }
+}

--- a/packages/cli/templates/system-js/scripts/data/gear-data.mjs
+++ b/packages/cli/templates/system-js/scripts/data/gear-data.mjs
@@ -1,0 +1,35 @@
+/**
+ * GearData — typed schema for the `gear` Item type.
+ *
+ * `kind` is an enum that drives the inventory pill on the character sheet:
+ * `equipped` and `valued` render with the accent pill, `stowed` renders
+ * muted.
+ */
+import { BaseTypeDataModel, fields } from '@vttforge/core';
+
+const GEAR_KINDS = /** @type {const} */ (['equipped', 'valued', 'stowed']);
+
+export class GearData extends BaseTypeDataModel() {
+  static defineSchema() {
+    const f = fields();
+    return {
+      quantity: new f.NumberField({
+        required: true,
+        integer: true,
+        min: 0,
+        initial: 1,
+      }),
+      weight: new f.NumberField({
+        required: true,
+        min: 0,
+        initial: 0,
+      }),
+      kind: new f.StringField({
+        required: true,
+        choices: GEAR_KINDS,
+        initial: 'stowed',
+      }),
+      description: new f.HTMLField(),
+    };
+  }
+}

--- a/packages/cli/templates/system-js/scripts/main.mjs
+++ b/packages/cli/templates/system-js/scripts/main.mjs
@@ -1,0 +1,79 @@
+/**
+ * {{TITLE}} — entry point.
+ *
+ * `registerSystem` from `@vttforge/core` replaces the ~60-line
+ * `Hooks.once("init", ...)` block most systems copy-paste from each other:
+ * data model registration, document class swap, initiative formula, sheet
+ * registration, settings, and the `Hooks.once("ready", ...)` migration
+ * gate are all wired by one call.
+ */
+import { registerSystem, SystemConfig, VttfError } from '@vttforge/core';
+import { CharacterData } from './data/character-data.mjs';
+import { GearData } from './data/gear-data.mjs';
+import { migrations } from './migrations.mjs';
+import { CharacterSheet } from './sheets/character-sheet.mjs';
+import { GearSheet } from './sheets/gear-sheet.mjs';
+
+const SYSTEM_ID = '{{ID}}';
+
+const settings = new SystemConfig(SYSTEM_ID);
+
+try {
+  registerSystem({
+    id: SYSTEM_ID,
+    actorDataModels: { character: CharacterData },
+    itemDataModels: { gear: GearData },
+    combat: {
+      initiative: { formula: '1d20 + @abilities.dex.mod', decimals: 2 },
+    },
+    onAfterInit: () => {
+      settings.register('showTutorial', {
+        name: '{{LOCALE_PREFIX}}.Settings.showTutorial.name',
+        hint: '{{LOCALE_PREFIX}}.Settings.showTutorial.hint',
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: true,
+      });
+
+      // Register the schemaVersion setting so migrations.run() has somewhere
+      // to read and write the version flag.
+      migrations.register();
+
+      const { Actors, Items } = foundry.documents.collections;
+      Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
+      Actors.registerSheet(SYSTEM_ID, CharacterSheet, {
+        types: ['character'],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Character.title',
+      });
+      Items.unregisterSheet('core', foundry.applications.sheets.ItemSheetV2);
+      Items.registerSheet(SYSTEM_ID, GearSheet, {
+        types: ['gear'],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Gear.title',
+      });
+    },
+    onReady: async () => {
+      if (!game.user?.isGM) return;
+      try {
+        const ran = await migrations.run();
+        if (ran.length > 0) {
+          console.info(`[${SYSTEM_ID}] applied migrations:`, ran.join(', '));
+        }
+      } catch (err) {
+        if (err instanceof VttfError) {
+          ui.notifications?.error(`[${err.code}] ${err.message} — see ${err.docsUrl}`, {
+            permanent: true,
+          });
+        }
+        throw err;
+      }
+    },
+  });
+} catch (err) {
+  if (err instanceof VttfError) {
+    console.error(`[${err.code}] ${err.message} — see ${err.docsUrl}`);
+  }
+  throw err;
+}

--- a/packages/cli/templates/system-js/scripts/migrations.mjs
+++ b/packages/cli/templates/system-js/scripts/migrations.mjs
@@ -1,0 +1,43 @@
+/**
+ * Migration registry for {{TITLE}}.
+ *
+ * Each entry is idempotent — safe to re-run if a prior pass failed
+ * mid-sequence. `createMigrationRunner` reads the version flag declared in
+ * `system.json` (`flags.{{ID}}.needsMigrationVersion`), runs every
+ * migration whose version is newer than what's stored in the world's
+ * `schemaVersion` setting, and persists the new high-water mark on success.
+ */
+import { createMigrationRunner } from '@vttforge/core';
+
+const SYSTEM_ID = '{{ID}}';
+
+/**
+ * v0.1.0 — first real schema. Add real migration logic here as soon as the
+ * first breaking schema change ships. Until then, this is a no-op example
+ * that proves the runner end-to-end.
+ */
+async function migrateToV0_1_0() {
+  // Iterate world documents and rewrite legacy fields here. Example:
+  //
+  //   const actors = game.actors?.filter((a) => a.type === 'character') ?? [];
+  //   for (const actor of actors) {
+  //     const legacy = actor.system?.bio;
+  //     if (typeof legacy !== 'string') continue;
+  //     await actor.update({
+  //       'system.biography': legacy,
+  //       '-=system.bio': null,
+  //     });
+  //   }
+}
+
+export const migrations = createMigrationRunner({
+  systemId: SYSTEM_ID,
+  compatibleVersion: '0.0.0',
+  migrations: [
+    {
+      version: '0.1.0',
+      description: 'initial schema — placeholder for first breaking change',
+      fn: migrateToV0_1_0,
+    },
+  ],
+});

--- a/packages/cli/templates/system-js/scripts/sheets/character-sheet.mjs
+++ b/packages/cli/templates/system-js/scripts/sheets/character-sheet.mjs
@@ -1,0 +1,164 @@
+/**
+ * CharacterSheet — tabbed character sheet built on `BaseActorSheet()` from
+ * `@vttforge/core`. Demonstrates the full boilerplate-elimination surface:
+ *
+ * - `static TABS` — `context.tabs.<group>` auto-populated by BaseActorSheet
+ *   (no manual `_prepareTabs` call).
+ * - `static DRAG_DROP` — wires `foundry.applications.ux.DragDrop` on first
+ *   render with `isEditable`-gated permissions.
+ * - Typed `onDropItem(item, event)` — pre-resolves UUIDs, rejects
+ *   non-`gear` items with a notification, lets `gear` flow through to
+ *   Foundry's default `_onDropItem` by returning `undefined`.
+ */
+import { BaseActorSheet } from '@vttforge/core';
+
+const SYSTEM_ID = '{{ID}}';
+
+export class CharacterSheet extends BaseActorSheet() {
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    super.DEFAULT_OPTIONS,
+    {
+      id: '{{ID}}-character',
+      classes: ['{{ID}}', 'sheet', 'actor', 'character'],
+      window: {
+        title: '{{LOCALE_PREFIX}}.Sheet.Character.title',
+        icon: 'fa-solid fa-user',
+      },
+      position: { width: 640, height: 700 },
+      actions: {
+        rollAbility: CharacterSheet._onRollAbility,
+        createGear: CharacterSheet._onCreateGear,
+        deleteItem: CharacterSheet._onDeleteItem,
+      },
+    },
+    { inplace: false },
+  );
+
+  static PARTS = {
+    sheet: {
+      template: `systems/${SYSTEM_ID}/templates/actor/character-sheet.hbs`,
+    },
+  };
+
+  static TABS = {
+    primary: {
+      tabs: [
+        {
+          id: 'abilities',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.abilities',
+          icon: 'fa-solid fa-dumbbell',
+        },
+        {
+          id: 'inventory',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.inventory',
+          icon: 'fa-solid fa-sack',
+        },
+        {
+          id: 'spells',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.spells',
+          icon: 'fa-solid fa-wand-magic-sparkles',
+        },
+        {
+          id: 'biography',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.biography',
+          icon: 'fa-solid fa-feather',
+        },
+      ],
+      initial: 'abilities',
+    },
+  };
+
+  static DRAG_DROP = [
+    {
+      dragSelector: '.sh-item[draggable=true]',
+      dropSelector: '.sh-body',
+    },
+  ];
+
+  /** @override */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const actor = this.document;
+    const system = actor.system;
+    const abilityLabels = {
+      str: '{{LOCALE_PREFIX}}.Ability.str',
+      dex: '{{LOCALE_PREFIX}}.Ability.dex',
+      con: '{{LOCALE_PREFIX}}.Ability.con',
+      int: '{{LOCALE_PREFIX}}.Ability.int',
+      wis: '{{LOCALE_PREFIX}}.Ability.wis',
+      cha: '{{LOCALE_PREFIX}}.Ability.cha',
+    };
+    context.actor = actor;
+    context.system = system;
+    context.isEditable = this.isEditable;
+    context.abilities = Object.entries(system.abilities ?? {}).map(([key, data]) => ({
+      key,
+      label: game.i18n.localize(abilityLabels[key] ?? key),
+      value: data?.value ?? data,
+      mod: data?.mod ?? 0,
+    }));
+    context.gear = actor.items
+      .filter((item) => item.type === 'gear')
+      .map((item) => ({
+        id: item.id,
+        name: item.name,
+        img: item.img,
+        kind: item.system?.kind ?? 'stowed',
+        quantity: item.system?.quantity ?? 1,
+        weight: item.system?.weight ?? 0,
+        description: item.system?.description ?? '',
+      }));
+    context.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      system.biography ?? '',
+      { relativeTo: actor, secrets: actor.isOwner },
+    );
+    return context;
+  }
+
+  /** Reject non-gear drops with a notification; let gear fall through. */
+  async onDropItem(item, _event) {
+    if (item?.type !== 'gear') {
+      ui.notifications?.warn(
+        game.i18n.format('{{LOCALE_PREFIX}}.Sheet.Drop.rejected', { type: item?.type ?? 'unknown' }),
+      );
+      return false;
+    }
+    return undefined;
+  }
+
+  static async _onRollAbility(_event, target) {
+    const key = target?.dataset?.ability;
+    if (!key) return;
+    const actor = this.document;
+    const mod = actor.system.abilities?.[key]?.mod ?? 0;
+    const roll = new Roll(`1d20 + ${mod}`, actor.getRollData());
+    await roll.evaluate();
+    await roll.toMessage({
+      speaker: ChatMessage.getSpeaker({ actor }),
+      flavor: game.i18n.format('{{LOCALE_PREFIX}}.Sheet.Roll.flavor', {
+        ability: game.i18n.localize(`{{LOCALE_PREFIX}}.Ability.${key}`),
+      }),
+    });
+  }
+
+  static async _onCreateGear(_event, _target) {
+    const cls = CONFIG.Item.documentClass;
+    const parent = this.document;
+    await cls.create(
+      { name: game.i18n.localize('{{LOCALE_PREFIX}}.Sheet.NewGearName'), type: 'gear' },
+      { parent, renderSheet: true },
+    );
+  }
+
+  static async _onDeleteItem(_event, target) {
+    const row = target?.closest('[data-item-id]');
+    const id = row?.dataset?.itemId;
+    if (!id) return;
+    const item = this.document.items.get(id);
+    await item?.delete();
+  }
+}

--- a/packages/cli/templates/system-js/scripts/sheets/gear-sheet.mjs
+++ b/packages/cli/templates/system-js/scripts/sheets/gear-sheet.mjs
@@ -1,0 +1,65 @@
+/**
+ * GearSheet — minimal Item sheet built on `BaseItemSheet()` from
+ * `@vttforge/core`. Single PART, single TABS group, no DRAG_DROP — exercises
+ * the mirror surface of BaseActorSheet on ItemSheetV2.
+ */
+import { BaseItemSheet } from '@vttforge/core';
+
+const SYSTEM_ID = '{{ID}}';
+
+export class GearSheet extends BaseItemSheet() {
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    super.DEFAULT_OPTIONS,
+    {
+      id: '{{ID}}-gear',
+      classes: ['{{ID}}', 'sheet', 'item', 'gear'],
+      window: {
+        title: '{{LOCALE_PREFIX}}.Sheet.Gear.title',
+        icon: 'fa-solid fa-sack',
+      },
+      position: { width: 480, height: 420 },
+    },
+    { inplace: false },
+  );
+
+  static PARTS = {
+    sheet: {
+      template: `systems/${SYSTEM_ID}/templates/item/gear-sheet.hbs`,
+    },
+  };
+
+  static TABS = {
+    primary: {
+      tabs: [
+        {
+          id: 'details',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.details',
+          icon: 'fa-solid fa-list',
+        },
+        {
+          id: 'description',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.description',
+          icon: 'fa-solid fa-feather',
+        },
+      ],
+      initial: 'details',
+    },
+  };
+
+  /** @override */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const item = this.document;
+    context.item = item;
+    context.system = item.system;
+    context.isEditable = this.isEditable;
+    context.enrichedDescription =
+      await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+        item.system?.description ?? '',
+        { relativeTo: item, secrets: item.isOwner },
+      );
+    return context;
+  }
+}

--- a/packages/cli/templates/system-js/styles/main.css
+++ b/packages/cli/templates/system-js/styles/main.css
@@ -1,0 +1,495 @@
+@import "@vttforge/styles";
+
+/*
+ * {{ID}} styles — implements the .sh-* class system from the
+ * canonical Figma reference (character-sheet.jsx + Theme Explorations.html)
+ * on top of @vttforge/styles. Tokens come from the Forge theme; no other
+ * theme is hand-rolled here (consumers swap themes by overriding --vttf-*).
+ *
+ * Per foundry-vtt-system-dev "Styling & Themes" rule #3, component CSS stays
+ * UNLAYERED so it wins over Foundry's @layer applications without specificity
+ * wars. Scoped under .{{ID}} so nothing leaks into core Foundry UI.
+ */
+
+/* Opaque sheet bg — Foundry's ApplicationV2 default is transparent. */
+.{{ID}}.sheet,
+.{{ID}} .window-content {
+  background: var(--vttf-bg);
+  opacity: 1;
+}
+
+.{{ID}}.sheet {
+  color: var(--vttf-text);
+  font-family: var(--vttf-font-body, system-ui, sans-serif);
+}
+
+.{{ID}}.sheet form {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+/* ════════ HEAD (.sh-head) ════════ */
+.{{ID}} .sh-head {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: var(--vttf-space-4);
+  padding: var(--vttf-space-4);
+  background: var(--vttf-surface);
+  border-bottom: 1px solid var(--vttf-border);
+}
+
+.{{ID}} .sh-portrait {
+  width: 88px;
+  height: 110px;
+  border-radius: var(--vttf-radius-md);
+  background: var(--vttf-surface-2);
+  object-fit: cover;
+  cursor: pointer;
+}
+
+.{{ID}} .sh-id {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.{{ID}} .sh-id-top {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.{{ID}} .sh-name {
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--vttf-text);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid transparent;
+  padding: 0;
+}
+
+.{{ID}} .sh-name:focus {
+  border-bottom-color: var(--vttf-border-strong);
+  outline: none;
+}
+
+.{{ID}} .sh-sub {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vttf-space-2);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-muted);
+}
+
+.{{ID}} .sh-sub input {
+  width: 3.5rem;
+  text-align: center;
+  background: transparent;
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  color: var(--vttf-text);
+  font: inherit;
+  padding: 2px 6px;
+}
+
+.{{ID}} .sh-quick {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--vttf-space-3);
+}
+
+.{{ID}} .sh-quick .q {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.{{ID}} .sh-quick .qv {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--vttf-ember-glow);
+}
+
+.{{ID}} .sh-quick .qv input {
+  width: 2.5rem;
+  font: inherit;
+  color: inherit;
+  text-align: center;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.{{ID}} .sh-quick .qv-sep {
+  font-size: 14px;
+  color: var(--vttf-text-faint);
+}
+
+.{{ID}} .sh-quick .qv-max {
+  font-size: 14px;
+  color: var(--vttf-text-muted);
+}
+
+.{{ID}} .sh-quick .qk {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+}
+
+/* ════════ TABS (.sh-tabs) ════════ */
+.{{ID}} .sh-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 var(--vttf-space-4);
+  background: var(--vttf-bg-elevated);
+  border-bottom: 1px solid var(--vttf-border);
+}
+
+.{{ID}} .sh-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 14px;
+  cursor: pointer;
+  color: var(--vttf-text-muted);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  font-family: var(--vttf-font-body);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.{{ID}} .sh-tab:hover {
+  color: var(--vttf-text);
+}
+
+.{{ID}} .sh-tab.on,
+.{{ID}} .sh-tab.active {
+  color: var(--vttf-text);
+  border-bottom-color: var(--vttf-ember);
+}
+
+/* ════════ BODY (.sh-body) ════════ */
+.{{ID}} .sh-body {
+  flex: 1;
+  overflow: auto;
+  padding: var(--vttf-space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--vttf-space-4);
+  min-height: 320px;
+}
+
+.{{ID}} .sh-body .tab {
+  display: none;
+  flex-direction: column;
+  gap: var(--vttf-space-3);
+}
+
+.{{ID}} .sh-body .tab.active {
+  display: flex;
+}
+
+.{{ID}} .sh-section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vttf-space-3);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+  font-weight: 600;
+  margin: 0;
+}
+
+.{{ID}} .sh-section-title::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--vttf-border);
+}
+
+.{{ID}} .sh-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--vttf-space-3);
+}
+
+.{{ID}} .sh-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: var(--vttf-radius-sm);
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border-strong);
+  color: var(--vttf-text);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.{{ID}} .sh-action:hover {
+  background: var(--vttf-surface-2);
+}
+
+.{{ID}} .sh-action i {
+  color: var(--vttf-ember);
+}
+
+/* ─── Abilities ─── */
+.{{ID}} .sh-abilities {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--vttf-space-2);
+}
+
+.{{ID}} .sh-abil {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 8px;
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-md);
+}
+
+.{{ID}} .sh-abil .lbl {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+  font-weight: 600;
+}
+
+.{{ID}} .sh-abil .val {
+  width: 100%;
+  text-align: center;
+  background: transparent;
+  border: none;
+  color: var(--vttf-text);
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0;
+}
+
+.{{ID}} .sh-abil .val:focus {
+  outline: 1px solid var(--vttf-ember);
+  border-radius: var(--vttf-radius-sm);
+}
+
+.{{ID}} .sh-abil .mod {
+  background: transparent;
+  border: none;
+  color: var(--vttf-ember-glow);
+  font-family: var(--vttf-font-body);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 2px 8px;
+  border-radius: var(--vttf-radius-full);
+}
+
+.{{ID}} .sh-abil .mod:hover {
+  background: color-mix(in oklch, var(--vttf-ember) 12%, transparent);
+}
+
+/* ─── Items ─── */
+.{{ID}} .sh-items {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.{{ID}} .sh-item {
+  display: grid;
+  grid-template-columns: 32px 1fr auto auto auto;
+  gap: var(--vttf-space-3);
+  align-items: center;
+  padding: 8px 10px;
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  cursor: grab;
+}
+
+.{{ID}} .sh-item:active {
+  cursor: grabbing;
+}
+
+.{{ID}} .sh-item-ico {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: var(--vttf-surface-2);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  color: var(--vttf-text-muted);
+  font-size: 16px;
+  overflow: hidden;
+}
+
+.{{ID}} .sh-item-ico img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.{{ID}} .sh-item-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--vttf-text);
+}
+
+.{{ID}} .sh-item-meta {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  color: var(--vttf-text-faint);
+}
+
+.{{ID}} .sh-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: var(--vttf-radius-full);
+  background: color-mix(in oklch, var(--vttf-ember) 10%, transparent);
+  color: var(--vttf-ember);
+  border: 1px solid color-mix(in oklch, var(--vttf-ember) 40%, transparent);
+}
+
+.{{ID}} .sh-tag.muted {
+  background: var(--vttf-bg-sunken);
+  color: var(--vttf-text-muted);
+  border-color: var(--vttf-border);
+}
+
+.{{ID}} .sh-qty {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 12px;
+  color: var(--vttf-text-muted);
+}
+
+.{{ID}} .sh-item-delete {
+  background: transparent;
+  border: none;
+  color: var(--vttf-text-faint);
+  cursor: pointer;
+  padding: 4px 6px;
+}
+
+.{{ID}} .sh-item-delete:hover {
+  color: var(--vttf-rose);
+}
+
+.{{ID}} .sh-items-empty {
+  text-align: center;
+  padding: var(--vttf-space-4);
+  color: var(--vttf-text-faint);
+  font-style: italic;
+}
+
+/* ─── Drop affordance ─── */
+.{{ID}} .sh-drop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 20px;
+  border: 1.5px dashed var(--vttf-border-strong);
+  border-radius: var(--vttf-radius-md);
+  background: color-mix(in oklch, var(--vttf-ember) 6%, transparent);
+  text-align: center;
+}
+
+.{{ID}} .sh-drop .lbl {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--vttf-text);
+}
+
+.{{ID}} .sh-drop .sub {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  color: var(--vttf-text-faint);
+}
+
+/* ─── Empty placeholder (Spells tab) ─── */
+.{{ID}} .sh-empty {
+  padding: var(--vttf-space-6);
+  text-align: center;
+  color: var(--vttf-text-faint);
+  font-style: italic;
+}
+
+/* ─── Biography (readonly fallback) ─── */
+.{{ID}} .sh-biography-readonly {
+  padding: var(--vttf-space-4);
+  background: var(--vttf-bg-sunken);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-md);
+  color: var(--vttf-text-muted);
+  line-height: 1.6;
+}
+
+/* ════════ FOOT (.sh-foot) ════════ */
+.{{ID}} .sh-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--vttf-space-4);
+  padding: 12px var(--vttf-space-4);
+  background: var(--vttf-surface);
+  border-top: 1px solid var(--vttf-border);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+}
+
+.{{ID}} .sh-foot .nm {
+  color: var(--vttf-ember);
+  font-weight: 600;
+}
+
+/* ════════ Gear sheet (unchanged structurally) ════════ */
+.{{ID}}.item .field {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: var(--vttf-space-3);
+  align-items: center;
+  padding: 0.35rem 0;
+}

--- a/packages/cli/templates/system-js/system.json
+++ b/packages/cli/templates/system-js/system.json
@@ -1,0 +1,44 @@
+{
+  "id": "{{ID}}",
+  "title": "{{TITLE}}",
+  "description": "{{DESCRIPTION}}",
+  "version": "0.1.0",
+  "compatibility": {
+    "minimum": "{{FOUNDRY_MIN_VERSION}}",
+    "verified": "{{FOUNDRY_VERIFIED_VERSION}}"
+  },
+  "authors": [{ "name": "{{AUTHOR}}" }],
+  "esmodules": ["main.mjs"],
+  "styles": [{ "src": "styles/main.css" }],
+  "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
+  "documentTypes": {
+    "Actor": {
+      "character": {
+        "htmlFields": ["biography"]
+      }
+    },
+    "Item": {
+      "gear": {
+        "htmlFields": ["description"]
+      }
+    }
+  },
+  "grid": {
+    "type": 1,
+    "distance": 5,
+    "units": "ft",
+    "diagonals": 0
+  },
+  "primaryTokenAttribute": "health",
+  "secondaryTokenAttribute": "power",
+  "flags": {
+    "hotReload": {
+      "extensions": ["css", "hbs", "json"],
+      "paths": ["styles", "templates", "lang"]
+    },
+    "{{ID}}": {
+      "needsMigrationVersion": "0.1.0",
+      "compatibleMigrationVersion": "0.0.0"
+    }
+  }
+}

--- a/packages/cli/templates/system-js/template.json
+++ b/packages/cli/templates/system-js/template.json
@@ -1,0 +1,8 @@
+{
+  "Actor": {
+    "types": ["character"]
+  },
+  "Item": {
+    "types": ["gear"]
+  }
+}

--- a/packages/cli/templates/system-js/templates/actor/character-sheet.hbs
+++ b/packages/cli/templates/system-js/templates/actor/character-sheet.hbs
@@ -1,0 +1,168 @@
+{{!--
+  Character sheet — markup mirrors the canonical Figma reference
+  (character-sheet.jsx + Theme Explorations .sh-* classes).
+
+  Tabs nav uses `data-tab`/`data-group` + `data-action="vttforgeTab"` so
+  BaseActorSheet's default tab action routes clicks. `context.tabs.primary`
+  is auto-populated by BaseActorSheet's _prepareContext.
+
+  `<img data-edit="img">` is handled by DocumentSheetV2's built-in editImage
+  action. `<prose-mirror>` is the v13 rich text element for biography.
+--}}
+<form autocomplete="off">
+
+  {{!-- ════════ HEAD (.sh-head) ════════ --}}
+  <div class="sh-head">
+    <img class="sh-portrait" src="{{actor.img}}" alt="{{actor.name}}" data-edit="img" />
+    <div class="sh-id">
+      <div class="sh-id-top">
+        <input class="sh-name" type="text" name="name" value="{{actor.name}}"
+               placeholder="{{localize '{{LOCALE_PREFIX}}.Sheet.NamePlaceholder'}}" />
+        <div class="sh-sub">
+          <span>{{localize "{{LOCALE_PREFIX}}.Sheet.Level"}}</span>
+          <input type="number" name="system.level" value="{{system.level}}" min="1" max="20" />
+        </div>
+      </div>
+      <div class="sh-quick">
+        <div class="q">
+          <div class="qv">
+            <input type="number" name="system.health.value" value="{{system.health.value}}" min="0" />
+            <span class="qv-sep">/</span>
+            <span class="qv-max">{{system.health.max}}</span>
+          </div>
+          <div class="qk">{{localize "{{LOCALE_PREFIX}}.Sheet.Quick.HP"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">{{system.armorClass}}</div>
+          <div class="qk">{{localize "{{LOCALE_PREFIX}}.Sheet.Quick.AC"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">
+            <input type="number" name="system.speed" value="{{system.speed}}" min="0" />
+          </div>
+          <div class="qk">{{localize "{{LOCALE_PREFIX}}.Sheet.Quick.SPD"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">{{numberFormat system.initiative sign=true}}</div>
+          <div class="qk">{{localize "{{LOCALE_PREFIX}}.Sheet.Quick.INIT"}}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{!-- ════════ TABS (.sh-tabs) ════════ --}}
+  <nav class="sh-tabs" data-group="primary">
+    {{#each tabs as |tab|}}
+      <button type="button" class="sh-tab {{#if tab.active}}on{{/if}}"
+              data-tab="{{tab.id}}"
+              data-group="primary"
+              data-action="vttforgeTab"
+              title="{{localize tab.label}}">
+        {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
+        <span>{{localize tab.label}}</span>
+      </button>
+    {{/each}}
+  </nav>
+
+  {{!-- ════════ BODY (.sh-body) ════════ --}}
+  <section class="sh-body">
+
+    {{!-- ABILITIES --}}
+    <section class="tab abilities {{tabs.abilities.cssClass}}"
+             data-tab="abilities" data-group="primary">
+      <h3 class="sh-section-title">{{localize "{{LOCALE_PREFIX}}.Sheet.AbilityScores"}}</h3>
+      <div class="sh-abilities">
+        {{#each abilities as |ability|}}
+          <div class="sh-abil">
+            <div class="lbl" title="{{ability.label}}">{{ability.key}}</div>
+            <input class="val" type="number"
+                   name="system.abilities.{{ability.key}}"
+                   value="{{ability.value}}" min="1" max="30" />
+            <button type="button" class="mod sh-abil-roll"
+                    data-action="rollAbility" data-ability="{{ability.key}}"
+                    title="{{localize '{{LOCALE_PREFIX}}.Sheet.Roll.label'}}">
+              {{numberFormat ability.mod sign=true}}
+            </button>
+          </div>
+        {{/each}}
+      </div>
+    </section>
+
+    {{!-- INVENTORY --}}
+    <section class="tab inventory {{tabs.inventory.cssClass}}"
+             data-tab="inventory" data-group="primary">
+      <header class="sh-section-head">
+        <h3 class="sh-section-title">{{localize "{{LOCALE_PREFIX}}.Sheet.Inventory"}}</h3>
+        <button type="button" class="sh-action" data-action="createGear"
+                title="{{localize '{{LOCALE_PREFIX}}.Sheet.NewGear'}}">
+          <i class="fa-solid fa-plus"></i>
+          <span>{{localize "{{LOCALE_PREFIX}}.Sheet.NewGear"}}</span>
+        </button>
+      </header>
+      <div class="sh-items">
+        {{#each gear as |item|}}
+          <div class="sh-item" data-item-id="{{item.id}}" draggable="true">
+            <div class="sh-item-ico">
+              {{#if item.img}}
+                <img src="{{item.img}}" alt="{{item.name}}" />
+              {{else}}
+                <i class="fa-solid fa-box"></i>
+              {{/if}}
+            </div>
+            <div>
+              <div class="sh-item-name">{{item.name}}</div>
+              <div class="sh-item-meta">{{numberFormat item.weight}} lb</div>
+            </div>
+            <span class="sh-tag {{#if (eq item.kind "stowed")}}muted{{/if}}">
+              {{localize (concat "{{LOCALE_PREFIX}}.Gear.Kind." item.kind)}}
+            </span>
+            <span class="sh-qty">×{{item.quantity}}</span>
+            <button type="button" class="sh-item-delete" data-action="deleteItem"
+                    title="{{localize '{{LOCALE_PREFIX}}.Sheet.Delete'}}">
+              <i class="fa-solid fa-trash"></i>
+            </button>
+          </div>
+        {{else}}
+          <div class="sh-items-empty">{{localize "{{LOCALE_PREFIX}}.Sheet.NoGear"}}</div>
+        {{/each}}
+      </div>
+
+      <div class="sh-drop">
+        <div class="lbl">{{localize "{{LOCALE_PREFIX}}.Sheet.Drop.label"}}</div>
+        <div class="sub">onDropItem(item, event)</div>
+      </div>
+    </section>
+
+    {{!-- SPELLS (placeholder) --}}
+    <section class="tab spells {{tabs.spells.cssClass}}"
+             data-tab="spells" data-group="primary">
+      <h3 class="sh-section-title">{{localize "{{LOCALE_PREFIX}}.Sheet.Spells"}}</h3>
+      <div class="sh-empty">{{localize "{{LOCALE_PREFIX}}.Sheet.SpellsEmpty"}}</div>
+    </section>
+
+    {{!-- BIOGRAPHY --}}
+    <section class="tab biography {{tabs.biography.cssClass}}"
+             data-tab="biography" data-group="primary">
+      <h3 class="sh-section-title">{{localize "{{LOCALE_PREFIX}}.Sheet.Biography"}}</h3>
+      {{#if isEditable}}
+        <prose-mirror name="system.biography"
+                      button="true"
+                      editable="{{isEditable}}"
+                      toggled="false"
+                      value="{{system.biography}}">
+          {{{enrichedBiography}}}
+        </prose-mirror>
+      {{else}}
+        <div class="sh-biography-readonly">{{{enrichedBiography}}}</div>
+      {{/if}}
+    </section>
+
+  </section>
+
+  {{!-- ════════ FOOT (.sh-foot) ════════ --}}
+  <footer class="sh-foot">
+    <span class="nm">VTTFORGE · FORGE</span>
+    <span>@vttforge/styles · v0.2</span>
+  </footer>
+
+</form>

--- a/packages/cli/templates/system-js/templates/item/gear-sheet.hbs
+++ b/packages/cli/templates/system-js/templates/item/gear-sheet.hbs
@@ -1,0 +1,54 @@
+{{!-- Gear sheet — minimal demo of BaseItemSheet on ItemSheetV2. --}}
+<form autocomplete="off">
+
+  <header class="sheet-header">
+    <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
+    <input type="text" name="name" value="{{item.name}}"
+           placeholder="{{localize '{{LOCALE_PREFIX}}.Sheet.NamePlaceholder'}}" />
+  </header>
+
+  <nav class="sheet-tabs" data-group="primary">
+    {{#each tabs as |tab|}}
+      <button type="button" class="item {{tab.cssClass}}"
+              data-tab="{{tab.id}}"
+              data-group="primary"
+              data-action="vttforgeTab"
+              title="{{localize tab.label}}">
+        {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
+        <span>{{localize tab.label}}</span>
+      </button>
+    {{/each}}
+  </nav>
+
+  <section class="sheet-body">
+    {{!-- DETAILS --}}
+    <section class="tab details {{tabs.details.cssClass}}"
+             data-tab="details" data-group="primary">
+      <div class="field">
+        <label>{{localize "{{LOCALE_PREFIX}}.Gear.Quantity"}}</label>
+        <input type="number" name="system.quantity" value="{{system.quantity}}" min="0" />
+      </div>
+      <div class="field">
+        <label>{{localize "{{LOCALE_PREFIX}}.Gear.Weight"}}</label>
+        <input type="number" name="system.weight" value="{{system.weight}}" min="0" step="0.1" />
+      </div>
+    </section>
+
+    {{!-- DESCRIPTION --}}
+    <section class="tab description {{tabs.description.cssClass}}"
+             data-tab="description" data-group="primary">
+      {{#if isEditable}}
+        <prose-mirror name="system.description"
+                      button="true"
+                      editable="{{isEditable}}"
+                      toggled="false"
+                      value="{{system.description}}">
+          {{{enrichedDescription}}}
+        </prose-mirror>
+      {{else}}
+        <div class="description-readonly">{{{enrichedDescription}}}</div>
+      {{/if}}
+    </section>
+  </section>
+
+</form>

--- a/packages/cli/templates/system-js/vite.config.mjs
+++ b/packages/cli/templates/system-js/vite.config.mjs
@@ -1,0 +1,16 @@
+import vttforge from '@vttforge/vite-plugin';
+import { defineConfig } from 'vite';
+
+/**
+ * Vite config for {{TITLE}}.
+ *
+ * `@vttforge/vite-plugin` owns the build contract — it bundles
+ * `scripts/main.mjs` into `dist/main.mjs` (no hash, no bare specifiers),
+ * resolves `@import "@vttforge/styles"` at build time, copies the manifest +
+ * `lang/` + `templates/` to `dist/`, and syncs the manifest version from
+ * `package.json` on every build. The result under `dist/` is the deployable
+ * artefact you symlink into Foundry's `Data/systems/{{ID}}/`.
+ */
+export default defineConfig({
+  plugins: [vttforge({ id: '{{ID}}' })],
+});

--- a/packages/cli/templates/system-ts/.github/workflows/release.yml
+++ b/packages/cli/templates/system-ts/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: pnpm install
+
+      - name: Sync manifest version
+        run: |
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${{ steps.version.outputs.version }}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
+
+      - run: pnpm build
+
+      - name: Inject release URLs into manifest
+        run: |
+          node -e "const fs=require('fs');const path='dist/system.json';const m=JSON.parse(fs.readFileSync(path,'utf8'));m.manifest='https://github.com/${{ github.repository }}/releases/latest/download/system.json';m.download='https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/{{ID}}-${{ steps.version.outputs.version }}.zip';fs.writeFileSync(path,JSON.stringify(m,null,2)+'\n');"
+
+      - name: Build release zip
+        run: |
+          cd dist
+          zip -r ../{{ID}}-${{ steps.version.outputs.version }}.zip .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            {{ID}}-${{ steps.version.outputs.version }}.zip
+            dist/system.json
+          generate_release_notes: true
+          body: |
+            ## Foundry installation
+
+            Install via Foundry's setup wizard with this manifest URL:
+
+            ```
+            https://github.com/${{ github.repository }}/releases/latest/download/system.json
+            ```

--- a/packages/cli/templates/system-ts/README.md
+++ b/packages/cli/templates/system-ts/README.md
@@ -1,0 +1,61 @@
+# {{TITLE}}
+
+{{DESCRIPTION}}
+
+Built on [VTTForge](https://github.com/vttforge/vttforge) — typed data models, declarative sheet boilerplate, migration runner, error catalogue, and a Vite-based build pipeline.
+
+> **Note** — VTTForge is currently in pre-release and not yet published to npm. The dependencies in `package.json` (`@vttforge/core`, `@vttforge/styles`, `@vttforge/vite-plugin`) will resolve once VTTForge ships its first public release. Until then, work from a local checkout: `pnpm link --global` from each VTTForge package, then `pnpm link --global @vttforge/core @vttforge/styles @vttforge/vite-plugin` here.
+
+## Quick start
+
+```bash
+pnpm install
+pnpm build         # bundles dist/ — the deployable artefact
+pnpm dev           # vite build --watch — rebuilds dist/ on every edit
+```
+
+Symlink the built `dist/` into your Foundry data directory:
+
+```bash
+# macOS
+ln -s "$(pwd)/dist" "$HOME/Library/Application Support/FoundryVTT/Data/systems/{{ID}}"
+
+# Linux
+ln -s "$(pwd)/dist" "$HOME/.local/share/FoundryVTT/Data/systems/{{ID}}"
+
+# Windows (PowerShell, as admin)
+New-Item -ItemType SymbolicLink -Path "$env:APPDATA\FoundryVTT\Data\systems\{{ID}}" -Target "$(pwd)\dist"
+```
+
+Then launch Foundry, create a world that uses **{{TITLE}}**, and open a character — the sheet is the `CharacterSheet` shipped in `scripts/sheets/`.
+
+## What's inside
+
+| Path | Purpose |
+|---|---|
+| `system.json` | Manifest (id, compatibility, document types, manifest-side sanitization paths) |
+| `template.json` | Foundry document type declarations (Actor + Item subtypes) |
+| `scripts/main.ts` | Entry point — one call to `registerSystem` from `@vttforge/core` |
+| `scripts/data/*.ts` | Typed data models (`BaseTypeDataModel()` from `@vttforge/core`) |
+| `scripts/sheets/*.ts` | Sheet boilerplate eliminators (`BaseActorSheet()` / `BaseItemSheet()`) |
+| `scripts/migrations.ts` | `createMigrationRunner()` — versioned data migrations |
+| `templates/` | Handlebars templates for sheets |
+| `styles/main.css` | Stylesheet — imports `@vttforge/styles` as the design system base |
+| `lang/en.json` | Localization strings |
+
+## Releasing to Foundry
+
+Tag-push triggers `.github/workflows/release.yml`, which builds the system, zips `dist/`, and attaches both `{{ID}}-<version>.zip` and `dist/system.json` to a GitHub Release.
+
+```bash
+git tag v0.1.0
+git push --tags
+```
+
+Foundry installs from the `system.json` URL on the Release — point users at the `latest/download/system.json` URL in the release notes so they auto-update on every tag.
+
+For foundryvtt.com submissions, submit the same manifest URL pattern.
+
+## License
+
+{{LICENSE}} © {{YEAR}} {{AUTHOR}}

--- a/packages/cli/templates/system-ts/_gitignore
+++ b/packages/cli/templates/system-ts/_gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.turbo
+.vscode
+.DS_Store
+*.log

--- a/packages/cli/templates/system-ts/lang/en.json
+++ b/packages/cli/templates/system-ts/lang/en.json
@@ -1,0 +1,55 @@
+{
+  "TYPES.Actor.character": "Character",
+  "TYPES.Item.gear": "Gear",
+
+  "{{LOCALE_PREFIX}}.System.title": "{{TITLE}}",
+  "{{LOCALE_PREFIX}}.System.description": "{{DESCRIPTION}}",
+
+  "{{LOCALE_PREFIX}}.Sheet.Character.title": "Character",
+  "{{LOCALE_PREFIX}}.Sheet.Gear.title": "Gear",
+  "{{LOCALE_PREFIX}}.Sheet.NamePlaceholder": "Name…",
+  "{{LOCALE_PREFIX}}.Sheet.Level": "LV",
+  "{{LOCALE_PREFIX}}.Sheet.AbilityScores": "Ability scores",
+  "{{LOCALE_PREFIX}}.Sheet.Inventory": "Inventory",
+  "{{LOCALE_PREFIX}}.Sheet.Biography": "Biography",
+  "{{LOCALE_PREFIX}}.Sheet.NewGear": "New gear",
+  "{{LOCALE_PREFIX}}.Sheet.NewGearName": "New Gear",
+  "{{LOCALE_PREFIX}}.Sheet.NoGear": "No gear yet — drag items here or click New gear.",
+  "{{LOCALE_PREFIX}}.Sheet.Delete": "Delete",
+
+  "{{LOCALE_PREFIX}}.Sheet.Quick.HP": "HP",
+  "{{LOCALE_PREFIX}}.Sheet.Quick.AC": "AC",
+  "{{LOCALE_PREFIX}}.Sheet.Quick.SPD": "SPD",
+  "{{LOCALE_PREFIX}}.Sheet.Quick.INIT": "INIT",
+
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.abilities": "Abilities",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.inventory": "Inventory",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.spells": "Spells",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.biography": "Biography",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.details": "Details",
+  "{{LOCALE_PREFIX}}.Sheet.Tabs.description": "Description",
+  "{{LOCALE_PREFIX}}.Sheet.Spells": "Spells",
+  "{{LOCALE_PREFIX}}.Sheet.SpellsEmpty": "Spells slot reserved for a follow-up release.",
+
+  "{{LOCALE_PREFIX}}.Sheet.Roll.label": "Roll",
+  "{{LOCALE_PREFIX}}.Sheet.Roll.flavor": "{ability} check",
+  "{{LOCALE_PREFIX}}.Sheet.Drop.label": "Drop item to add",
+  "{{LOCALE_PREFIX}}.Sheet.Drop.rejected": "Cannot drop {type} items here — only gear is accepted.",
+
+  "{{LOCALE_PREFIX}}.Ability.str": "Strength",
+  "{{LOCALE_PREFIX}}.Ability.dex": "Dexterity",
+  "{{LOCALE_PREFIX}}.Ability.con": "Constitution",
+  "{{LOCALE_PREFIX}}.Ability.int": "Intelligence",
+  "{{LOCALE_PREFIX}}.Ability.wis": "Wisdom",
+  "{{LOCALE_PREFIX}}.Ability.cha": "Charisma",
+
+  "{{LOCALE_PREFIX}}.Gear.Quantity": "Quantity",
+  "{{LOCALE_PREFIX}}.Gear.Weight": "Weight (lb)",
+  "{{LOCALE_PREFIX}}.Gear.Kind": "Kind",
+  "{{LOCALE_PREFIX}}.Gear.Kind.equipped": "equipped",
+  "{{LOCALE_PREFIX}}.Gear.Kind.valued": "valued",
+  "{{LOCALE_PREFIX}}.Gear.Kind.stowed": "stowed",
+
+  "{{LOCALE_PREFIX}}.Settings.showTutorial.name": "Show tutorial",
+  "{{LOCALE_PREFIX}}.Settings.showTutorial.hint": "Display the welcome banner on world load."
+}

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "{{ID}}",
+  "version": "0.1.0",
+  "private": true,
+  "description": "{{DESCRIPTION}}",
+  "type": "module",
+  "license": "{{LICENSE}}",
+  "author": "{{AUTHOR}}",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@vttforge/core": "^0.3.0",
+    "@vttforge/styles": "^0.2.0"
+  },
+  "devDependencies": {
+    "@vttforge/vite-plugin": "^0.1.0",
+    "typescript": "^5.4.0",
+    "vite": "^6.3.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/cli/templates/system-ts/scripts/data/character-data.ts
+++ b/packages/cli/templates/system-ts/scripts/data/character-data.ts
@@ -1,0 +1,67 @@
+/**
+ * CharacterData — typed schema for the `character` Actor type.
+ *
+ * Quick stats are HP / AC / SPD / INIT, abilities are the six classic
+ * scores (str/dex/con/int/wis/cha). Derived state (modifiers, max HP,
+ * armor class, initiative) is computed in-memory in `prepareDerivedData`.
+ *
+ * `prepareBaseData` initialises fields that Active Effects need to mutate
+ * (base max HP before any AE bonus); `prepareDerivedData` then computes
+ * the AE-aware values (modifiers, percentages, totals). Never write to the
+ * database in either hook — they're purely in-memory derivations.
+ */
+import { BaseTypeDataModel, fields } from '@vttforge/core';
+
+export class CharacterData extends BaseTypeDataModel() {
+  static defineSchema() {
+    const f = fields();
+    return {
+      level: new f.NumberField({
+        required: true,
+        integer: true,
+        min: 1,
+        max: 20,
+        initial: 1,
+      }),
+      speed: new f.NumberField({
+        required: true,
+        integer: true,
+        min: 0,
+        initial: 30,
+      }),
+      abilities: new f.SchemaField({
+        str: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        dex: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        con: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        int: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        wis: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        cha: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+      }),
+      health: new f.SchemaField({
+        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
+        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
+      }),
+      power: new f.SchemaField({
+        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
+        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
+      }),
+      biography: new f.HTMLField(),
+    };
+  }
+
+  prepareDerivedData() {
+    // biome-ignore lint/suspicious/noExplicitAny: schema-driven types ship in a later @vttforge/types release
+    const self = this as any;
+    for (const [key, value] of Object.entries(self.abilities)) {
+      const score = typeof value === 'number' ? value : ((value as { value?: number })?.value ?? 10);
+      const mod = Math.floor((score - 10) / 2);
+      self.abilities[key] = { value: score, mod };
+    }
+
+    const conMod = self.abilities.con.mod;
+    self.health.max = 10 + self.level + conMod;
+
+    self.armorClass = 10 + self.abilities.dex.mod;
+    self.initiative = self.abilities.dex.mod;
+  }
+}

--- a/packages/cli/templates/system-ts/scripts/data/gear-data.ts
+++ b/packages/cli/templates/system-ts/scripts/data/gear-data.ts
@@ -1,0 +1,35 @@
+/**
+ * GearData — typed schema for the `gear` Item type.
+ *
+ * `kind` is an enum that drives the inventory pill on the character sheet:
+ * `equipped` and `valued` render with the accent pill, `stowed` renders
+ * muted.
+ */
+import { BaseTypeDataModel, fields } from '@vttforge/core';
+
+const GEAR_KINDS = ['equipped', 'valued', 'stowed'] as const;
+
+export class GearData extends BaseTypeDataModel() {
+  static defineSchema() {
+    const f = fields();
+    return {
+      quantity: new f.NumberField({
+        required: true,
+        integer: true,
+        min: 0,
+        initial: 1,
+      }),
+      weight: new f.NumberField({
+        required: true,
+        min: 0,
+        initial: 0,
+      }),
+      kind: new f.StringField({
+        required: true,
+        choices: GEAR_KINDS as unknown as string[],
+        initial: 'stowed',
+      }),
+      description: new f.HTMLField(),
+    };
+  }
+}

--- a/packages/cli/templates/system-ts/scripts/foundry-globals.ts
+++ b/packages/cli/templates/system-ts/scripts/foundry-globals.ts
@@ -1,0 +1,33 @@
+/**
+ * Minimal Foundry runtime globals.
+ *
+ * These declarations let the scaffold compile cleanly without an external
+ * type package. Replace with `fvtt-types` (community-maintained, pinned to
+ * a known-working commit SHA) or `@vttforge/types` (coming in a later
+ * VTTForge release) for full type coverage:
+ *
+ *   pnpm add -D 'github:League-of-Foundry-Developers/foundry-vtt-types#main'
+ *
+ * Then declare `types: ["fvtt-types"]` in `tsconfig.json` and delete this
+ * file.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+declare global {
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const game: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const CONFIG: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const Hooks: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const ui: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const ChatMessage: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const Roll: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const foundry: any;
+}
+
+export {};

--- a/packages/cli/templates/system-ts/scripts/main.ts
+++ b/packages/cli/templates/system-ts/scripts/main.ts
@@ -1,0 +1,82 @@
+/**
+ * {{TITLE}} — entry point.
+ *
+ * `registerSystem` from `@vttforge/core` replaces the ~60-line
+ * `Hooks.once("init", ...)` block most systems copy-paste from each other:
+ * data model registration, document class swap, initiative formula, sheet
+ * registration, settings, and the `Hooks.once("ready", ...)` migration
+ * gate are all wired by one call.
+ */
+import './foundry-globals.js';
+import { registerSystem, SystemConfig, VttfError } from '@vttforge/core';
+import { CharacterData } from './data/character-data.js';
+import { GearData } from './data/gear-data.js';
+import { migrations } from './migrations.js';
+import { CharacterSheet } from './sheets/character-sheet.js';
+import { GearSheet } from './sheets/gear-sheet.js';
+
+const SYSTEM_ID = '{{ID}}';
+
+const settings = new SystemConfig(SYSTEM_ID);
+
+try {
+  registerSystem({
+    id: SYSTEM_ID,
+    actorDataModels: { character: CharacterData },
+    itemDataModels: { gear: GearData },
+    combat: {
+      initiative: { formula: '1d20 + @abilities.dex.mod', decimals: 2 },
+    },
+    onAfterInit: () => {
+      settings.register('showTutorial', {
+        name: '{{LOCALE_PREFIX}}.Settings.showTutorial.name',
+        hint: '{{LOCALE_PREFIX}}.Settings.showTutorial.hint',
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: true,
+      });
+
+      // Register the schemaVersion setting so migrations.run() has somewhere
+      // to read and write the version flag.
+      migrations.register();
+
+      const { Actors, Items } = foundry.documents.collections;
+      Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
+      Actors.registerSheet(SYSTEM_ID, CharacterSheet, {
+        types: ['character'],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Character.title',
+      });
+      Items.unregisterSheet('core', foundry.applications.sheets.ItemSheetV2);
+      Items.registerSheet(SYSTEM_ID, GearSheet, {
+        types: ['gear'],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Gear.title',
+      });
+    },
+    onReady: async () => {
+      if (!game.user?.isGM) return;
+      try {
+        const ran = await migrations.run();
+        if (ran.length > 0) {
+          // biome-ignore lint/suspicious/noConsole: console.info is the only Foundry-portable info logger
+          console.info(`[${SYSTEM_ID}] applied migrations:`, ran.join(', '));
+        }
+      } catch (err) {
+        if (err instanceof VttfError) {
+          ui.notifications?.error(`[${err.code}] ${err.message} — see ${err.docsUrl}`, {
+            permanent: true,
+          });
+        }
+        throw err;
+      }
+    },
+  });
+} catch (err) {
+  if (err instanceof VttfError) {
+    // biome-ignore lint/suspicious/noConsole: bootstrap-time failures must surface
+    console.error(`[${err.code}] ${err.message} — see ${err.docsUrl}`);
+  }
+  throw err;
+}

--- a/packages/cli/templates/system-ts/scripts/migrations.ts
+++ b/packages/cli/templates/system-ts/scripts/migrations.ts
@@ -1,0 +1,43 @@
+/**
+ * Migration registry for {{TITLE}}.
+ *
+ * Each entry is idempotent — safe to re-run if a prior pass failed
+ * mid-sequence. `createMigrationRunner` reads the version flag declared in
+ * `system.json` (`flags.{{ID}}.needsMigrationVersion`), runs every
+ * migration whose version is newer than what's stored in the world's
+ * `schemaVersion` setting, and persists the new high-water mark on success.
+ */
+import { createMigrationRunner } from '@vttforge/core';
+
+const SYSTEM_ID = '{{ID}}';
+
+/**
+ * v0.1.0 — first real schema. Add real migration logic here as soon as the
+ * first breaking schema change ships. Until then, this is a no-op example
+ * that proves the runner end-to-end.
+ */
+async function migrateToV0_1_0(): Promise<void> {
+  // Iterate world documents and rewrite legacy fields here. Example:
+  //
+  //   const actors = game.actors?.filter((a) => a.type === 'character') ?? [];
+  //   for (const actor of actors) {
+  //     const legacy = actor.system?.bio;
+  //     if (typeof legacy !== 'string') continue;
+  //     await actor.update({
+  //       'system.biography': legacy,
+  //       '-=system.bio': null,
+  //     });
+  //   }
+}
+
+export const migrations = createMigrationRunner({
+  systemId: SYSTEM_ID,
+  compatibleVersion: '0.0.0',
+  migrations: [
+    {
+      version: '0.1.0',
+      description: 'initial schema — placeholder for first breaking change',
+      fn: migrateToV0_1_0,
+    },
+  ],
+});

--- a/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
@@ -1,0 +1,202 @@
+/**
+ * CharacterSheet — tabbed character sheet built on `BaseActorSheet()` from
+ * `@vttforge/core`. Demonstrates the full boilerplate-elimination surface:
+ *
+ * - `static TABS` — `context.tabs.<group>` auto-populated by BaseActorSheet
+ *   (no manual `_prepareTabs` call).
+ * - `static DRAG_DROP` — wires `foundry.applications.ux.DragDrop` on first
+ *   render with `isEditable`-gated permissions.
+ * - Typed `onDropItem(item, event)` — pre-resolves UUIDs, rejects
+ *   non-`gear` items with a notification, lets `gear` flow through to
+ *   Foundry's default `_onDropItem` by returning `undefined`.
+ */
+import { BaseActorSheet } from '@vttforge/core';
+
+const SYSTEM_ID = '{{ID}}';
+
+interface AbilityViewModel {
+  key: string;
+  label: string;
+  value: number;
+  mod: number;
+}
+
+interface GearViewModel {
+  id: string;
+  name: string;
+  img: string;
+  kind: string;
+  quantity: number;
+  weight: number;
+  description: string;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: typed sheet bases ship in a later @vttforge/types release
+const Base = BaseActorSheet() as any;
+
+export class CharacterSheet extends Base {
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    Base.DEFAULT_OPTIONS,
+    {
+      id: '{{ID}}-character',
+      classes: ['{{ID}}', 'sheet', 'actor', 'character'],
+      window: {
+        title: '{{LOCALE_PREFIX}}.Sheet.Character.title',
+        icon: 'fa-solid fa-user',
+      },
+      position: { width: 640, height: 700 },
+      actions: {
+        rollAbility: CharacterSheet._onRollAbility,
+        createGear: CharacterSheet._onCreateGear,
+        deleteItem: CharacterSheet._onDeleteItem,
+      },
+    },
+    { inplace: false },
+  );
+
+  static PARTS = {
+    sheet: {
+      template: `systems/${SYSTEM_ID}/templates/actor/character-sheet.hbs`,
+    },
+  };
+
+  static TABS = {
+    primary: {
+      tabs: [
+        {
+          id: 'abilities',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.abilities',
+          icon: 'fa-solid fa-dumbbell',
+        },
+        {
+          id: 'inventory',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.inventory',
+          icon: 'fa-solid fa-sack',
+        },
+        {
+          id: 'spells',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.spells',
+          icon: 'fa-solid fa-wand-magic-sparkles',
+        },
+        {
+          id: 'biography',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.biography',
+          icon: 'fa-solid fa-feather',
+        },
+      ],
+      initial: 'abilities',
+    },
+  };
+
+  static DRAG_DROP = [
+    {
+      dragSelector: '.sh-item[draggable=true]',
+      dropSelector: '.sh-body',
+    },
+  ];
+
+  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
+  async _prepareContext(options: any) {
+    const context = await super._prepareContext(options);
+    const actor = (this as unknown as { document: any }).document;
+    const system = actor.system;
+    const abilityLabels: Record<string, string> = {
+      str: '{{LOCALE_PREFIX}}.Ability.str',
+      dex: '{{LOCALE_PREFIX}}.Ability.dex',
+      con: '{{LOCALE_PREFIX}}.Ability.con',
+      int: '{{LOCALE_PREFIX}}.Ability.int',
+      wis: '{{LOCALE_PREFIX}}.Ability.wis',
+      cha: '{{LOCALE_PREFIX}}.Ability.cha',
+    };
+    context.actor = actor;
+    context.system = system;
+    context.isEditable = (this as unknown as { isEditable: boolean }).isEditable;
+    context.abilities = Object.entries(system.abilities ?? {}).map(
+      ([key, data]): AbilityViewModel => {
+        const ability = data as { value?: number; mod?: number } | number;
+        const value = typeof ability === 'number' ? ability : (ability?.value ?? 10);
+        const mod = typeof ability === 'number' ? 0 : (ability?.mod ?? 0);
+        return {
+          key,
+          label: game.i18n.localize(abilityLabels[key] ?? key),
+          value,
+          mod,
+        };
+      },
+    );
+    context.gear = actor.items
+      .filter((item: { type: string }) => item.type === 'gear')
+      .map(
+        (item: {
+          id: string;
+          name: string;
+          img: string;
+          system?: { kind?: string; quantity?: number; weight?: number; description?: string };
+        }): GearViewModel => ({
+          id: item.id,
+          name: item.name,
+          img: item.img,
+          kind: item.system?.kind ?? 'stowed',
+          quantity: item.system?.quantity ?? 1,
+          weight: item.system?.weight ?? 0,
+          description: item.system?.description ?? '',
+        }),
+      );
+    context.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      system.biography ?? '',
+      { relativeTo: actor, secrets: actor.isOwner },
+    );
+    return context;
+  }
+
+  /** Reject non-gear drops with a notification; let gear fall through. */
+  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
+  async onDropItem(item: any, _event: unknown): Promise<false | undefined> {
+    if (item?.type !== 'gear') {
+      ui.notifications?.warn(
+        game.i18n.format('{{LOCALE_PREFIX}}.Sheet.Drop.rejected', { type: item?.type ?? 'unknown' }),
+      );
+      return false;
+    }
+    return undefined;
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
+  static async _onRollAbility(this: any, _event: Event, target: HTMLElement) {
+    const key = target?.dataset?.ability;
+    if (!key) return;
+    const actor = this.document;
+    const mod = actor.system.abilities?.[key]?.mod ?? 0;
+    const roll = new Roll(`1d20 + ${mod}`, actor.getRollData());
+    await roll.evaluate();
+    await roll.toMessage({
+      speaker: ChatMessage.getSpeaker({ actor }),
+      flavor: game.i18n.format('{{LOCALE_PREFIX}}.Sheet.Roll.flavor', {
+        ability: game.i18n.localize(`{{LOCALE_PREFIX}}.Ability.${key}`),
+      }),
+    });
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
+  static async _onCreateGear(this: any, _event: Event, _target: HTMLElement) {
+    const cls = CONFIG.Item.documentClass;
+    const parent = this.document;
+    await cls.create(
+      { name: game.i18n.localize('{{LOCALE_PREFIX}}.Sheet.NewGearName'), type: 'gear' },
+      { parent, renderSheet: true },
+    );
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
+  static async _onDeleteItem(this: any, _event: Event, target: HTMLElement) {
+    const row = target?.closest('[data-item-id]') as HTMLElement | null;
+    const id = row?.dataset?.itemId;
+    if (!id) return;
+    const item = this.document.items.get(id);
+    await item?.delete();
+  }
+}

--- a/packages/cli/templates/system-ts/scripts/sheets/gear-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/gear-sheet.ts
@@ -1,0 +1,68 @@
+/**
+ * GearSheet — minimal Item sheet built on `BaseItemSheet()` from
+ * `@vttforge/core`. Single PART, single TABS group, no DRAG_DROP — exercises
+ * the mirror surface of BaseActorSheet on ItemSheetV2.
+ */
+import { BaseItemSheet } from '@vttforge/core';
+
+const SYSTEM_ID = '{{ID}}';
+
+// biome-ignore lint/suspicious/noExplicitAny: typed sheet bases ship in a later @vttforge/types release
+const Base = BaseItemSheet() as any;
+
+export class GearSheet extends Base {
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    Base.DEFAULT_OPTIONS,
+    {
+      id: '{{ID}}-gear',
+      classes: ['{{ID}}', 'sheet', 'item', 'gear'],
+      window: {
+        title: '{{LOCALE_PREFIX}}.Sheet.Gear.title',
+        icon: 'fa-solid fa-sack',
+      },
+      position: { width: 480, height: 420 },
+    },
+    { inplace: false },
+  );
+
+  static PARTS = {
+    sheet: {
+      template: `systems/${SYSTEM_ID}/templates/item/gear-sheet.hbs`,
+    },
+  };
+
+  static TABS = {
+    primary: {
+      tabs: [
+        {
+          id: 'details',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.details',
+          icon: 'fa-solid fa-list',
+        },
+        {
+          id: 'description',
+          group: 'primary',
+          label: '{{LOCALE_PREFIX}}.Sheet.Tabs.description',
+          icon: 'fa-solid fa-feather',
+        },
+      ],
+      initial: 'details',
+    },
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
+  async _prepareContext(options: any) {
+    const context = await super._prepareContext(options);
+    const item = (this as unknown as { document: any }).document;
+    context.item = item;
+    context.system = item.system;
+    context.isEditable = (this as unknown as { isEditable: boolean }).isEditable;
+    context.enrichedDescription =
+      await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+        item.system?.description ?? '',
+        { relativeTo: item, secrets: item.isOwner },
+      );
+    return context;
+  }
+}

--- a/packages/cli/templates/system-ts/styles/main.css
+++ b/packages/cli/templates/system-ts/styles/main.css
@@ -1,0 +1,495 @@
+@import "@vttforge/styles";
+
+/*
+ * {{ID}} styles — implements the .sh-* class system from the
+ * canonical Figma reference (character-sheet.jsx + Theme Explorations.html)
+ * on top of @vttforge/styles. Tokens come from the Forge theme; no other
+ * theme is hand-rolled here (consumers swap themes by overriding --vttf-*).
+ *
+ * Per foundry-vtt-system-dev "Styling & Themes" rule #3, component CSS stays
+ * UNLAYERED so it wins over Foundry's @layer applications without specificity
+ * wars. Scoped under .{{ID}} so nothing leaks into core Foundry UI.
+ */
+
+/* Opaque sheet bg — Foundry's ApplicationV2 default is transparent. */
+.{{ID}}.sheet,
+.{{ID}} .window-content {
+  background: var(--vttf-bg);
+  opacity: 1;
+}
+
+.{{ID}}.sheet {
+  color: var(--vttf-text);
+  font-family: var(--vttf-font-body, system-ui, sans-serif);
+}
+
+.{{ID}}.sheet form {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+/* ════════ HEAD (.sh-head) ════════ */
+.{{ID}} .sh-head {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: var(--vttf-space-4);
+  padding: var(--vttf-space-4);
+  background: var(--vttf-surface);
+  border-bottom: 1px solid var(--vttf-border);
+}
+
+.{{ID}} .sh-portrait {
+  width: 88px;
+  height: 110px;
+  border-radius: var(--vttf-radius-md);
+  background: var(--vttf-surface-2);
+  object-fit: cover;
+  cursor: pointer;
+}
+
+.{{ID}} .sh-id {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.{{ID}} .sh-id-top {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.{{ID}} .sh-name {
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--vttf-text);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid transparent;
+  padding: 0;
+}
+
+.{{ID}} .sh-name:focus {
+  border-bottom-color: var(--vttf-border-strong);
+  outline: none;
+}
+
+.{{ID}} .sh-sub {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vttf-space-2);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-muted);
+}
+
+.{{ID}} .sh-sub input {
+  width: 3.5rem;
+  text-align: center;
+  background: transparent;
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  color: var(--vttf-text);
+  font: inherit;
+  padding: 2px 6px;
+}
+
+.{{ID}} .sh-quick {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--vttf-space-3);
+}
+
+.{{ID}} .sh-quick .q {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.{{ID}} .sh-quick .qv {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--vttf-ember-glow);
+}
+
+.{{ID}} .sh-quick .qv input {
+  width: 2.5rem;
+  font: inherit;
+  color: inherit;
+  text-align: center;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.{{ID}} .sh-quick .qv-sep {
+  font-size: 14px;
+  color: var(--vttf-text-faint);
+}
+
+.{{ID}} .sh-quick .qv-max {
+  font-size: 14px;
+  color: var(--vttf-text-muted);
+}
+
+.{{ID}} .sh-quick .qk {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+}
+
+/* ════════ TABS (.sh-tabs) ════════ */
+.{{ID}} .sh-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 var(--vttf-space-4);
+  background: var(--vttf-bg-elevated);
+  border-bottom: 1px solid var(--vttf-border);
+}
+
+.{{ID}} .sh-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 14px;
+  cursor: pointer;
+  color: var(--vttf-text-muted);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  font-family: var(--vttf-font-body);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.{{ID}} .sh-tab:hover {
+  color: var(--vttf-text);
+}
+
+.{{ID}} .sh-tab.on,
+.{{ID}} .sh-tab.active {
+  color: var(--vttf-text);
+  border-bottom-color: var(--vttf-ember);
+}
+
+/* ════════ BODY (.sh-body) ════════ */
+.{{ID}} .sh-body {
+  flex: 1;
+  overflow: auto;
+  padding: var(--vttf-space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--vttf-space-4);
+  min-height: 320px;
+}
+
+.{{ID}} .sh-body .tab {
+  display: none;
+  flex-direction: column;
+  gap: var(--vttf-space-3);
+}
+
+.{{ID}} .sh-body .tab.active {
+  display: flex;
+}
+
+.{{ID}} .sh-section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vttf-space-3);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+  font-weight: 600;
+  margin: 0;
+}
+
+.{{ID}} .sh-section-title::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--vttf-border);
+}
+
+.{{ID}} .sh-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--vttf-space-3);
+}
+
+.{{ID}} .sh-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: var(--vttf-radius-sm);
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border-strong);
+  color: var(--vttf-text);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.{{ID}} .sh-action:hover {
+  background: var(--vttf-surface-2);
+}
+
+.{{ID}} .sh-action i {
+  color: var(--vttf-ember);
+}
+
+/* ─── Abilities ─── */
+.{{ID}} .sh-abilities {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--vttf-space-2);
+}
+
+.{{ID}} .sh-abil {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 8px;
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-md);
+}
+
+.{{ID}} .sh-abil .lbl {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+  font-weight: 600;
+}
+
+.{{ID}} .sh-abil .val {
+  width: 100%;
+  text-align: center;
+  background: transparent;
+  border: none;
+  color: var(--vttf-text);
+  font-family: var(--vttf-font-display, var(--vttf-font-body));
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0;
+}
+
+.{{ID}} .sh-abil .val:focus {
+  outline: 1px solid var(--vttf-ember);
+  border-radius: var(--vttf-radius-sm);
+}
+
+.{{ID}} .sh-abil .mod {
+  background: transparent;
+  border: none;
+  color: var(--vttf-ember-glow);
+  font-family: var(--vttf-font-body);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 2px 8px;
+  border-radius: var(--vttf-radius-full);
+}
+
+.{{ID}} .sh-abil .mod:hover {
+  background: color-mix(in oklch, var(--vttf-ember) 12%, transparent);
+}
+
+/* ─── Items ─── */
+.{{ID}} .sh-items {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.{{ID}} .sh-item {
+  display: grid;
+  grid-template-columns: 32px 1fr auto auto auto;
+  gap: var(--vttf-space-3);
+  align-items: center;
+  padding: 8px 10px;
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  cursor: grab;
+}
+
+.{{ID}} .sh-item:active {
+  cursor: grabbing;
+}
+
+.{{ID}} .sh-item-ico {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: var(--vttf-surface-2);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  color: var(--vttf-text-muted);
+  font-size: 16px;
+  overflow: hidden;
+}
+
+.{{ID}} .sh-item-ico img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.{{ID}} .sh-item-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--vttf-text);
+}
+
+.{{ID}} .sh-item-meta {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  color: var(--vttf-text-faint);
+}
+
+.{{ID}} .sh-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: var(--vttf-radius-full);
+  background: color-mix(in oklch, var(--vttf-ember) 10%, transparent);
+  color: var(--vttf-ember);
+  border: 1px solid color-mix(in oklch, var(--vttf-ember) 40%, transparent);
+}
+
+.{{ID}} .sh-tag.muted {
+  background: var(--vttf-bg-sunken);
+  color: var(--vttf-text-muted);
+  border-color: var(--vttf-border);
+}
+
+.{{ID}} .sh-qty {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 12px;
+  color: var(--vttf-text-muted);
+}
+
+.{{ID}} .sh-item-delete {
+  background: transparent;
+  border: none;
+  color: var(--vttf-text-faint);
+  cursor: pointer;
+  padding: 4px 6px;
+}
+
+.{{ID}} .sh-item-delete:hover {
+  color: var(--vttf-rose);
+}
+
+.{{ID}} .sh-items-empty {
+  text-align: center;
+  padding: var(--vttf-space-4);
+  color: var(--vttf-text-faint);
+  font-style: italic;
+}
+
+/* ─── Drop affordance ─── */
+.{{ID}} .sh-drop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 20px;
+  border: 1.5px dashed var(--vttf-border-strong);
+  border-radius: var(--vttf-radius-md);
+  background: color-mix(in oklch, var(--vttf-ember) 6%, transparent);
+  text-align: center;
+}
+
+.{{ID}} .sh-drop .lbl {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--vttf-text);
+}
+
+.{{ID}} .sh-drop .sub {
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 11px;
+  color: var(--vttf-text-faint);
+}
+
+/* ─── Empty placeholder (Spells tab) ─── */
+.{{ID}} .sh-empty {
+  padding: var(--vttf-space-6);
+  text-align: center;
+  color: var(--vttf-text-faint);
+  font-style: italic;
+}
+
+/* ─── Biography (readonly fallback) ─── */
+.{{ID}} .sh-biography-readonly {
+  padding: var(--vttf-space-4);
+  background: var(--vttf-bg-sunken);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-md);
+  color: var(--vttf-text-muted);
+  line-height: 1.6;
+}
+
+/* ════════ FOOT (.sh-foot) ════════ */
+.{{ID}} .sh-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--vttf-space-4);
+  padding: 12px var(--vttf-space-4);
+  background: var(--vttf-surface);
+  border-top: 1px solid var(--vttf-border);
+  font-family: var(--vttf-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+}
+
+.{{ID}} .sh-foot .nm {
+  color: var(--vttf-ember);
+  font-weight: 600;
+}
+
+/* ════════ Gear sheet (unchanged structurally) ════════ */
+.{{ID}}.item .field {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: var(--vttf-space-3);
+  align-items: center;
+  padding: 0.35rem 0;
+}

--- a/packages/cli/templates/system-ts/system.json
+++ b/packages/cli/templates/system-ts/system.json
@@ -1,0 +1,44 @@
+{
+  "id": "{{ID}}",
+  "title": "{{TITLE}}",
+  "description": "{{DESCRIPTION}}",
+  "version": "0.1.0",
+  "compatibility": {
+    "minimum": "{{FOUNDRY_MIN_VERSION}}",
+    "verified": "{{FOUNDRY_VERIFIED_VERSION}}"
+  },
+  "authors": [{ "name": "{{AUTHOR}}" }],
+  "esmodules": ["main.mjs"],
+  "styles": [{ "src": "styles/main.css" }],
+  "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
+  "documentTypes": {
+    "Actor": {
+      "character": {
+        "htmlFields": ["biography"]
+      }
+    },
+    "Item": {
+      "gear": {
+        "htmlFields": ["description"]
+      }
+    }
+  },
+  "grid": {
+    "type": 1,
+    "distance": 5,
+    "units": "ft",
+    "diagonals": 0
+  },
+  "primaryTokenAttribute": "health",
+  "secondaryTokenAttribute": "power",
+  "flags": {
+    "hotReload": {
+      "extensions": ["css", "hbs", "json"],
+      "paths": ["styles", "templates", "lang"]
+    },
+    "{{ID}}": {
+      "needsMigrationVersion": "0.1.0",
+      "compatibleMigrationVersion": "0.0.0"
+    }
+  }
+}

--- a/packages/cli/templates/system-ts/template.json
+++ b/packages/cli/templates/system-ts/template.json
@@ -1,0 +1,8 @@
+{
+  "Actor": {
+    "types": ["character"]
+  },
+  "Item": {
+    "types": ["gear"]
+  }
+}

--- a/packages/cli/templates/system-ts/templates/actor/character-sheet.hbs
+++ b/packages/cli/templates/system-ts/templates/actor/character-sheet.hbs
@@ -1,0 +1,168 @@
+{{!--
+  Character sheet — markup mirrors the canonical Figma reference
+  (character-sheet.jsx + Theme Explorations .sh-* classes).
+
+  Tabs nav uses `data-tab`/`data-group` + `data-action="vttforgeTab"` so
+  BaseActorSheet's default tab action routes clicks. `context.tabs.primary`
+  is auto-populated by BaseActorSheet's _prepareContext.
+
+  `<img data-edit="img">` is handled by DocumentSheetV2's built-in editImage
+  action. `<prose-mirror>` is the v13 rich text element for biography.
+--}}
+<form autocomplete="off">
+
+  {{!-- ════════ HEAD (.sh-head) ════════ --}}
+  <div class="sh-head">
+    <img class="sh-portrait" src="{{actor.img}}" alt="{{actor.name}}" data-edit="img" />
+    <div class="sh-id">
+      <div class="sh-id-top">
+        <input class="sh-name" type="text" name="name" value="{{actor.name}}"
+               placeholder="{{localize '{{LOCALE_PREFIX}}.Sheet.NamePlaceholder'}}" />
+        <div class="sh-sub">
+          <span>{{localize "{{LOCALE_PREFIX}}.Sheet.Level"}}</span>
+          <input type="number" name="system.level" value="{{system.level}}" min="1" max="20" />
+        </div>
+      </div>
+      <div class="sh-quick">
+        <div class="q">
+          <div class="qv">
+            <input type="number" name="system.health.value" value="{{system.health.value}}" min="0" />
+            <span class="qv-sep">/</span>
+            <span class="qv-max">{{system.health.max}}</span>
+          </div>
+          <div class="qk">{{localize "{{LOCALE_PREFIX}}.Sheet.Quick.HP"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">{{system.armorClass}}</div>
+          <div class="qk">{{localize "{{LOCALE_PREFIX}}.Sheet.Quick.AC"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">
+            <input type="number" name="system.speed" value="{{system.speed}}" min="0" />
+          </div>
+          <div class="qk">{{localize "{{LOCALE_PREFIX}}.Sheet.Quick.SPD"}}</div>
+        </div>
+        <div class="q">
+          <div class="qv">{{numberFormat system.initiative sign=true}}</div>
+          <div class="qk">{{localize "{{LOCALE_PREFIX}}.Sheet.Quick.INIT"}}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{!-- ════════ TABS (.sh-tabs) ════════ --}}
+  <nav class="sh-tabs" data-group="primary">
+    {{#each tabs as |tab|}}
+      <button type="button" class="sh-tab {{#if tab.active}}on{{/if}}"
+              data-tab="{{tab.id}}"
+              data-group="primary"
+              data-action="vttforgeTab"
+              title="{{localize tab.label}}">
+        {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
+        <span>{{localize tab.label}}</span>
+      </button>
+    {{/each}}
+  </nav>
+
+  {{!-- ════════ BODY (.sh-body) ════════ --}}
+  <section class="sh-body">
+
+    {{!-- ABILITIES --}}
+    <section class="tab abilities {{tabs.abilities.cssClass}}"
+             data-tab="abilities" data-group="primary">
+      <h3 class="sh-section-title">{{localize "{{LOCALE_PREFIX}}.Sheet.AbilityScores"}}</h3>
+      <div class="sh-abilities">
+        {{#each abilities as |ability|}}
+          <div class="sh-abil">
+            <div class="lbl" title="{{ability.label}}">{{ability.key}}</div>
+            <input class="val" type="number"
+                   name="system.abilities.{{ability.key}}"
+                   value="{{ability.value}}" min="1" max="30" />
+            <button type="button" class="mod sh-abil-roll"
+                    data-action="rollAbility" data-ability="{{ability.key}}"
+                    title="{{localize '{{LOCALE_PREFIX}}.Sheet.Roll.label'}}">
+              {{numberFormat ability.mod sign=true}}
+            </button>
+          </div>
+        {{/each}}
+      </div>
+    </section>
+
+    {{!-- INVENTORY --}}
+    <section class="tab inventory {{tabs.inventory.cssClass}}"
+             data-tab="inventory" data-group="primary">
+      <header class="sh-section-head">
+        <h3 class="sh-section-title">{{localize "{{LOCALE_PREFIX}}.Sheet.Inventory"}}</h3>
+        <button type="button" class="sh-action" data-action="createGear"
+                title="{{localize '{{LOCALE_PREFIX}}.Sheet.NewGear'}}">
+          <i class="fa-solid fa-plus"></i>
+          <span>{{localize "{{LOCALE_PREFIX}}.Sheet.NewGear"}}</span>
+        </button>
+      </header>
+      <div class="sh-items">
+        {{#each gear as |item|}}
+          <div class="sh-item" data-item-id="{{item.id}}" draggable="true">
+            <div class="sh-item-ico">
+              {{#if item.img}}
+                <img src="{{item.img}}" alt="{{item.name}}" />
+              {{else}}
+                <i class="fa-solid fa-box"></i>
+              {{/if}}
+            </div>
+            <div>
+              <div class="sh-item-name">{{item.name}}</div>
+              <div class="sh-item-meta">{{numberFormat item.weight}} lb</div>
+            </div>
+            <span class="sh-tag {{#if (eq item.kind "stowed")}}muted{{/if}}">
+              {{localize (concat "{{LOCALE_PREFIX}}.Gear.Kind." item.kind)}}
+            </span>
+            <span class="sh-qty">×{{item.quantity}}</span>
+            <button type="button" class="sh-item-delete" data-action="deleteItem"
+                    title="{{localize '{{LOCALE_PREFIX}}.Sheet.Delete'}}">
+              <i class="fa-solid fa-trash"></i>
+            </button>
+          </div>
+        {{else}}
+          <div class="sh-items-empty">{{localize "{{LOCALE_PREFIX}}.Sheet.NoGear"}}</div>
+        {{/each}}
+      </div>
+
+      <div class="sh-drop">
+        <div class="lbl">{{localize "{{LOCALE_PREFIX}}.Sheet.Drop.label"}}</div>
+        <div class="sub">onDropItem(item, event)</div>
+      </div>
+    </section>
+
+    {{!-- SPELLS (placeholder) --}}
+    <section class="tab spells {{tabs.spells.cssClass}}"
+             data-tab="spells" data-group="primary">
+      <h3 class="sh-section-title">{{localize "{{LOCALE_PREFIX}}.Sheet.Spells"}}</h3>
+      <div class="sh-empty">{{localize "{{LOCALE_PREFIX}}.Sheet.SpellsEmpty"}}</div>
+    </section>
+
+    {{!-- BIOGRAPHY --}}
+    <section class="tab biography {{tabs.biography.cssClass}}"
+             data-tab="biography" data-group="primary">
+      <h3 class="sh-section-title">{{localize "{{LOCALE_PREFIX}}.Sheet.Biography"}}</h3>
+      {{#if isEditable}}
+        <prose-mirror name="system.biography"
+                      button="true"
+                      editable="{{isEditable}}"
+                      toggled="false"
+                      value="{{system.biography}}">
+          {{{enrichedBiography}}}
+        </prose-mirror>
+      {{else}}
+        <div class="sh-biography-readonly">{{{enrichedBiography}}}</div>
+      {{/if}}
+    </section>
+
+  </section>
+
+  {{!-- ════════ FOOT (.sh-foot) ════════ --}}
+  <footer class="sh-foot">
+    <span class="nm">VTTFORGE · FORGE</span>
+    <span>@vttforge/styles · v0.2</span>
+  </footer>
+
+</form>

--- a/packages/cli/templates/system-ts/templates/item/gear-sheet.hbs
+++ b/packages/cli/templates/system-ts/templates/item/gear-sheet.hbs
@@ -1,0 +1,54 @@
+{{!-- Gear sheet — minimal demo of BaseItemSheet on ItemSheetV2. --}}
+<form autocomplete="off">
+
+  <header class="sheet-header">
+    <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
+    <input type="text" name="name" value="{{item.name}}"
+           placeholder="{{localize '{{LOCALE_PREFIX}}.Sheet.NamePlaceholder'}}" />
+  </header>
+
+  <nav class="sheet-tabs" data-group="primary">
+    {{#each tabs as |tab|}}
+      <button type="button" class="item {{tab.cssClass}}"
+              data-tab="{{tab.id}}"
+              data-group="primary"
+              data-action="vttforgeTab"
+              title="{{localize tab.label}}">
+        {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
+        <span>{{localize tab.label}}</span>
+      </button>
+    {{/each}}
+  </nav>
+
+  <section class="sheet-body">
+    {{!-- DETAILS --}}
+    <section class="tab details {{tabs.details.cssClass}}"
+             data-tab="details" data-group="primary">
+      <div class="field">
+        <label>{{localize "{{LOCALE_PREFIX}}.Gear.Quantity"}}</label>
+        <input type="number" name="system.quantity" value="{{system.quantity}}" min="0" />
+      </div>
+      <div class="field">
+        <label>{{localize "{{LOCALE_PREFIX}}.Gear.Weight"}}</label>
+        <input type="number" name="system.weight" value="{{system.weight}}" min="0" step="0.1" />
+      </div>
+    </section>
+
+    {{!-- DESCRIPTION --}}
+    <section class="tab description {{tabs.description.cssClass}}"
+             data-tab="description" data-group="primary">
+      {{#if isEditable}}
+        <prose-mirror name="system.description"
+                      button="true"
+                      editable="{{isEditable}}"
+                      toggled="false"
+                      value="{{system.description}}">
+          {{{enrichedDescription}}}
+        </prose-mirror>
+      {{else}}
+        <div class="description-readonly">{{{enrichedDescription}}}</div>
+      {{/if}}
+    </section>
+  </section>
+
+</form>

--- a/packages/cli/templates/system-ts/tsconfig.json
+++ b/packages/cli/templates/system-ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["scripts/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/templates/system-ts/vite.config.mjs
+++ b/packages/cli/templates/system-ts/vite.config.mjs
@@ -1,0 +1,16 @@
+import vttforge from '@vttforge/vite-plugin';
+import { defineConfig } from 'vite';
+
+/**
+ * Vite config for {{TITLE}}.
+ *
+ * `@vttforge/vite-plugin` owns the build contract — it bundles
+ * `scripts/main.ts` into `dist/main.mjs` (no hash, no bare specifiers),
+ * resolves `@import "@vttforge/styles"` at build time, copies the manifest +
+ * `lang/` + `templates/` to `dist/`, and syncs the manifest version from
+ * `package.json` on every build. The result under `dist/` is the deployable
+ * artefact you symlink into Foundry's `Data/systems/{{ID}}/`.
+ */
+export default defineConfig({
+  plugins: [vttforge({ id: '{{ID}}', entry: 'scripts/main.ts' })],
+});

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Templates live alongside the CLI source but are intentionally
+    // text-with-placeholders (not buildable code). Keep vitest from trying
+    // to discover or transform anything under `templates/`.
+    exclude: ['templates/**', 'node_modules/**', 'dist/**'],
+  },
+});

--- a/packages/create-vttforge/README.md
+++ b/packages/create-vttforge/README.md
@@ -1,0 +1,17 @@
+# create-vttforge
+
+Scaffold a new Foundry VTT system or module with VTTForge.
+
+```bash
+pnpm create vttforge my-system
+# or
+npm create vttforge@latest my-system
+# or
+bun create vttforge my-system
+# or
+yarn create vttforge my-system
+```
+
+This package is a thin wrapper around `@vttforge/cli init`. The scaffolder asks for the package type, language, id, title, author, license, and Foundry version, then writes a runnable Foundry v13+ scaffold into the named directory.
+
+See [`@vttforge/cli`](https://www.npmjs.com/package/@vttforge/cli) for the full CLI surface (`init`, `dev`, `build`, `audit`).

--- a/packages/create-vttforge/bin.mjs
+++ b/packages/create-vttforge/bin.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * create-vttforge — npm `create-*` convention wrapper.
+ *
+ * `pnpm create vttforge my-system` (or `npm create vttforge@latest my-system`,
+ * `bun create vttforge my-system`, `yarn create vttforge my-system`) invokes
+ * this binary. We forward the args directly to `@vttforge/cli`'s `init`
+ * subcommand so the scaffolder code lives in exactly one place.
+ */
+import { runInit } from '@vttforge/cli';
+
+const args = process.argv.slice(2);
+
+let name;
+let type;
+let lang;
+let noInstall = false;
+let noGit = false;
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === undefined) continue;
+  // Accept both the create-* convention (--no-install, --no-git) and the
+  // affirmative form (--install=false). Defaults are install + git enabled.
+  if (arg === '--no-install' || arg === '--install=false') {
+    noInstall = true;
+    continue;
+  }
+  if (arg === '--no-git' || arg === '--git=false') {
+    noGit = true;
+    continue;
+  }
+  if (arg === '--type' || arg === '-t') {
+    i += 1;
+    type = args[i];
+    continue;
+  }
+  if (arg === '--lang' || arg === '-l') {
+    i += 1;
+    lang = args[i];
+    continue;
+  }
+  if (arg.startsWith('--type=')) {
+    type = arg.slice('--type='.length);
+    continue;
+  }
+  if (arg.startsWith('--lang=')) {
+    lang = arg.slice('--lang='.length);
+    continue;
+  }
+  if (arg.startsWith('-')) {
+    // Unknown flag — skip silently rather than crash the create-* flow.
+    continue;
+  }
+  if (name === undefined) {
+    name = arg;
+  }
+}
+
+try {
+  await runInit({ name, type, lang, noInstall, noGit });
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/packages/create-vttforge/package.json
+++ b/packages/create-vttforge/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "create-vttforge",
+  "version": "0.1.0",
+  "description": "Scaffold a Foundry VTT system or module with VTTForge. Thin wrapper around `@vttforge/cli init`.",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/vttforge/vttforge#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vttforge/vttforge.git",
+    "directory": "packages/create-vttforge"
+  },
+  "bugs": "https://github.com/vttforge/vttforge/issues",
+  "keywords": [
+    "foundryvtt",
+    "vttforge",
+    "scaffold",
+    "create"
+  ],
+  "bin": {
+    "create-vttforge": "./bin.mjs"
+  },
+  "files": [
+    "bin.mjs",
+    "README.md"
+  ],
+  "dependencies": {
+    "@vttforge/cli": "workspace:*"
+  },
+  "engines": {
+    "node": ">=22.14.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": false
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,15 @@ catalogs:
     '@changesets/cli':
       specifier: ^2.31.0
       version: 2.31.0
+    '@clack/prompts':
+      specifier: ^0.11.0
+      version: 0.11.0
     '@types/node':
       specifier: ^25.9.1
       version: 25.9.1
+    citty:
+      specifier: ^0.1.6
+      version: 0.1.6
     happy-dom:
       specifier: ^20.9.0
       version: 20.9.0
@@ -119,6 +125,13 @@ importers:
         version: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
 
   packages/cli:
+    dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 0.11.0
+      citty:
+        specifier: 'catalog:'
+        version: 0.1.6
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -165,6 +178,12 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
+
+  packages/create-vttforge:
+    dependencies:
+      '@vttforge/cli':
+        specifier: workspace:*
+        version: link:../cli
 
   packages/styles:
     devDependencies:
@@ -411,6 +430,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1466,6 +1491,9 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -1499,6 +1527,10 @@ packages:
   component-emitter@2.0.0:
     resolution: {integrity: sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==}
     engines: {node: '>=18'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2372,6 +2404,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
@@ -3087,6 +3122,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@colors/colors@1.5.0':
     optional: true
@@ -3861,6 +3907,10 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
   cjs-module-lexer@1.4.3: {}
 
   cli-highlight@2.1.11:
@@ -3895,6 +3945,8 @@ snapshots:
   commander@12.1.0: {}
 
   component-emitter@2.0.0: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4824,6 +4876,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
 
   skin-tone@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,9 @@ catalog:
   '@arethetypeswrong/cli': ^0.18.2
   '@biomejs/biome': ^2.4.15
   '@changesets/cli': ^2.31.0
+  '@clack/prompts': ^0.11.0
   '@types/node': ^25.9.1
+  citty: ^0.1.6
   happy-dom: ^20.9.0
   knip: ^6.14.2
   lefthook: ^2.1.8


### PR DESCRIPTION
## Summary

Track 1 of the v1.0 roadmap — the CLI gets its first real subcommand.

`vttforge init` walks the user through naming the project, picking system/module + TypeScript/JavaScript, then scaffolds a complete VTTForge starter into a new directory. A companion package, `create-vttforge`, exposes the same flow under the npm `create-*` UX (`pnpm create vttforge my-system`, `npm create vttforge@latest my-system`, etc.).

### CLI surface

- **`vttforge init [name]`** — interactive scaffolder. Honors `--type`, `--lang`, `--no-install`, `--no-git`. Detects the calling package manager via `npm_config_user_agent` (pnpm / npm / bun / yarn) and offers to run its install command after writing files. **Install runs before `git init`** so the lockfile lands in the initial commit and the working tree stays clean after scaffold. `runInit` and `ScaffoldError` are exported from `@vttforge/cli` so library consumers (tests, wrappers, other CLIs) can drive the same flow without `process.exit` side-effects.
- **`vttforge dev` / `build` / `audit`** — reserved stubs that print a discoverable next-step message until the real implementations land.

### Four built-in templates

Under `packages/cli/templates/`:

- **`system-ts` / `system-js`** — realistic Foundry v13+ system that mirrors `examples/simple-system`. Ships `CharacterData` + `GearData` TypeDataModels, `CharacterSheet` + `GearSheet` extending `BaseActorSheet` / `BaseItemSheet`, a `createMigrationRunner` with an example migration, Handlebars templates for both sheets, the v13 manifest shapes (`grid` object, `styles: [{src}]`, `flags.hotReload.{extensions,paths}` at the root of `flags`, per-subtype `htmlFields`), the `.sh-*` sheet stylesheet on top of `@vttforge/styles`, and a tagged-release GitHub Actions workflow that builds, zips, injects manifest/download URLs into the released `system.json`, and publishes to a GitHub Release.
- **`module-ts` / `module-js`** — minimal but realistic module. Registers a client-scope setting via `SystemConfig`, listens on `renderActorSheetV2` to badge the rendered sheet, exposes a tiny API on `game.modules.get(id).api`, and ships the same tag-driven release workflow.

### Hard-earned safety guarantees

- **Gitignore packaging** — templates ship `_gitignore` (not `.gitignore`) because npm strips dotfiles on publish; the scaffolder renames it during copy.
- **Substitution safety** — `init` rejects `"`, `\`, line breaks, and `*/` in the prompted title / description / author. Every JS string literal in the templates that interpolates metadata uses double quotes, so apostrophes survive (`Daisy's Module`) and the listed characters can never produce broken JSON or runaway block comments.
- **Submit shape** — ability inputs submit to `system.abilities.<key>` (a `NumberField` at that path), not `system.abilities.<key>.value` — Foundry would reject the latter as an object-shaped update against a numeric field.

### `@vttforge/cli` deps

Runtime deps added through the workspace catalog: `citty` (CLI parsing), `@clack/prompts` (interactive prompts). A new `vitest.config.mts` and a biome includes entry exclude templates from test/lint scanning since they're text-with-placeholders.

### Tests

44 unit + integration tests in `packages/cli/src/__tests__/` cover the substitution logic, the package-manager detector, the bin surface, and a per-template integration suite that scaffolds every variant into a temporary directory and asserts shape (no leftover `{{PLACEHOLDER}}` strings, valid v13 manifest, expected file set per variant).

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — all 12 tasks green
- [x] `pnpm test` — 176 tests pass (cli 44, core 102, vite-plugin 23, simple-system 7)
- [x] `pnpm build` — all 9 packages build
- [x] `pnpm knip` — clean (templates excluded)
- [x] `node packages/cli/dist/bin.mjs --help` — prints the subcommand list with versions
- [x] `codex review --uncommitted` — iterated across 8 rounds to clear P1/P2 findings: TS entrypoint in vite config, manifest install URLs from release workflow, file-pack-safe `_gitignore`, dragdrop selector ↔ stylesheet alignment, full localization key set, top-level `TYPES` keys, sheet markup ↔ stylesheet alignment, ability-field submit shape, blank-title rejection, comment-terminator rejection, git-author fallback validation, Citty negation flag handling, install-before-git ordering, pnpm-cache removal from release workflows