### PR TITLE
feat(cli): vttforge audit (PR-c of Track 1)

### DIFF
--- a/.changeset/cli-audit.md
+++ b/.changeset/cli-audit.md
@@ -1,0 +1,59 @@
+---
+'@vttforge/cli': minor
+---
+
+feat(cli): ship `vttforge audit` — scan for seven v13 footguns
+
+Closes the third and final slice of Track 1. `vttforge audit [path]` scans
+a system or module project root and reports findings against the
+`VTTF-AUDIT-NNN` catalog of v13 manifest + code footguns.
+
+**Rules implemented:**
+
+| ID | Severity | Scope | What it catches |
+|---|---|---|---|
+| `VTTF-AUDIT-001` | HIGH | manifest | `flags.hotReload` as array (v12) or missing required `extensions` key. Silently disables HMR. |
+| `VTTF-AUDIT-002` | MEDIUM | manifest | Top-level `gridDistance` / `gridUnits` (v12) instead of `grid: {type, distance, units, diagonals}` (v13). Auto-migrates today, removed in v14. |
+| `VTTF-AUDIT-003` | LOW | manifest | `styles: ["foo.css"]` (string array) instead of `[{src, layer?}]` (v13). Auto-migrates but loses cascade-layer control. |
+| `VTTF-AUDIT-004` | MEDIUM | manifest + source | `HTMLField` / `FilePathField` declared in TypeDataModel schema but missing from `documentTypes.<Doc>.<subtype>.htmlFields` / `.filePathFields`. Server only sanitises declared paths → XSS risk on undeclared. Subtype-aware via `CONFIG.*.dataModels` + `registerSystem({ actorDataModels })` parsing; full-path matching through SchemaField nesting. |
+| `VTTF-AUDIT-005` | MEDIUM | source | `class X extends TypeDataModel` without a `prepareBaseData()` method. Active Effects apply between base and derived; consumers see uninitialised fields. Checked per class. |
+| `VTTF-AUDIT-006` | LOW | source | `_addDataFieldMigrations()` override on a TypeDataModel subclass. Real API is `static migrateData(source)` calling singular `super._addDataFieldMigration(...)`. |
+| `VTTF-AUDIT-007` | MEDIUM | manifest + source | `primaryTokenAttribute` / `secondaryTokenAttribute` doesn't resolve to a `SchemaField({ value, max })` at the exact dot-path. Nested paths like `attributes.hp` are traversed. |
+
+**CLI surface:**
+
+```bash
+vttforge audit                  # scan cwd, print markdown
+vttforge audit ./my-project     # scan a different path
+vttforge audit --json           # machine-readable JSON for CI piping
+vttforge audit --strict         # exit 1 on any finding (default: HIGH only)
+```
+
+**Exit codes:**
+- `0` — clean, or only MEDIUM/LOW findings (advisory mode)
+- `1` — at least one HIGH finding, or any finding in `--strict`
+
+Uses `process.exitCode` (not `process.exit`) so piped JSON reports aren't
+truncated on failing CI runs.
+
+**Implementation notes:**
+
+- Pure read-only — never modifies the source tree.
+- Regex-based source scanning. The trade-off is occasional false negatives
+  on heavily-formatted code; an AST dependency (TypeScript compiler) would
+  add ~30MB to the CLI for seven pattern checks. Rule 007's
+  `SchemaField({value, max})` detection uses a balanced-brace scan plus a
+  depth-tracking top-level-key extractor to correctly distinguish
+  SchemaField siblings from nested constructor options.
+- Rule 005 distinguishes `extends TypeDataModel` (direct, flagged) from
+  `extends BaseTypeDataModel()` (VTTForge factory, safe) via the `\b`
+  word boundary, and is checked per class so a sibling subclass without
+  the hook doesn't hide behind a sibling that has it.
+- Rule 004 takes the FULL schema path through enclosing SchemaField
+  wrappers and matches exactly against declared paths (with `system.`
+  prefix stripped — Foundry convention).
+
+**Tests:** 247 passing (+13 new test files, ~110 new test cases). Integration
+suite scaffolds each of the four templates and runs the audit against the
+output — they must report zero findings, otherwise either a template
+regressed or the audit grew a false positive.

--- a/packages/cli/src/__tests__/audit/audit-command.test.ts
+++ b/packages/cli/src/__tests__/audit/audit-command.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AuditTargetError, runAudit } from '../../audit/index.js';
+import { runAuditCommand } from '../../commands/audit.js';
+
+describe('runAudit (orchestrator)', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'vttforge-audit-orch-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('returns an empty report for an empty project', async () => {
+    const report = await runAudit({ cwd });
+    expect(report.findings).toHaveLength(0);
+    expect(report.counts).toEqual({ HIGH: 0, MEDIUM: 0, LOW: 0 });
+    expect(report.cwd).toBe(cwd);
+  });
+
+  it('aggregates manifest + source findings into a single report', async () => {
+    await writeFile(
+      join(cwd, 'system.json'),
+      JSON.stringify({
+        id: 'my-system',
+        version: '1.0.0',
+        flags: { hotReload: ['css'] }, // VTTF-AUDIT-001 HIGH
+        gridDistance: 5, // VTTF-AUDIT-002 MEDIUM
+      }),
+      'utf8',
+    );
+    await writeFile(
+      join(cwd, 'data.ts'),
+      `class CharacterData extends foundry.abstract.TypeDataModel {
+  static defineSchema() { return {}; }
+}`, // VTTF-AUDIT-005 MEDIUM
+      'utf8',
+    );
+
+    const report = await runAudit({ cwd });
+    expect(report.counts).toEqual({ HIGH: 1, MEDIUM: 2, LOW: 0 });
+    expect(report.findings[0]?.severity).toBe('HIGH');
+    expect(report.findings.map((f) => f.ruleId)).toEqual(
+      expect.arrayContaining(['VTTF-AUDIT-001', 'VTTF-AUDIT-002', 'VTTF-AUDIT-005']),
+    );
+  });
+
+  it('throws AuditTargetError when the path does not exist', async () => {
+    const missing = join(cwd, 'does-not-exist');
+    await expect(runAudit({ cwd: missing })).rejects.toThrow(AuditTargetError);
+  });
+
+  it('throws AuditTargetError when the path is a file (not a directory)', async () => {
+    const filePath = join(cwd, 'a-file.txt');
+    await writeFile(filePath, 'hi', 'utf8');
+    await expect(runAudit({ cwd: filePath })).rejects.toThrow(/not a directory/);
+  });
+
+  it('sorts findings HIGH → MEDIUM → LOW', async () => {
+    await writeFile(
+      join(cwd, 'system.json'),
+      JSON.stringify({
+        id: 'my-system',
+        version: '1.0.0',
+        flags: { hotReload: ['css'] }, // HIGH
+        gridDistance: 5, // MEDIUM
+        styles: ['styles/a.css'], // LOW
+      }),
+      'utf8',
+    );
+
+    const report = await runAudit({ cwd });
+    expect(report.findings[0]?.severity).toBe('HIGH');
+    expect(report.findings[1]?.severity).toBe('MEDIUM');
+    expect(report.findings[2]?.severity).toBe('LOW');
+  });
+});
+
+describe('runAuditCommand (CLI surface)', () => {
+  let cwd: string;
+  let captured: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'vttforge-audit-cmd-'));
+    captured = '';
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  const write = (chunk: string) => {
+    captured += chunk;
+  };
+
+  it('writes markdown output by default and exits 0 on clean projects', async () => {
+    const result = await runAuditCommand({ cwd, write });
+    expect(result.exitCode).toBe(0);
+    expect(captured).toContain('# vttforge audit report');
+    expect(captured).toContain('No issues found');
+  });
+
+  it('writes JSON output when format is json', async () => {
+    const result = await runAuditCommand({ cwd, format: 'json', write });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(captured);
+    expect(parsed.findings).toEqual([]);
+  });
+
+  it('exits 1 when HIGH findings are present', async () => {
+    await writeFile(
+      join(cwd, 'system.json'),
+      JSON.stringify({
+        id: 'my-system',
+        version: '1.0.0',
+        flags: { hotReload: ['css'] },
+      }),
+      'utf8',
+    );
+    const result = await runAuditCommand({ cwd, write });
+    expect(result.exitCode).toBe(1);
+    expect(result.report.counts.HIGH).toBe(1);
+  });
+
+  it('exits 0 by default for MEDIUM/LOW-only findings (advisory mode)', async () => {
+    await writeFile(
+      join(cwd, 'system.json'),
+      JSON.stringify({ id: 'my-system', version: '1.0.0', gridDistance: 5 }),
+      'utf8',
+    );
+    const result = await runAuditCommand({ cwd, write });
+    expect(result.exitCode).toBe(0);
+    expect(result.report.counts.MEDIUM).toBe(1);
+  });
+
+  it('exits 1 in --strict for MEDIUM findings', async () => {
+    await writeFile(
+      join(cwd, 'system.json'),
+      JSON.stringify({ id: 'my-system', version: '1.0.0', gridDistance: 5 }),
+      'utf8',
+    );
+    const result = await runAuditCommand({ cwd, strict: true, write });
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('exits 1 in --strict for LOW findings', async () => {
+    await writeFile(
+      join(cwd, 'system.json'),
+      JSON.stringify({ id: 'my-system', version: '1.0.0', styles: ['styles/a.css'] }),
+      'utf8',
+    );
+    const result = await runAuditCommand({ cwd, strict: true, write });
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/__tests__/audit/audit.integration.test.ts
+++ b/packages/cli/src/__tests__/audit/audit.integration.test.ts
@@ -1,0 +1,54 @@
+/**
+ * End-to-end smoke: scaffold each of the four templates and audit the
+ * result. Templates are the canonical "compliant" inputs — the audit
+ * must report zero findings against them. If this test fails it means
+ * either a template regressed against v13 conventions, or the audit
+ * grew a false positive against the official scaffolds.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runAudit } from '../../audit/index.js';
+import { type ScaffoldVars, scaffold, templatesRoot } from '../../scaffold.js';
+
+const VARS: ScaffoldVars = {
+  ID: 'audit-smoke',
+  TITLE: 'Audit Smoke',
+  DESCRIPTION: 'Audit integration test scaffold.',
+  AUTHOR: 'Daisy',
+  LICENSE: 'MIT',
+  FOUNDRY_MIN_VERSION: '13',
+  FOUNDRY_VERIFIED_VERSION: '13.341',
+  LOCALE_PREFIX: 'AUDIT_SMOKE',
+  YEAR: '2026',
+};
+
+describe.each([
+  'system-ts',
+  'system-js',
+  'module-ts',
+  'module-js',
+])('audit clean against %s template', (variant) => {
+  let dest: string;
+
+  beforeEach(async () => {
+    dest = mkdtempSync(join(tmpdir(), `vttforge-audit-${variant}-`));
+    await scaffold({
+      templateDir: join(templatesRoot(), variant),
+      destDir: dest,
+      vars: VARS,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(dest, { recursive: true, force: true });
+  });
+
+  it('emits zero findings', async () => {
+    const report = await runAudit({ cwd: dest });
+    expect(report.findings).toEqual([]);
+    expect(report.counts).toEqual({ HIGH: 0, MEDIUM: 0, LOW: 0 });
+  });
+});

--- a/packages/cli/src/__tests__/audit/manifest-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/manifest-rules.test.ts
@@ -1,0 +1,287 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runManifestRules } from '../../audit/manifest-rules.js';
+
+describe('runManifestRules', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'vttforge-audit-manifest-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('returns no findings when no manifest is present', async () => {
+    expect(await runManifestRules(cwd)).toEqual([]);
+  });
+
+  it('tolerates an unparseable manifest without crashing', async () => {
+    await writeFile(join(cwd, 'system.json'), 'not json at all', 'utf8');
+    expect(await runManifestRules(cwd)).toEqual([]);
+  });
+
+  it('tolerates a manifest that is a JSON array (Foundry would also reject it)', async () => {
+    await writeFile(join(cwd, 'system.json'), '[]', 'utf8');
+    expect(await runManifestRules(cwd)).toEqual([]);
+  });
+
+  describe('VTTF-AUDIT-001 — flags.hotReload shape', () => {
+    it('flags array-shaped flags.hotReload as HIGH', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          flags: { hotReload: ['css', 'hbs'] },
+        }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ruleId).toBe('VTTF-AUDIT-001');
+      expect(results[0]?.severity).toBe('HIGH');
+      expect(results[0]?.line).toBeGreaterThan(0);
+    });
+
+    it('flags non-object scalar shapes (e.g. boolean) as HIGH', async () => {
+      await writeFile(
+        join(cwd, 'module.json'),
+        JSON.stringify({ id: 'my-module', version: '1.0.0', flags: { hotReload: true } }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ruleId).toBe('VTTF-AUDIT-001');
+    });
+
+    it('flags `flags.hotReload: null` as HIGH (typeof null === "object")', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', flags: { hotReload: null } }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ruleId).toBe('VTTF-AUDIT-001');
+    });
+
+    it('flags an object missing the required `extensions` key as HIGH', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          flags: { hotReload: { paths: ['styles'] } }, // missing `extensions`
+        }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ruleId).toBe('VTTF-AUDIT-001');
+      expect(results[0]?.title).toContain('extensions');
+    });
+
+    it('accepts `extensions` without `paths` (Foundry defaults to package root)', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          flags: { hotReload: { extensions: ['css', 'hbs'] } },
+        }),
+        'utf8',
+      );
+      expect(await runManifestRules(cwd)).toEqual([]);
+    });
+
+    it('passes the v13 object shape', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          flags: {
+            hotReload: {
+              extensions: ['css', 'hbs', 'json'],
+              paths: ['styles', 'templates', 'lang'],
+            },
+          },
+        }),
+        'utf8',
+      );
+      expect(await runManifestRules(cwd)).toEqual([]);
+    });
+
+    it('passes when flags is absent entirely', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0' }),
+        'utf8',
+      );
+      expect(await runManifestRules(cwd)).toEqual([]);
+    });
+
+    it('flags both manifest files independently when both are misconfigured', async () => {
+      const broken = { id: 'x', version: '1.0.0', flags: { hotReload: ['css'] } };
+      await writeFile(join(cwd, 'system.json'), JSON.stringify(broken), 'utf8');
+      await writeFile(join(cwd, 'module.json'), JSON.stringify(broken), 'utf8');
+      const results = await runManifestRules(cwd);
+      expect(results.filter((r) => r.ruleId === 'VTTF-AUDIT-001')).toHaveLength(2);
+    });
+  });
+
+  describe('VTTF-AUDIT-002 — grid shape', () => {
+    it('flags top-level gridDistance as MEDIUM', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', gridDistance: 5 }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ruleId).toBe('VTTF-AUDIT-002');
+      expect(results[0]?.severity).toBe('MEDIUM');
+    });
+
+    it('flags top-level gridUnits as MEDIUM', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', gridUnits: 'ft' }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results.some((r) => r.ruleId === 'VTTF-AUDIT-002')).toBe(true);
+    });
+
+    it('does not double-flag when both legacy keys are present', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          gridDistance: 5,
+          gridUnits: 'ft',
+        }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results.filter((r) => r.ruleId === 'VTTF-AUDIT-002')).toHaveLength(1);
+    });
+
+    it('passes the v13 grid object', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          grid: { type: 1, distance: 5, units: 'ft', diagonals: 0 },
+        }),
+        'utf8',
+      );
+      expect(await runManifestRules(cwd)).toEqual([]);
+    });
+  });
+
+  describe('VTTF-AUDIT-003 — styles shape', () => {
+    it('flags styles array of strings as LOW', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          styles: ['styles/foo.css'],
+        }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ruleId).toBe('VTTF-AUDIT-003');
+      expect(results[0]?.severity).toBe('LOW');
+    });
+
+    it('flags a mixed array as long as any entry is a string', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          styles: [{ src: 'styles/a.css' }, 'styles/b.css'],
+        }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      expect(results.some((r) => r.ruleId === 'VTTF-AUDIT-003')).toBe(true);
+    });
+
+    it('passes the v13 object-array shape', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          styles: [{ src: 'styles/a.css' }, { src: 'styles/b.css', layer: 'tokens' }],
+        }),
+        'utf8',
+      );
+      expect(await runManifestRules(cwd)).toEqual([]);
+    });
+
+    it('passes an empty styles array', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', styles: [] }),
+        'utf8',
+      );
+      expect(await runManifestRules(cwd)).toEqual([]);
+    });
+
+    it('passes when styles is absent', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0' }),
+        'utf8',
+      );
+      expect(await runManifestRules(cwd)).toEqual([]);
+    });
+  });
+
+  describe('multi-rule aggregation', () => {
+    it('emits all three rules in a worst-case manifest', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          gridDistance: 5,
+          gridUnits: 'ft',
+          styles: ['styles/a.css'],
+          flags: { hotReload: ['css'] },
+        }),
+        'utf8',
+      );
+      const results = await runManifestRules(cwd);
+      const ids = results.map((r) => r.ruleId).sort();
+      expect(ids).toEqual(['VTTF-AUDIT-001', 'VTTF-AUDIT-002', 'VTTF-AUDIT-003']);
+    });
+
+    it('emits zero findings on a clean v13 manifest', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          grid: { type: 1, distance: 5, units: 'ft', diagonals: 0 },
+          styles: [{ src: 'styles/a.css' }],
+          flags: { hotReload: { extensions: ['css'], paths: ['styles'] } },
+        }),
+        'utf8',
+      );
+      expect(await runManifestRules(cwd)).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/audit/reporter.test.ts
+++ b/packages/cli/src/__tests__/audit/reporter.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { formatReport } from '../../audit/reporter.js';
+import type { AuditReport, RuleResult } from '../../audit/types.js';
+
+function makeReport(findings: RuleResult[]): AuditReport {
+  return {
+    cwd: '/projects/my-system',
+    startedAt: '2026-05-27T00:00:00.000Z',
+    findings,
+    counts: {
+      HIGH: findings.filter((f) => f.severity === 'HIGH').length,
+      MEDIUM: findings.filter((f) => f.severity === 'MEDIUM').length,
+      LOW: findings.filter((f) => f.severity === 'LOW').length,
+    },
+  };
+}
+
+const highFinding: RuleResult = {
+  ruleId: 'VTTF-AUDIT-001',
+  title: 'flags.hotReload shape',
+  severity: 'HIGH',
+  filePath: '/projects/my-system/system.json',
+  line: 34,
+  message: 'flags.hotReload is an array; v13 expects {extensions, paths}',
+  remediation: 'Replace `["css","hbs"]` with `{ "extensions": [...], "paths": [...] }`.',
+};
+
+const mediumFinding: RuleResult = {
+  ruleId: 'VTTF-AUDIT-002',
+  title: 'Deprecated grid shape',
+  severity: 'MEDIUM',
+  filePath: '/projects/my-system/system.json',
+  line: 26,
+  message:
+    'gridDistance/gridUnits are v12 fields; v13 wants `grid: {type, distance, units, diagonals}`',
+};
+
+describe('formatReport — JSON', () => {
+  it('emits a stable JSON envelope', () => {
+    const json = formatReport(makeReport([highFinding]), 'json');
+    const parsed = JSON.parse(json);
+    expect(parsed.cwd).toBe('/projects/my-system');
+    expect(parsed.findings).toHaveLength(1);
+    expect(parsed.findings[0].ruleId).toBe('VTTF-AUDIT-001');
+    expect(parsed.counts).toEqual({ HIGH: 1, MEDIUM: 0, LOW: 0 });
+  });
+
+  it('ends with a trailing newline (POSIX convention)', () => {
+    const json = formatReport(makeReport([]), 'json');
+    expect(json.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('formatReport — markdown', () => {
+  it('renders a "no issues" body when findings are empty', () => {
+    const md = formatReport(makeReport([]), 'markdown');
+    expect(md).toContain('# vttforge audit report');
+    expect(md).toContain('No issues found');
+  });
+
+  it('groups findings by severity with counts', () => {
+    const md = formatReport(makeReport([highFinding, mediumFinding]), 'markdown');
+    expect(md).toContain('## HIGH (1)');
+    expect(md).toContain('## MEDIUM (1)');
+    expect(md).toContain('VTTF-AUDIT-001');
+    expect(md).toContain('VTTF-AUDIT-002');
+  });
+
+  it('uses relative paths when files live under cwd', () => {
+    const md = formatReport(makeReport([highFinding]), 'markdown');
+    expect(md).toContain('`system.json:34`');
+    expect(md).not.toContain('/projects/my-system/system.json');
+  });
+
+  it('keeps the absolute path when the file is outside cwd', () => {
+    const outside: RuleResult = { ...highFinding, filePath: '/other/place/system.json' };
+    const md = formatReport(makeReport([outside]), 'markdown');
+    expect(md).toContain('/other/place/system.json');
+  });
+
+  it('omits the line suffix when no line is present', () => {
+    const noLine: RuleResult = { ...highFinding, line: undefined };
+    const md = formatReport(makeReport([noLine]), 'markdown');
+    expect(md).toContain('`system.json`');
+    expect(md).not.toContain(':34');
+  });
+
+  it('renders the remediation hint when provided', () => {
+    const md = formatReport(makeReport([highFinding]), 'markdown');
+    expect(md).toContain('Replace `["css","hbs"]`');
+  });
+
+  it('skips the fix line when remediation is omitted', () => {
+    const md = formatReport(makeReport([mediumFinding]), 'markdown');
+    expect(md).not.toContain('fix:');
+  });
+
+  it('shows the totals header even when there are findings', () => {
+    const md = formatReport(makeReport([highFinding, mediumFinding]), 'markdown');
+    expect(md).toContain('findings: 2 (1 HIGH · 1 MEDIUM · 0 LOW)');
+  });
+});

--- a/packages/cli/src/__tests__/audit/source-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/source-rules.test.ts
@@ -1,0 +1,608 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _internal, runSourceRules } from '../../audit/source-rules.js';
+
+describe('runSourceRules', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'vttforge-audit-source-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('returns no findings on an empty project', async () => {
+    expect(await runSourceRules(cwd)).toEqual([]);
+  });
+
+  it('skips excluded directories (node_modules, dist, …)', async () => {
+    await mkdir(join(cwd, 'node_modules', 'something'), { recursive: true });
+    await writeFile(
+      join(cwd, 'node_modules', 'something', 'index.ts'),
+      'class X extends TypeDataModel { static defineSchema() { return {}; } }',
+      'utf8',
+    );
+    expect(await runSourceRules(cwd)).toEqual([]);
+  });
+
+  describe('VTTF-AUDIT-005 — prepareBaseData missing', () => {
+    it('flags `extends TypeDataModel` without prepareBaseData', async () => {
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `class CharacterData extends foundry.abstract.TypeDataModel {
+  static defineSchema() { return {}; }
+  prepareDerivedData() {}
+}`,
+        'utf8',
+      );
+      const results = await runSourceRules(cwd);
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ruleId).toBe('VTTF-AUDIT-005');
+      expect(results[0]?.severity).toBe('MEDIUM');
+      expect(results[0]?.line).toBe(1);
+    });
+
+    it('does not flag when prepareBaseData is defined', async () => {
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `class CharacterData extends foundry.abstract.TypeDataModel {
+  prepareBaseData() {}
+}`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
+    it('does not flag the `BaseTypeDataModel()` factory pattern', async () => {
+      // VTTForge's factory returns a class that already provides the stub.
+      // `\bTypeDataModel\b` does not match inside `BaseTypeDataModel`.
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `import { BaseTypeDataModel } from '@vttforge/core';
+class CharacterData extends BaseTypeDataModel() {
+  static defineSchema() { return {}; }
+}`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
+    it('reports one finding per offending class (not one per file)', async () => {
+      // Codex round-2 fix: a file with two TypeDataModel subclasses where
+      // only one defines prepareBaseData must still flag the sibling.
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `class AData extends TypeDataModel {
+  prepareBaseData() {}
+}
+class BData extends TypeDataModel {
+  static defineSchema() { return {}; }
+}`,
+        'utf8',
+      );
+      const five = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-005');
+      // AData has the hook; BData is missing it — only BData flags.
+      expect(five).toHaveLength(1);
+      expect(five[0]?.message).toContain('BData');
+    });
+
+    it('flags every class when multiple are missing the hook', async () => {
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `class AData extends TypeDataModel {}
+class BData extends TypeDataModel {}`,
+        'utf8',
+      );
+      const five = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-005');
+      expect(five).toHaveLength(2);
+      expect(five.map((f) => f.message).join(' ')).toContain('AData');
+      expect(five.map((f) => f.message).join(' ')).toContain('BData');
+    });
+  });
+
+  describe('VTTF-AUDIT-006 — _addDataFieldMigrations override', () => {
+    it('flags an override on a TypeDataModel subclass', async () => {
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `class CharacterData extends foundry.abstract.TypeDataModel {
+  prepareBaseData() {}
+  _addDataFieldMigrations() { return []; }
+}`,
+        'utf8',
+      );
+      const results = await runSourceRules(cwd);
+      expect(results.some((r) => r.ruleId === 'VTTF-AUDIT-006')).toBe(true);
+    });
+
+    it('does not flag files that have _addDataFieldMigrations but no TypeDataModel', async () => {
+      // E.g. a documentation example or a helper script.
+      await writeFile(
+        join(cwd, 'helper.ts'),
+        `function showSignature() { return '_addDataFieldMigrations(source, oldKey, newKey)'; }`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
+    it('also flags overrides on the BaseTypeDataModel() factory pattern', async () => {
+      // Most templates use BaseTypeDataModel(). A bad migration override
+      // there should still be caught.
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `class CharacterData extends BaseTypeDataModel() {
+  _addDataFieldMigrations() {}
+}`,
+        'utf8',
+      );
+      const six = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-006');
+      expect(six).toHaveLength(1);
+    });
+  });
+
+  describe('VTTF-AUDIT-004 — HTMLField / FilePathField not declared', () => {
+    it('flags HTMLField that is missing from manifest documentTypes', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: { Actor: { character: { htmlFields: [] } } },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return {
+    biography: new f.HTMLField(),
+  };
+}`,
+        'utf8',
+      );
+      const results = await runSourceRules(cwd);
+      const four = results.filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four).toHaveLength(1);
+      expect(four[0]?.message).toContain('biography');
+    });
+
+    it('passes when the field is declared in manifest', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: { Actor: { character: { htmlFields: ['biography'] } } },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() { return { biography: new f.HTMLField() }; }`,
+        'utf8',
+      );
+      const results = await runSourceRules(cwd);
+      expect(results.filter((r) => r.ruleId === 'VTTF-AUDIT-004')).toHaveLength(0);
+    });
+
+    it('accepts dot-paths in the manifest (uses last segment)', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: { Actor: { character: { htmlFields: ['system.biography'] } } },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() { return { biography: new f.HTMLField() }; }`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
+    it('flags an undeclared field when class IS registered to a subtype', async () => {
+      // Even though Actor.character declares biography, our class is
+      // registered to Actor.npc which doesn't — the strict per-subtype
+      // check catches it where the global-union fallback would miss.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: {
+            Actor: {
+              character: { htmlFields: ['biography'] },
+              npc: { htmlFields: [] },
+            },
+          },
+        }),
+        'utf8',
+      );
+      await writeFile(join(cwd, 'main.ts'), `CONFIG.Actor.dataModels.npc = NpcData;`, 'utf8');
+      await writeFile(
+        join(cwd, 'npc-data.ts'),
+        `class NpcData extends BaseTypeDataModel() {
+  static defineSchema() { return { biography: new f.HTMLField() }; }
+}`,
+        'utf8',
+      );
+      const four = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four).toHaveLength(1);
+      expect(four[0]?.message).toContain('Actor.npc');
+    });
+
+    it('passes when the class IS registered AND the matching subtype declares the field', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: { Actor: { npc: { htmlFields: ['biography'] } } },
+        }),
+        'utf8',
+      );
+      await writeFile(join(cwd, 'main.ts'), `CONFIG.Actor.dataModels.npc = NpcData;`, 'utf8');
+      await writeFile(
+        join(cwd, 'npc-data.ts'),
+        `class NpcData extends BaseTypeDataModel() {
+  static defineSchema() { return { biography: new f.HTMLField() }; }
+}`,
+        'utf8',
+      );
+      const four = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four).toHaveLength(0);
+    });
+
+    it('does not let a declared `profile.bio` shadow an undeclared `journal.bio`', async () => {
+      // Codex round-2 fix: leaf-only matching would accept the global
+      // `bio` declaration. Now we compare FULL source paths against
+      // declared full paths.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: { Actor: { character: { htmlFields: ['profile.bio'] } } },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return {
+    journal: new fields.SchemaField({
+      bio: new fields.HTMLField(),
+    }),
+  };
+}`,
+        'utf8',
+      );
+      const four = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four).toHaveLength(1);
+      expect(four[0]?.message).toContain('journal.bio');
+    });
+
+    it('accepts a nested HTMLField when its full path matches the manifest', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: { Actor: { character: { htmlFields: ['profile.bio'] } } },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return {
+    profile: new fields.SchemaField({
+      bio: new fields.HTMLField(),
+    }),
+  };
+}`,
+        'utf8',
+      );
+      const four = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four).toHaveLength(0);
+    });
+
+    it('detects registerSystem(...) DataModel registrations', async () => {
+      // VTTForge templates register through `registerSystem({ actorDataModels })`.
+      // Without recognising that form, rule 004 would fall back to the
+      // global-union check and miss subtype-specific gaps.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: {
+            Actor: {
+              character: { htmlFields: ['biography'] },
+              npc: { htmlFields: [] },
+            },
+          },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'main.ts'),
+        `registerSystem({
+  actorDataModels: { character: CharacterData, npc: NpcData },
+});`,
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'npc-data.ts'),
+        `class NpcData extends BaseTypeDataModel() {
+  static defineSchema() { return { biography: new f.HTMLField() }; }
+}`,
+        'utf8',
+      );
+      const four = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four).toHaveLength(1);
+      expect(four[0]?.message).toContain('Actor.npc');
+    });
+
+    it('flags FilePathField independently from HTMLField', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: { Actor: { character: { htmlFields: ['biography'] } } },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return {
+    biography: new f.HTMLField(),
+    portrait: new f.FilePathField({ categories: ['IMAGE'] }),
+  };
+}`,
+        'utf8',
+      );
+      const four = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four).toHaveLength(1);
+      expect(four[0]?.message).toContain('portrait');
+      expect(four[0]?.message).toContain('FilePathField');
+    });
+  });
+
+  describe('VTTF-AUDIT-007 — token attribute SchemaField', () => {
+    it('passes when health resolves to {value, max} SchemaField', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          primaryTokenAttribute: 'health',
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return {
+    health: new fields.SchemaField({
+      value: new fields.NumberField(),
+      max: new fields.NumberField(),
+    }),
+  };
+}`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
+    it('does NOT accept a nested NumberField.max as the SchemaField.max key', async () => {
+      // The naive `/\bmax\s*:/.test(body)` check would pass this — both
+      // `value:` and `max:` appear in the captured body. The top-level-key
+      // scanner rejects it because `max:` is at depth 1 (inside the
+      // NumberField constructor), not at depth 0 of the SchemaField body.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          primaryTokenAttribute: 'health',
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return {
+    health: new fields.SchemaField({
+      value: new fields.NumberField({ max: 100 }),
+    }),
+  };
+}`,
+        'utf8',
+      );
+      const seven = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-007');
+      expect(seven).toHaveLength(1);
+    });
+
+    it('flags when manifest names an attribute that has no matching SchemaField', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          primaryTokenAttribute: 'sanity',
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return { health: new fields.SchemaField({ value: new fields.NumberField(), max: new fields.NumberField() }) };
+}`,
+        'utf8',
+      );
+      const results = await runSourceRules(cwd);
+      const seven = results.filter((r) => r.ruleId === 'VTTF-AUDIT-007');
+      expect(seven).toHaveLength(1);
+      expect(seven[0]?.message).toContain('sanity');
+    });
+
+    it('flags a SchemaField that is missing the max key', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          primaryTokenAttribute: 'health',
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return { health: new fields.SchemaField({ value: new fields.NumberField() }) };
+}`,
+        'utf8',
+      );
+      const seven = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-007');
+      expect(seven).toHaveLength(1);
+    });
+
+    it('resolves nested paths against the actual source schema (passing case)', async () => {
+      // Codex round-3 fix: rule 007 used to emit a MEDIUM finding for
+      // any dotted path with "verify manually". Now it walks the source
+      // and validates against the declaration at the EXACT dot-path.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          primaryTokenAttribute: 'attributes.hp',
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return {
+    attributes: new fields.SchemaField({
+      hp: new fields.SchemaField({
+        value: new fields.NumberField(),
+        max: new fields.NumberField(),
+      }),
+    }),
+  };
+}`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
+    it('flags a top-level token attribute that only exists nested in source', async () => {
+      // Codex round-3 fix: manifest says `health`, but the only matching
+      // SchemaField is nested under `attributes`. Schema path
+      // `attributes.health` ≠ manifest path `health` — fail.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          primaryTokenAttribute: 'health',
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return {
+    attributes: new fields.SchemaField({
+      health: new fields.SchemaField({
+        value: new fields.NumberField(),
+        max: new fields.NumberField(),
+      }),
+    }),
+  };
+}`,
+        'utf8',
+      );
+      const seven = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-007');
+      expect(seven).toHaveLength(1);
+    });
+
+    it('checks secondaryTokenAttribute independently', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          primaryTokenAttribute: 'health',
+          secondaryTokenAttribute: 'mana',
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `static defineSchema() {
+  return { health: new fields.SchemaField({ value: new fields.NumberField(), max: new fields.NumberField() }) };
+}`,
+        'utf8',
+      );
+      const seven = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-007');
+      expect(seven).toHaveLength(1);
+      expect(seven[0]?.message).toContain('mana');
+    });
+
+    it('does nothing when no token attribute is declared', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0' }),
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+  });
+});
+
+describe('_internal.isSourceFile', () => {
+  it('accepts every supported source extension', () => {
+    expect(_internal.isSourceFile('main.ts')).toBe(true);
+    expect(_internal.isSourceFile('main.tsx')).toBe(true);
+    expect(_internal.isSourceFile('main.mts')).toBe(true);
+    expect(_internal.isSourceFile('main.cts')).toBe(true);
+    expect(_internal.isSourceFile('main.mjs')).toBe(true);
+    expect(_internal.isSourceFile('main.cjs')).toBe(true);
+    expect(_internal.isSourceFile('main.js')).toBe(true);
+  });
+
+  it('rejects declaration files', () => {
+    expect(_internal.isSourceFile('types.d.ts')).toBe(false);
+    expect(_internal.isSourceFile('types.d.mts')).toBe(false);
+    expect(_internal.isSourceFile('types.d.cts')).toBe(false);
+  });
+
+  it('rejects non-source extensions', () => {
+    expect(_internal.isSourceFile('README.md')).toBe(false);
+    expect(_internal.isSourceFile('system.json')).toBe(false);
+    expect(_internal.isSourceFile('main.css')).toBe(false);
+  });
+});
+
+describe('_internal.lastSegment', () => {
+  it('returns the final dot-separated segment', () => {
+    expect(_internal.lastSegment('system.biography')).toBe('biography');
+    expect(_internal.lastSegment('a.b.c.d')).toBe('d');
+  });
+
+  it('returns the whole string when there is no dot', () => {
+    expect(_internal.lastSegment('biography')).toBe('biography');
+  });
+});

--- a/packages/cli/src/audit/index.ts
+++ b/packages/cli/src/audit/index.ts
@@ -1,0 +1,73 @@
+/**
+ * Audit orchestrator — runs every rule against a project root and
+ * aggregates the findings into an `AuditReport`.
+ *
+ * Rule organisation:
+ *   - manifest-rules.ts → VTTF-AUDIT-001, 002, 003 (manifest-only)
+ *   - source-rules.ts   → VTTF-AUDIT-004, 005, 006, 007 (source walker
+ *                         + cross-check with manifest where needed)
+ *
+ * The orchestrator stays minimal — it knows which rule sets exist, but
+ * the rules themselves are responsible for their own file IO. This keeps
+ * the individual rule files testable in isolation.
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { runManifestRules } from './manifest-rules.js';
+import { runSourceRules } from './source-rules.js';
+import { type AuditReport, type RuleResult, SEVERITY_RANK } from './types.js';
+
+export interface RunAuditOptions {
+  cwd: string;
+}
+
+export class AuditTargetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuditTargetError';
+  }
+}
+
+export async function runAudit(options: RunAuditOptions): Promise<AuditReport> {
+  const cwd = resolve(options.cwd);
+  // A missing or non-directory target must fail loudly. Otherwise both
+  // rule sets return zero findings, the CLI prints "No issues found" and
+  // exits 0 — silently auditing nothing in CI. The mistyped-path failure
+  // mode is invisible without this check.
+  if (!existsSync(cwd)) {
+    throw new AuditTargetError(`Audit target does not exist: ${cwd}`);
+  }
+  if (!statSync(cwd).isDirectory()) {
+    throw new AuditTargetError(`Audit target is not a directory: ${cwd}`);
+  }
+  const startedAt = new Date().toISOString();
+
+  const [manifestFindings, sourceFindings] = await Promise.all([
+    runManifestRules(cwd),
+    runSourceRules(cwd),
+  ]);
+
+  const findings: RuleResult[] = [...manifestFindings, ...sourceFindings].sort(compareFindings);
+
+  return {
+    cwd,
+    startedAt,
+    findings,
+    counts: countBySeverity(findings),
+  };
+}
+
+/** Sort: HIGH first, then by ruleId for deterministic output. */
+function compareFindings(a: RuleResult, b: RuleResult): number {
+  const sev = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+  if (sev !== 0) return sev;
+  if (a.ruleId !== b.ruleId) return a.ruleId.localeCompare(b.ruleId);
+  return a.filePath.localeCompare(b.filePath);
+}
+
+function countBySeverity(findings: ReadonlyArray<RuleResult>): AuditReport['counts'] {
+  const counts = { HIGH: 0, MEDIUM: 0, LOW: 0 };
+  for (const f of findings) counts[f.severity] += 1;
+  return counts;
+}

--- a/packages/cli/src/audit/manifest-rules.ts
+++ b/packages/cli/src/audit/manifest-rules.ts
@@ -1,0 +1,222 @@
+/**
+ * Manifest-scope audit rules.
+ *
+ * These rules operate on the parsed contents of `system.json` and/or
+ * `module.json` at the project root. They cover three v13 manifest
+ * footguns from the VTTForge audit catalog:
+ *
+ *   VTTF-AUDIT-001 (HIGH)   — flags.hotReload shape
+ *   VTTF-AUDIT-002 (MEDIUM) — deprecated gridDistance/gridUnits
+ *   VTTF-AUDIT-003 (LOW)    — styles array of strings (v12 shape)
+ *
+ * Each rule emits zero or more `RuleResult`s. Line numbers are looked up
+ * cheaply by scanning the raw JSON for the offending key — accurate
+ * enough for navigation, no AST dependency.
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { RuleResult } from './types.js';
+
+const MANIFEST_FILES = ['system.json', 'module.json'] as const;
+
+interface LoadedManifest {
+  path: string;
+  raw: string;
+  parsed: Record<string, unknown>;
+}
+
+/**
+ * Load the manifest(s) at the project root. Returns at most two entries
+ * (system + module), skipping anything that can't be parsed as a JSON
+ * object. We tolerate parse errors here because that's a separate failure
+ * mode the user will hit when they actually run `vite build`; the audit
+ * shouldn't double-report it.
+ */
+async function loadManifests(cwd: string): Promise<LoadedManifest[]> {
+  const out: LoadedManifest[] = [];
+  for (const file of MANIFEST_FILES) {
+    const path = join(cwd, file);
+    if (!existsSync(path)) continue;
+    let raw: string;
+    try {
+      raw = await readFile(path, 'utf8');
+    } catch {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      out.push({ path, raw, parsed: parsed as Record<string, unknown> });
+    }
+  }
+  return out;
+}
+
+/**
+ * Find the 1-based line number of the first `"key":` occurrence in JSON
+ * source. Good enough for navigation — JSON keys are usually unique at
+ * the level we report on, and even when nested duplicates exist the
+ * first occurrence points at the right region of the file.
+ */
+function findKeyLine(raw: string, key: string): number | undefined {
+  const needle = `"${key}"`;
+  const idx = raw.indexOf(needle);
+  if (idx < 0) return undefined;
+  let line = 1;
+  for (let i = 0; i < idx; i += 1) {
+    if (raw[i] === '\n') line += 1;
+  }
+  return line;
+}
+
+/**
+ * VTTF-AUDIT-001 (HIGH) — flags.hotReload shape.
+ *
+ * v12 accepted `"hotReload": ["css", "hbs", ...]` (array). v13 expects
+ * `"hotReload": { "extensions": [...], "paths": [...] }` (object at the
+ * root of `flags`, NOT nested under a package id). With the array shape
+ * the server's chokidar watcher reads `.extensions` and gets undefined,
+ * silently disabling HMR for the package.
+ */
+function ruleHotReload(manifest: LoadedManifest): RuleResult[] {
+  const flags = manifest.parsed.flags;
+  if (!flags || typeof flags !== 'object' || Array.isArray(flags)) return [];
+  const hr = (flags as Record<string, unknown>).hotReload;
+  if (hr === undefined) return [];
+
+  const line = findKeyLine(manifest.raw, 'hotReload');
+  if (Array.isArray(hr)) {
+    return [
+      {
+        ruleId: 'VTTF-AUDIT-001',
+        title: 'flags.hotReload uses the deprecated v12 array shape',
+        severity: 'HIGH',
+        filePath: manifest.path,
+        line,
+        message:
+          'flags.hotReload is an array; v13 expects an object `{ "extensions": [...], "paths": [...] }`. With the array shape Foundry silently disables HMR for this package.',
+        remediation:
+          'Replace the array with an object: `"hotReload": { "extensions": ["css", "hbs", "json"], "paths": ["styles", "templates", "lang"] }`.',
+      },
+    ];
+  }
+  // `typeof null === 'object'` would slip past a naive check, so the
+  // null / scalar / array branches are all rejected explicitly before
+  // we trust hr as an object.
+  if (hr === null || typeof hr !== 'object') {
+    return [
+      {
+        ruleId: 'VTTF-AUDIT-001',
+        title: 'flags.hotReload has an invalid shape',
+        severity: 'HIGH',
+        filePath: manifest.path,
+        line,
+        message: 'flags.hotReload must be an object with `extensions` and `paths` arrays in v13.',
+        remediation: 'Replace with `"hotReload": { "extensions": [...], "paths": [...] }`.',
+      },
+    ];
+  }
+  // Object shape — `extensions` is mandatory (Foundry has no default for
+  // which extensions to watch), but `paths` is optional: when omitted,
+  // Foundry watches the entire package root. Don't penalise users who
+  // legitimately want the broader watch scope.
+  const hrObj = hr as Record<string, unknown>;
+  if (!Array.isArray(hrObj.extensions)) {
+    return [
+      {
+        ruleId: 'VTTF-AUDIT-001',
+        title: 'flags.hotReload is missing the required `extensions` key',
+        severity: 'HIGH',
+        filePath: manifest.path,
+        line,
+        message:
+          'flags.hotReload must declare an `extensions` array — Foundry has no default and the watcher silently does nothing without it.',
+        remediation:
+          'Add `extensions`: `"hotReload": { "extensions": ["css", "hbs", "json"], "paths": ["styles", "templates", "lang"] }`. `paths` is optional (defaults to the package root) but recommended.',
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * VTTF-AUDIT-002 (MEDIUM) — deprecated top-level grid fields.
+ *
+ * v12 used flat `gridDistance` + `gridUnits`. v13 wants
+ * `grid: { type, distance, units, diagonals }`. The legacy keys still
+ * work today (Foundry auto-migrates and warns) but will be removed in
+ * v14 — flag them now so the project is forward-compatible.
+ */
+function ruleGridShape(manifest: LoadedManifest): RuleResult[] {
+  const hasLegacyDistance = 'gridDistance' in manifest.parsed;
+  const hasLegacyUnits = 'gridUnits' in manifest.parsed;
+  if (!hasLegacyDistance && !hasLegacyUnits) return [];
+
+  const offendingKey = hasLegacyDistance ? 'gridDistance' : 'gridUnits';
+  return [
+    {
+      ruleId: 'VTTF-AUDIT-002',
+      title: 'Top-level gridDistance / gridUnits are deprecated v12 fields',
+      severity: 'MEDIUM',
+      filePath: manifest.path,
+      line: findKeyLine(manifest.raw, offendingKey),
+      message:
+        'gridDistance and gridUnits at the manifest root are the v12 shape. Foundry v13 expects a structured `grid` object and emits a deprecation warning on load; the fields will be removed in v14.',
+      remediation:
+        'Replace with `"grid": { "type": 1, "distance": 5, "units": "ft", "diagonals": 0 }` (adjust values to your system).',
+    },
+  ];
+}
+
+/**
+ * VTTF-AUDIT-003 (LOW) — styles array of strings.
+ *
+ * v12 took `styles: ["styles/foo.css"]`. v13 expects `styles: [{ src,
+ * layer? }]` so cascade-layer ordering can be declared in the manifest.
+ * The string form still works (Foundry auto-migrates) but emits a
+ * deprecation warning and loses the ability to control layer placement.
+ */
+function ruleStylesShape(manifest: LoadedManifest): RuleResult[] {
+  const styles = manifest.parsed.styles;
+  if (!Array.isArray(styles) || styles.length === 0) return [];
+
+  // The whole array is uniform in the v12 shape — entries are strings.
+  // Mixed arrays (some string, some object) also fail v13 expectations.
+  const hasString = styles.some((entry) => typeof entry === 'string');
+  if (!hasString) return [];
+
+  return [
+    {
+      ruleId: 'VTTF-AUDIT-003',
+      title: 'styles uses the deprecated v12 string-array shape',
+      severity: 'LOW',
+      filePath: manifest.path,
+      line: findKeyLine(manifest.raw, 'styles'),
+      message:
+        'styles entries should be objects of the form `{ "src": "path/to.css", "layer": "optional-layer" }` in v13. String entries auto-migrate today but the conversion drops your control over cascade-layer placement.',
+      remediation:
+        'Replace each string with `{ "src": "<that-path>" }`. Add a `"layer"` field per entry where you want explicit cascade ordering.',
+    },
+  ];
+}
+
+/**
+ * Entry point: run every manifest rule against every manifest at the
+ * project root.
+ */
+export async function runManifestRules(cwd: string): Promise<RuleResult[]> {
+  const manifests = await loadManifests(cwd);
+  const results: RuleResult[] = [];
+  for (const manifest of manifests) {
+    results.push(...ruleHotReload(manifest));
+    results.push(...ruleGridShape(manifest));
+    results.push(...ruleStylesShape(manifest));
+  }
+  return results;
+}

--- a/packages/cli/src/audit/reporter.ts
+++ b/packages/cli/src/audit/reporter.ts
@@ -1,0 +1,83 @@
+/**
+ * Render an `AuditReport` as JSON (machine-readable, stable schema) or
+ * markdown (terminal-friendly, sectioned by severity).
+ *
+ * JSON output is the contract for downstream CI tooling: stable shape,
+ * stable severity strings, stable ruleId namespace `VTTF-AUDIT-NNN`. The
+ * markdown variant exists so a human running `vttforge audit` in a
+ * scrollback gets immediate signal without piping through `jq`.
+ */
+
+import { relative } from 'node:path';
+import type { AuditReport, RuleResult } from './types.js';
+
+export type ReportFormat = 'json' | 'markdown';
+
+export function formatReport(report: AuditReport, format: ReportFormat): string {
+  return format === 'json' ? formatJson(report) : formatMarkdown(report);
+}
+
+function formatJson(report: AuditReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+function formatMarkdown(report: AuditReport): string {
+  const { findings, counts, cwd } = report;
+  const lines: string[] = [];
+  lines.push('# vttforge audit report');
+  lines.push('');
+  lines.push(`- cwd: \`${cwd}\``);
+  lines.push(`- started: ${report.startedAt}`);
+  lines.push(
+    `- findings: ${findings.length} (${counts.HIGH} HIGH · ${counts.MEDIUM} MEDIUM · ${counts.LOW} LOW)`,
+  );
+  lines.push('');
+  if (findings.length === 0) {
+    lines.push('No issues found. The system / module looks healthy against the v13 catalog.');
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  for (const severity of ['HIGH', 'MEDIUM', 'LOW'] as const) {
+    const bucket = findings.filter((f) => f.severity === severity);
+    if (bucket.length === 0) continue;
+    lines.push(`## ${severity} (${bucket.length})`);
+    lines.push('');
+    for (const finding of bucket) {
+      lines.push(formatFinding(finding, cwd));
+      lines.push('');
+    }
+  }
+  return lines.join('\n');
+}
+
+function formatFinding(finding: RuleResult, cwd: string): string {
+  const location = formatLocation(finding, cwd);
+  const lines: string[] = [];
+  lines.push(`### \`${finding.ruleId}\` — ${finding.title}`);
+  lines.push('');
+  lines.push(`- file: ${location}`);
+  lines.push(`- message: ${finding.message}`);
+  if (finding.remediation) {
+    lines.push(`- fix: ${finding.remediation}`);
+  }
+  return lines.join('\n');
+}
+
+function formatLocation(finding: RuleResult, cwd: string): string {
+  const rel = relativizeIfBelow(finding.filePath, cwd);
+  return finding.line !== undefined ? `\`${rel}:${finding.line}\`` : `\`${rel}\``;
+}
+
+/**
+ * Show paths relative to `cwd` when they live underneath it (cleaner reports),
+ * fall back to the absolute path otherwise so we don't lie about where the
+ * file actually is.
+ */
+function relativizeIfBelow(filePath: string, cwd: string): string {
+  const rel = relative(cwd, filePath);
+  if (rel === '' || rel.startsWith('..') || rel.startsWith('/')) {
+    return filePath;
+  }
+  return rel;
+}

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -1,0 +1,807 @@
+/**
+ * Source-tree audit rules.
+ *
+ * These walk `.ts` / `.tsx` / `.mjs` / `.cjs` / `.js` files under the
+ * project root (excluding common build/dependency dirs) and apply regex
+ * heuristics to spot four v13 footguns from the VTTForge audit catalog:
+ *
+ *   VTTF-AUDIT-004 (MEDIUM) — HTMLField/FilePathField missing manifest declaration
+ *   VTTF-AUDIT-005 (MEDIUM) — extends TypeDataModel without prepareBaseData stub
+ *   VTTF-AUDIT-006 (LOW)    — `_addDataFieldMigrations` override (wrong signature)
+ *   VTTF-AUDIT-007 (MEDIUM) — manifest primary/secondaryTokenAttribute not matched
+ *                             by a `value`/`max` SchemaField in source
+ *
+ * Regex-based on purpose: avoids pulling in a TypeScript AST dependency
+ * for what amount to four pattern checks. The trade-off is occasional
+ * false negatives on heavily-formatted code; the alternative would be a
+ * 30MB+ runtime dep for marginal gains.
+ */
+
+import { existsSync } from 'node:fs';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { RuleResult } from './types.js';
+
+/** Directories we never descend into — they're not user source. */
+const EXCLUDED_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.git',
+  '.turbo',
+  '.vttforge',
+  '.next',
+  'coverage',
+  '.vitest-cache',
+]);
+
+// `.mts`/`.cts` are valid TS ESM/CJS source files; `.d.ts`/`.d.mts`/`.d.cts`
+// are declaration-only and skipped (no real source to scan).
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.mjs', '.cjs', '.js'] as const;
+
+function isSourceFile(name: string): boolean {
+  if (name.endsWith('.d.ts') || name.endsWith('.d.mts') || name.endsWith('.d.cts')) {
+    return false;
+  }
+  return SOURCE_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
+
+async function* walkSourceFiles(cwd: string): AsyncGenerator<string> {
+  const entries = await readdir(cwd, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') && EXCLUDED_DIRS.has(entry.name)) continue;
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+      yield* walkSourceFiles(join(cwd, entry.name));
+    } else if (entry.isFile() && isSourceFile(entry.name)) {
+      yield join(cwd, entry.name);
+    }
+  }
+}
+
+/** Find the 1-based line number of the first occurrence of `needle`. */
+function lineOf(content: string, needle: string | RegExp): number | undefined {
+  const idx = typeof needle === 'string' ? content.indexOf(needle) : content.search(needle);
+  if (idx < 0) return undefined;
+  let line = 1;
+  for (let i = 0; i < idx; i += 1) {
+    if (content[i] === '\n') line += 1;
+  }
+  return line;
+}
+
+/** VTTF-AUDIT-005 — `extends TypeDataModel` without a `prepareBaseData(...)` method. */
+function rule005(filePath: string, content: string): RuleResult[] {
+  // Find every direct TypeDataModel subclass with its body extents so we
+  // can check each class independently. The previous file-wide check
+  // would pass a whole file if ANY class in it had prepareBaseData; that
+  // silently let sibling subclasses miss the hook.
+  const out: RuleResult[] = [];
+  const directClasses = findDirectTypeDataModelClasses(content);
+  for (const cls of directClasses) {
+    const body = content.slice(cls.openIdx + 1, cls.endIdx);
+    if (/prepareBaseData\s*\(/.test(body)) continue;
+    out.push({
+      ruleId: 'VTTF-AUDIT-005',
+      title: 'TypeDataModel subclass missing prepareBaseData stub',
+      severity: 'MEDIUM',
+      filePath,
+      line: cls.startLine,
+      message: `Class \`${cls.className}\` extends TypeDataModel directly but does not define prepareBaseData(). Active Effects apply between prepareBaseData and prepareDerivedData; without the hook, AE consumers see uninitialised fields.`,
+      remediation:
+        'Add a no-op `prepareBaseData()` method (or extend `BaseTypeDataModel()` from `@vttforge/core`, which provides the stub).',
+    });
+  }
+  return out;
+}
+
+/**
+ * Subset of `findClassRanges` that only returns classes whose `extends`
+ * names `TypeDataModel` (and not via the `BaseTypeDataModel()` factory).
+ * The word boundary in `\bTypeDataModel\b` keeps the factory pattern
+ * out, same as the lower-level helper.
+ */
+function findDirectTypeDataModelClasses(content: string): ClassRange[] {
+  const re = /class\s+(\w+)\s+extends\s+(?:[\w.]+\.)?\bTypeDataModel\b[^{]*\{/g;
+  const out: ClassRange[] = [];
+  for (const match of content.matchAll(re)) {
+    if (match.index === undefined) continue;
+    const openIdx = match.index + match[0].length - 1;
+    let depth = 0;
+    let endIdx = -1;
+    for (let i = openIdx; i < content.length; i += 1) {
+      if (content[i] === '{') depth += 1;
+      else if (content[i] === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          endIdx = i;
+          break;
+        }
+      }
+    }
+    if (endIdx < 0) continue;
+    let line = 1;
+    for (let i = 0; i < match.index; i += 1) {
+      if (content[i] === '\n') line += 1;
+    }
+    out.push({ className: match[1] ?? '(anonymous)', startLine: line, openIdx, endIdx });
+  }
+  return out;
+}
+
+/** VTTF-AUDIT-006 — `_addDataFieldMigrations(` override on a TypeDataModel subclass. */
+function rule006(filePath: string, content: string): RuleResult[] {
+  if (!/_addDataFieldMigrations\s*\(/.test(content)) return [];
+  // Only flag when the file defines a TypeDataModel-derived class — direct
+  // `TypeDataModel` OR the VTTForge `BaseTypeDataModel()` factory. The
+  // factory case matters because templates lean on it; an override there
+  // is the most likely place users would write the buggy signature.
+  if (!/extends\s+(?:[\w.]+\.)?(?:Base)?TypeDataModel\b/.test(content)) return [];
+  return [
+    {
+      ruleId: 'VTTF-AUDIT-006',
+      title: 'Method name confused with Foundry migration API',
+      severity: 'LOW',
+      filePath,
+      line: lineOf(content, /_addDataFieldMigrations\s*\(/),
+      message:
+        'The plural `_addDataFieldMigrations` is not a real Foundry API. The canonical v13 migration hook is a static `migrateData(source)` override that calls singular `super._addDataFieldMigration(source, oldKey, newKey, apply?)` for each rename. Instance overrides named `_addDataFieldMigrations` never run.',
+      remediation:
+        'Replace the override with `static migrateData(source) { super._addDataFieldMigration(source, "oldKey", "newKey"); return super.migrateData(source); }`.',
+    },
+  ];
+}
+
+/**
+ * Track each class declaration's brace-balanced range so we can ask
+ * "which class encloses position X?" later. Without this, rule 004 has
+ * to fall back to a global declared-fields union, which silently passes
+ * when two subtypes share a field name but only one declares it.
+ */
+interface ClassRange {
+  className: string;
+  startLine: number;
+  openIdx: number;
+  endIdx: number;
+}
+
+function findClassRanges(content: string): ClassRange[] {
+  const out: ClassRange[] = [];
+  const re = /class\s+(\w+)(?:\s+extends\s+[^{]+)?\{/g;
+  for (const match of content.matchAll(re)) {
+    if (match.index === undefined) continue;
+    const openIdx = match.index + match[0].length - 1;
+    let depth = 0;
+    let endIdx = -1;
+    for (let i = openIdx; i < content.length; i += 1) {
+      if (content[i] === '{') depth += 1;
+      else if (content[i] === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          endIdx = i;
+          break;
+        }
+      }
+    }
+    if (endIdx < 0) continue;
+    let line = 1;
+    for (let i = 0; i < match.index; i += 1) {
+      if (content[i] === '\n') line += 1;
+    }
+    out.push({ className: match[1] ?? '(anonymous)', startLine: line, openIdx, endIdx });
+  }
+  return out;
+}
+
+function findEnclosingClass(ranges: ClassRange[], idx: number): string | undefined {
+  // Inner class wins (later in the array, since classes are flat in typical
+  // Foundry code). Iterate in reverse so a nested class beats its parent.
+  for (let i = ranges.length - 1; i >= 0; i -= 1) {
+    const r = ranges[i];
+    if (!r) continue;
+    if (idx >= r.openIdx && idx <= r.endIdx) return r.className;
+  }
+  return undefined;
+}
+
+/**
+ * Detect class→subtype registrations in three forms:
+ *
+ *   1. `CONFIG.<Doc>.dataModels.<subtype> = <ClassName>` (direct assignment)
+ *   2. `CONFIG.<Doc>.dataModels = { <subtype>: <ClassName>, … }` (block)
+ *   3. `registerSystem({ actorDataModels: { <subtype>: <ClassName>, … }, … })`
+ *      and the analogous `itemDataModels`, `activeEffectDataModels`, etc.
+ *      — VTTForge's templated entry point uses this form, so without case
+ *      (3) the bundled scaffolds register through an unknown surface and
+ *      rule 004 falls back to the looser global-union check.
+ */
+interface ConfigMapping {
+  doc: string;
+  subtype: string;
+  className: string;
+}
+
+/** Map a `registerSystem({ ...DataModels })` key to the document name. */
+const REGISTER_SYSTEM_KEYS: ReadonlyArray<{ key: string; doc: string }> = [
+  { key: 'actorDataModels', doc: 'Actor' },
+  { key: 'itemDataModels', doc: 'Item' },
+  { key: 'activeEffectDataModels', doc: 'ActiveEffect' },
+  { key: 'journalEntryPageDataModels', doc: 'JournalEntryPage' },
+  { key: 'regionBehaviorDataModels', doc: 'RegionBehavior' },
+];
+
+function findConfigMappings(content: string): ConfigMapping[] {
+  const out: ConfigMapping[] = [];
+
+  // (1) Direct CONFIG.<Doc>.dataModels.<subtype> = <Class>
+  const direct = /CONFIG\.(\w+)\.dataModels\.(\w+)\s*=\s*(\w+)/g;
+  for (const m of content.matchAll(direct)) {
+    out.push({ doc: m[1] ?? '', subtype: m[2] ?? '', className: m[3] ?? '' });
+  }
+
+  // (2) Block CONFIG.<Doc>.dataModels = { <subtype>: <Class>, … }
+  const block = /CONFIG\.(\w+)\.dataModels\s*=\s*\{([\s\S]*?)\}/g;
+  for (const m of content.matchAll(block)) {
+    const doc = m[1] ?? '';
+    const body = m[2] ?? '';
+    const entries = body.matchAll(/(\w+)\s*:\s*(\w+)/g);
+    for (const e of entries) {
+      out.push({ doc, subtype: e[1] ?? '', className: e[2] ?? '' });
+    }
+  }
+
+  // (3) registerSystem({ actorDataModels: { ... }, itemDataModels: { ... }, … })
+  // Find every `<KeyName>: {` block within the file body, then grab the
+  // pairs inside. We use balanced-brace extraction so a nested SchemaField
+  // initializer doesn't truncate the body — but `dataModels` blocks
+  // typically only contain simple `<subtype>: <ClassName>` entries.
+  for (const { key, doc } of REGISTER_SYSTEM_KEYS) {
+    const re = new RegExp(String.raw`\b${key}\s*:\s*\{`, 'g');
+    for (const m of content.matchAll(re)) {
+      if (m.index === undefined) continue;
+      const openIdx = m.index + m[0].length - 1;
+      let depth = 0;
+      let endIdx = -1;
+      for (let i = openIdx; i < content.length; i += 1) {
+        if (content[i] === '{') depth += 1;
+        else if (content[i] === '}') {
+          depth -= 1;
+          if (depth === 0) {
+            endIdx = i;
+            break;
+          }
+        }
+      }
+      if (endIdx < 0) continue;
+      const body = content.slice(openIdx + 1, endIdx);
+      for (const pair of body.matchAll(/(\w+)\s*:\s*(\w+)/g)) {
+        out.push({ doc, subtype: pair[1] ?? '', className: pair[2] ?? '' });
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Match `<name>: new (f|fields|foundry.data.fields).HTMLField(` or
+ * `.FilePathField(`. We capture the field name, the field type, the
+ * enclosing class, AND the dot-path through any enclosing SchemaField
+ * wrappers — so rule 004 compares against the FULL manifest declaration
+ * path (`profile.bio`), not just the leaf segment (`bio`).
+ */
+const RICH_FIELD_RE = /(\w+)\s*:\s*new\s+(?:[\w.]+\.)?(HTMLField|FilePathField)\s*\(/g;
+
+interface RichFieldUsage {
+  fieldName: string;
+  type: 'HTMLField' | 'FilePathField';
+  line: number;
+  enclosingClass: string | undefined;
+  /** Dot-path through SchemaField nesting (e.g. `profile.bio`, or just `bio` at top level). */
+  schemaPath: string;
+}
+
+function findRichFields(content: string, classes: ClassRange[]): RichFieldUsage[] {
+  const out: RichFieldUsage[] = [];
+  for (const m of content.matchAll(RICH_FIELD_RE)) {
+    if (m.index === undefined) continue;
+    let line = 1;
+    for (let i = 0; i < m.index; i += 1) {
+      if (content[i] === '\n') line += 1;
+    }
+    const fieldName = m[1] ?? '(anonymous)';
+    out.push({
+      fieldName,
+      type: (m[2] as 'HTMLField' | 'FilePathField') ?? 'HTMLField',
+      line,
+      enclosingClass: findEnclosingClass(classes, m.index),
+      schemaPath: buildSchemaPath(content, m.index, fieldName),
+    });
+  }
+  return out;
+}
+
+/**
+ * Walk backward from a rich-field match looking for enclosing SchemaField
+ * wrappers, building the dot-path up to the outermost schema.
+ *
+ * For `profile: new SchemaField({ bio: new HTMLField() })`, the rich-field
+ * match is `bio: new HTMLField(`; walking back, we find the enclosing `{`
+ * that's preceded by `profile: new ...SchemaField(`, prepend `profile`, and
+ * recurse. Top-level fields (immediate children of `defineSchema()`'s
+ * returned object) recurse until the enclosing `{` has no SchemaField
+ * ancestor, returning just the field name.
+ */
+function buildSchemaPath(content: string, idx: number, fieldName: string): string {
+  // Find the immediate enclosing `{` by walking backward, tracking balance.
+  let depth = 0;
+  let openIdx = -1;
+  for (let i = idx - 1; i >= 0; i -= 1) {
+    const ch = content[i];
+    if (ch === '}') depth += 1;
+    else if (ch === '{') {
+      if (depth === 0) {
+        openIdx = i;
+        break;
+      }
+      depth -= 1;
+    }
+  }
+  if (openIdx < 0) return fieldName;
+
+  // Look at the text immediately preceding the enclosing `{` for a
+  // `<key>: new <prefix>SchemaField(` pattern. The lookback window is
+  // bounded so we don't accidentally cross other constructs.
+  const lookbackStart = Math.max(0, openIdx - 200);
+  const before = content.slice(lookbackStart, openIdx);
+  const m = before.match(/(\w+)\s*:\s*new\s+(?:[\w.]+\.)?SchemaField\s*\(\s*$/);
+  if (!m) return fieldName;
+  const parentName = m[1] ?? '';
+  if (!parentName) return fieldName;
+  // The parent's match position relative to content — recurse from there
+  // so multi-level nesting (`profile.contact.email`) is captured.
+  const parentMatchStart = lookbackStart + (m.index ?? 0);
+  const parentPath = buildSchemaPath(content, parentMatchStart, parentName);
+  return `${parentPath}.${fieldName}`;
+}
+
+interface DeclaredFields {
+  /**
+   * Keyed `Doc.subtype` → declared htmlFields / filePathFields.
+   * Paths are stored AFTER stripping a leading `system.` prefix (Foundry
+   * convention puts TypeDataModel-driven manifests under `system.…`) so
+   * we can compare against source-side paths that don't include the
+   * `system.` root.
+   */
+  perSubtype: Map<string, { html: Set<string>; filePath: Set<string> }>;
+  /** Union across every subtype — used as a fallback when class→subtype lookup fails. */
+  globalHtml: Set<string>;
+  globalFilePath: Set<string>;
+}
+
+/**
+ * Foundry's manifest convention puts TypeDataModel-driven field paths
+ * under the `system.` root (`system.biography`). Source-side rich-field
+ * paths from `buildSchemaPath` don't include that prefix because they
+ * start from `defineSchema()`'s returned object. Strip it for matching.
+ */
+function normalizeDeclaredPath(path: string): string {
+  return path.startsWith('system.') ? path.slice('system.'.length) : path;
+}
+
+/**
+ * VTTF-AUDIT-004 — cross-check source HTMLField/FilePathField usages
+ * against the manifest's documentTypes declarations.
+ *
+ * Subtype-aware: if the enclosing class is registered on
+ * `CONFIG.<Doc>.dataModels.<subtype>`, the field must be declared in
+ * THAT subtype's htmlFields / filePathFields. Otherwise — class
+ * unregistered, registration spread across files, dynamic registration —
+ * we fall back to the global union check (catches the common "forgot to
+ * declare anything" case without false positives on advanced setups).
+ */
+function rule004(
+  filePath: string,
+  content: string,
+  declared: DeclaredFields,
+  classToSubtypes: Map<string, ConfigMapping[]>,
+): RuleResult[] {
+  const classes = findClassRanges(content);
+  const usages = findRichFields(content, classes);
+  const out: RuleResult[] = [];
+  for (const usage of usages) {
+    const declaredBucketName = usage.type === 'HTMLField' ? 'htmlFields' : 'filePathFields';
+    const mappings = usage.enclosingClass ? (classToSubtypes.get(usage.enclosingClass) ?? []) : [];
+    const sourcePath = usage.schemaPath;
+
+    if (mappings.length > 0) {
+      // Strict per-subtype check: every subtype this class is registered
+      // under must declare the field's FULL source path. `profile.bio`
+      // declared in `Actor.character` doesn't cover an undeclared
+      // `profile.bio` in `Actor.npc`.
+      const missing = mappings.filter((mapping) => {
+        const decl = declared.perSubtype.get(`${mapping.doc}.${mapping.subtype}`);
+        const bucket = usage.type === 'HTMLField' ? decl?.html : decl?.filePath;
+        return !bucket?.has(sourcePath);
+      });
+      if (missing.length > 0) {
+        const locations = missing.map((mapping) => `${mapping.doc}.${mapping.subtype}`).join(', ');
+        out.push({
+          ruleId: 'VTTF-AUDIT-004',
+          title: `${usage.type} not declared in manifest documentTypes`,
+          severity: 'MEDIUM',
+          filePath,
+          line: usage.line,
+          message: `\`${usage.enclosingClass}\` declares \`${sourcePath}\` as ${usage.type}, but documentTypes.${locations}.${declaredBucketName} does not list this path. The Foundry server only sanitises declared paths.`,
+          remediation: `Add \`${sourcePath}\` (or \`system.${sourcePath}\`) to documentTypes.${missing[0]?.doc}.${missing[0]?.subtype}.${declaredBucketName} in your manifest.`,
+        });
+      }
+      continue;
+    }
+
+    // Fallback: no class→subtype mapping detected (class not registered,
+    // registration via an unrecognized API, dynamic registration). Check
+    // the global union — still useful, but with looser semantics. Match
+    // on FULL source path so `profile.bio` declared doesn't silently
+    // shadow an undeclared `journal.bio`.
+    const bucket = usage.type === 'HTMLField' ? declared.globalHtml : declared.globalFilePath;
+    if (bucket.has(sourcePath)) continue;
+    out.push({
+      ruleId: 'VTTF-AUDIT-004',
+      title: `${usage.type} not declared in manifest documentTypes`,
+      severity: 'MEDIUM',
+      filePath,
+      line: usage.line,
+      message: `Schema declares \`${sourcePath}\` as ${usage.type}, but no documentTypes.<Doc>.<subtype>.${declaredBucketName} entry lists this path. The Foundry server only sanitises declared paths.`,
+      remediation: `Add \`${sourcePath}\` (or \`system.${sourcePath}\`) to documentTypes.<Doc>.<subtype>.${declaredBucketName} in your manifest.`,
+    });
+  }
+  return out;
+}
+
+/**
+ * VTTF-AUDIT-007 — manifest's `primaryTokenAttribute` /
+ * `secondaryTokenAttribute` must point at a SchemaField with `value` +
+ * `max` keys. If not, Foundry's `getBarAttribute` silently degrades to
+ * value-only rendering (no bar at all).
+ *
+ * Cross-check walks the source for every SchemaField declaration paired
+ * with its full schema path (`buildSchemaPath`). The manifest path is
+ * matched EXACTLY — `primaryTokenAttribute: 'health'` does not accept a
+ * nested `attributes.health` SchemaField, and a nested path like
+ * `attributes.hp` is resolved by finding the declaration at that exact
+ * dot-path. No more "verify manually" branch; either the path resolves
+ * or it doesn't.
+ */
+async function rule007(
+  manifestPath: string | null,
+  manifestRaw: string | null,
+  manifestParsed: Record<string, unknown> | null,
+  sourceFiles: string[],
+): Promise<RuleResult[]> {
+  if (!manifestPath || !manifestRaw || !manifestParsed) return [];
+  const out: RuleResult[] = [];
+  for (const key of ['primaryTokenAttribute', 'secondaryTokenAttribute'] as const) {
+    const value = manifestParsed[key];
+    if (typeof value !== 'string' || value.length === 0) continue;
+    const matched = await sourceHasValueMaxSchemaAtPath(sourceFiles, value);
+    if (!matched) {
+      out.push({
+        ruleId: 'VTTF-AUDIT-007',
+        title: `${key} does not resolve to a {value, max} SchemaField`,
+        severity: 'MEDIUM',
+        filePath: manifestPath,
+        line: lineOfInRaw(manifestRaw, key),
+        message: `Manifest ${key} is \`${value}\`, but no TypeDataModel schema in the source declares a SchemaField at this path with both \`value\` and \`max\` keys. Foundry's getBarAttribute degrades silently when the structure doesn't match.`,
+        remediation: `Define \`${value}\` as a SchemaField with \`value\` and \`max\` NumberField children in your TypeDataModel schema (matching the manifest path exactly).`,
+      });
+    }
+  }
+  return out;
+}
+
+function lineOfInRaw(raw: string, key: string): number | undefined {
+  const idx = raw.indexOf(`"${key}"`);
+  if (idx < 0) return undefined;
+  let line = 1;
+  for (let i = 0; i < idx; i += 1) {
+    if (raw[i] === '\n') line += 1;
+  }
+  return line;
+}
+
+/**
+ * Path-aware lookup for the rule-007 cross-check. For every SchemaField
+ * declaration in every source file, compute its FULL schema path via
+ * `buildSchemaPath`. Match the manifest's `primaryTokenAttribute` (which
+ * may be a single key like `health` or a dotted path like `attributes.hp`)
+ * against the declaration's path exactly. Only declarations whose schema
+ * path equals the manifest value contribute to the value+max check.
+ *
+ * Why exact path: an unqualified `health: new SchemaField(...)` inside
+ * `attributes: new SchemaField({...})` has schema path `attributes.health`.
+ * Manifest `primaryTokenAttribute: 'health'` should NOT resolve to that
+ * nested declaration — Foundry walks the document path structurally and
+ * would look for `health.value` at the top of `system`, not under
+ * `attributes`.
+ */
+async function sourceHasValueMaxSchemaAtPath(
+  sourceFiles: string[],
+  targetPath: string,
+): Promise<boolean> {
+  for (const file of sourceFiles) {
+    let content: string;
+    try {
+      content = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const decl of findAllSchemaFields(content)) {
+      if (decl.path !== targetPath) continue;
+      const topKeys = extractTopLevelKeys(decl.body);
+      if (topKeys.has('value') && topKeys.has('max')) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Find every `<name>: new ...SchemaField({...})` declaration in `content`,
+ * returning each with its FULL dot-path through enclosing SchemaField
+ * wrappers and the raw object-literal body. Used by rule 007 to look up
+ * a SchemaField at an exact manifest path.
+ */
+interface SchemaFieldDecl {
+  path: string;
+  body: string;
+}
+
+function findAllSchemaFields(content: string): SchemaFieldDecl[] {
+  const out: SchemaFieldDecl[] = [];
+  const startRe = /(\w+)\s*:\s*new\s+(?:[\w.]+\.)?SchemaField\s*\(\s*\{/g;
+  for (const m of content.matchAll(startRe)) {
+    if (m.index === undefined) continue;
+    const fieldName = m[1] ?? '';
+    const openIdx = m.index + m[0].length - 1;
+    let depth = 0;
+    let endIdx = -1;
+    for (let i = openIdx; i < content.length; i += 1) {
+      if (content[i] === '{') depth += 1;
+      else if (content[i] === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          endIdx = i;
+          break;
+        }
+      }
+    }
+    if (endIdx < 0) continue;
+    out.push({
+      path: buildSchemaPath(content, m.index, fieldName),
+      body: content.slice(openIdx + 1, endIdx),
+    });
+  }
+  return out;
+}
+
+/**
+ * Extract identifier keys declared at depth 0 of an object-literal body.
+ *
+ * The naive `value:`/`max:` regex check matches nested constructor options
+ * too — `value: new NumberField({ max: 100 })` looked to a flat regex like
+ * both keys were SchemaField siblings. Walking the body byte-by-byte with
+ * depth tracking + string-boundary handling correctly distinguishes
+ * top-level keys from nested ones.
+ */
+function extractTopLevelKeys(body: string): Set<string> {
+  const keys = new Set<string>();
+  let depth = 0;
+  let inString: '"' | "'" | '`' | null = null;
+  let escaped = false;
+  let pos = 0;
+  const idStart = /[a-zA-Z_$]/;
+  const idCont = /[\w$]/;
+  const ws = /\s/;
+  while (pos < body.length) {
+    const ch = body[pos];
+    if (ch === undefined) break;
+    if (escaped) {
+      escaped = false;
+      pos += 1;
+      continue;
+    }
+    if (inString) {
+      if (ch === '\\') escaped = true;
+      else if (ch === inString) inString = null;
+      pos += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      inString = ch;
+      pos += 1;
+      continue;
+    }
+    if (ch === '{' || ch === '(' || ch === '[') {
+      depth += 1;
+      pos += 1;
+      continue;
+    }
+    if (ch === '}' || ch === ')' || ch === ']') {
+      depth -= 1;
+      pos += 1;
+      continue;
+    }
+    if (depth === 0 && idStart.test(ch)) {
+      let end = pos;
+      while (end < body.length && idCont.test(body[end] ?? '')) end += 1;
+      const name = body.slice(pos, end);
+      let after = end;
+      while (after < body.length && ws.test(body[after] ?? '')) after += 1;
+      if (body[after] === ':') {
+        keys.add(name);
+        pos = after + 1;
+        continue;
+      }
+      pos = end;
+      continue;
+    }
+    pos += 1;
+  }
+  return keys;
+}
+
+/**
+ * Load every manifest at the project root, then return:
+ *   - declared.perSubtype: per `Doc.subtype` htmlFields / filePathFields sets
+ *   - declared.globalHtml / globalFilePath: union across all subtypes
+ *   - manifest path/raw/parsed for the manifest we found first
+ *
+ * Used by rules 004 and 007. The per-subtype map lets rule 004 do a strict
+ * cross-check when it knows which subtype a source class is registered to;
+ * the global union is the fallback when no class→subtype mapping is found.
+ */
+async function collectDeclaredRichFields(cwd: string): Promise<{
+  declared: DeclaredFields;
+  manifestPath: string | null;
+  manifestRaw: string | null;
+  manifestParsed: Record<string, unknown> | null;
+}> {
+  const perSubtype = new Map<string, { html: Set<string>; filePath: Set<string> }>();
+  const globalHtml = new Set<string>();
+  const globalFilePath = new Set<string>();
+  let manifestPath: string | null = null;
+  let manifestRaw: string | null = null;
+  let manifestParsed: Record<string, unknown> | null = null;
+
+  for (const file of ['system.json', 'module.json']) {
+    const p = join(cwd, file);
+    if (!existsSync(p)) continue;
+    let raw: string;
+    try {
+      raw = await readFile(p, 'utf8');
+    } catch {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
+    if (!manifestPath) {
+      manifestPath = p;
+      manifestRaw = raw;
+      manifestParsed = parsed as Record<string, unknown>;
+    }
+    const docTypes = (parsed as Record<string, unknown>).documentTypes;
+    if (!docTypes || typeof docTypes !== 'object' || Array.isArray(docTypes)) continue;
+    for (const [docName, docType] of Object.entries(docTypes as Record<string, unknown>)) {
+      if (!docType || typeof docType !== 'object' || Array.isArray(docType)) continue;
+      for (const [subName, subtype] of Object.entries(docType as Record<string, unknown>)) {
+        if (!subtype || typeof subtype !== 'object' || Array.isArray(subtype)) continue;
+        const sub = subtype as Record<string, unknown>;
+        const key = `${docName}.${subName}`;
+        const entry = perSubtype.get(key) ?? {
+          html: new Set<string>(),
+          filePath: new Set<string>(),
+        };
+        if (Array.isArray(sub.htmlFields)) {
+          for (const e of sub.htmlFields) {
+            if (typeof e === 'string') {
+              const normalized = normalizeDeclaredPath(e);
+              entry.html.add(normalized);
+              globalHtml.add(normalized);
+            }
+          }
+        }
+        if (Array.isArray(sub.filePathFields)) {
+          for (const e of sub.filePathFields) {
+            if (typeof e === 'string') {
+              const normalized = normalizeDeclaredPath(e);
+              entry.filePath.add(normalized);
+              globalFilePath.add(normalized);
+            }
+          }
+        }
+        perSubtype.set(key, entry);
+      }
+    }
+  }
+  return {
+    declared: { perSubtype, globalHtml, globalFilePath },
+    manifestPath,
+    manifestRaw,
+    manifestParsed,
+  };
+}
+
+/**
+ * Aggregate every `CONFIG.<Doc>.dataModels.<subtype> = <ClassName>`
+ * mapping discovered across all source files, keyed by class name.
+ * Rule 004 reads this to determine which subtype each rich-field's
+ * enclosing class is registered under.
+ */
+function buildClassToSubtypes(fileContents: Iterable<string>): Map<string, ConfigMapping[]> {
+  const map = new Map<string, ConfigMapping[]>();
+  for (const content of fileContents) {
+    for (const mapping of findConfigMappings(content)) {
+      if (!mapping.className) continue;
+      const existing = map.get(mapping.className) ?? [];
+      existing.push(mapping);
+      map.set(mapping.className, existing);
+    }
+  }
+  return map;
+}
+
+/** Strip a dot-path to its final segment (e.g. `system.biography` → `biography`). */
+function lastSegment(path: string): string {
+  const idx = path.lastIndexOf('.');
+  return idx < 0 ? path : path.slice(idx + 1);
+}
+
+/** Entry point: gather everything once, then dispatch to the per-file rules. */
+export async function runSourceRules(cwd: string): Promise<RuleResult[]> {
+  if (!existsSync(cwd)) return [];
+  const info = await stat(cwd);
+  if (!info.isDirectory()) return [];
+
+  const { declared, manifestPath, manifestRaw, manifestParsed } =
+    await collectDeclaredRichFields(cwd);
+  const sourceFiles: string[] = [];
+  for await (const file of walkSourceFiles(cwd)) {
+    sourceFiles.push(file);
+  }
+
+  // Read every source file once so rule 004's class→subtype map can scan
+  // across the whole project (CONFIG mappings frequently live in `main.ts`
+  // separate from the data-model files).
+  const contents = new Map<string, string>();
+  for (const file of sourceFiles) {
+    try {
+      contents.set(file, await readFile(file, 'utf8'));
+    } catch {
+      // skip unreadable files
+    }
+  }
+  const classToSubtypes = buildClassToSubtypes(contents.values());
+
+  const results: RuleResult[] = [];
+  for (const [file, content] of contents) {
+    results.push(...rule005(file, content));
+    results.push(...rule006(file, content));
+    results.push(...rule004(file, content, declared, classToSubtypes));
+  }
+  results.push(...(await rule007(manifestPath, manifestRaw, manifestParsed, sourceFiles)));
+  return results;
+}
+
+// Internal helpers exported so tests can drive the file walker without
+// pulling in the orchestrator's manifest dependency.
+export const _internal = {
+  walkSourceFiles,
+  isSourceFile,
+  lastSegment,
+  EXCLUDED_DIRS,
+};

--- a/packages/cli/src/audit/types.ts
+++ b/packages/cli/src/audit/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared types for the `vttforge audit` rule engine.
+ *
+ * The audit catalog covers seven v13 footguns from the VTTForge audit
+ * spec. Each rule produces zero or more `RuleResult` entries; the
+ * orchestrator aggregates them into an `AuditReport` which the reporter
+ * renders as JSON or markdown.
+ *
+ * The CLI never touches the source tree — audit is purely read-only.
+ */
+
+export type Severity = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export interface RuleResult {
+  /** Stable identifier — used by users to suppress / pin / look up specific rules. */
+  ruleId: string;
+  /** Human title. Shown in markdown report headers. */
+  title: string;
+  severity: Severity;
+  /** Absolute or project-relative path of the file the finding refers to. */
+  filePath: string;
+  /** Optional line number (1-based) inside `filePath`. */
+  line?: number;
+  /** One-line description of what was found. */
+  message: string;
+  /** Optional follow-up describing how to fix it. */
+  remediation?: string;
+}
+
+export interface AuditReport {
+  /** Project root the audit ran against. */
+  cwd: string;
+  /** ISO timestamp of when the run started. */
+  startedAt: string;
+  /** Findings, ordered by severity then by ruleId. */
+  findings: ReadonlyArray<RuleResult>;
+  /** Per-severity tallies, for exit-code logic and report headers. */
+  counts: { HIGH: number; MEDIUM: number; LOW: number };
+}
+
+/** Severity rank for sorting (HIGH first). */
+export const SEVERITY_RANK: Record<Severity, number> = {
+  HIGH: 0,
+  MEDIUM: 1,
+  LOW: 2,
+};
+
+/**
+ * A rule is a plain function over the project root. Manifest rules parse
+ * `system.json` / `module.json`; source rules walk `scripts/` / `src/`.
+ * Rules return their own findings — the orchestrator stitches them
+ * together. Pure functions over the filesystem so tests inject tmp dirs.
+ */
+// (kept here for tests/library consumers that want to define their own rules)
+export type RuleFn = (cwd: string) => Promise<RuleResult[]> | RuleResult[];

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -7,6 +7,7 @@
  * at the right workaround until that subcommand lands.
  */
 import { defineCommand, runMain } from 'citty';
+import { runAuditCommand } from './commands/audit.js';
 import { runBuild } from './commands/build.js';
 import { runDev } from './commands/dev.js';
 import { runInit, ScaffoldError } from './commands/init.js';
@@ -111,12 +112,41 @@ const build = defineCommand({
 const audit = defineCommand({
   meta: {
     name: 'audit',
-    description:
-      'Scan a system/module source tree for v13 manifest footguns (coming in a later release)',
+    description: 'Scan a system/module project for the seven v13 manifest + code footguns',
   },
-  run() {
-    console.error('vttforge audit is not implemented yet. Coming after the build pipeline lands.');
-    process.exit(1);
+  args: {
+    path: {
+      type: 'positional',
+      description: 'Project root to scan (defaults to the current directory)',
+      required: false,
+    },
+    json: {
+      type: 'boolean',
+      default: false,
+      description: 'Emit a machine-readable JSON report instead of markdown',
+    },
+    strict: {
+      type: 'boolean',
+      default: false,
+      description: 'Exit non-zero on any finding (default: only HIGH triggers a non-zero exit)',
+    },
+  },
+  async run({ args }) {
+    try {
+      const result = await runAuditCommand({
+        cwd: typeof args.path === 'string' ? args.path : undefined,
+        format: args.json === true ? 'json' : 'markdown',
+        strict: args.strict === true,
+      });
+      // Set exitCode instead of calling process.exit so any pending stdout
+      // writes (the JSON / markdown report) get flushed before the process
+      // tears down. process.exit(1) would truncate large reports on the
+      // exact runs CI needs them intact.
+      if (result.exitCode !== 0) process.exitCode = result.exitCode;
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+    }
   },
 });
 

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,0 +1,58 @@
+/**
+ * `vttforge audit` — scan a system/module project against the VTTForge
+ * audit catalog (seven v13 manifest + code footguns).
+ *
+ * The seven rules (VTTF-AUDIT-001 through 007) live in
+ * `audit/manifest-rules.ts` or `audit/source-rules.ts`; this file is the
+ * CLI surface that orchestrates them and prints the report.
+ *
+ * Exit codes:
+ *   0 — clean run, or only MEDIUM/LOW findings (informational)
+ *   1 — at least one HIGH finding (or any finding in `--strict` mode)
+ */
+
+import { resolve } from 'node:path';
+import { runAudit } from '../audit/index.js';
+import { formatReport, type ReportFormat } from '../audit/reporter.js';
+import type { AuditReport } from '../audit/types.js';
+
+export interface AuditOptions {
+  /** Project root to scan. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Output format. Default: 'markdown'. */
+  format?: ReportFormat;
+  /**
+   * When true, MEDIUM and LOW findings also trigger a non-zero exit.
+   * Default false — HIGH-only is the canonical "block CI" line.
+   */
+  strict?: boolean;
+  /** Custom writer (tests). Defaults to process.stdout.write. */
+  write?: (chunk: string) => void;
+}
+
+export interface AuditResult {
+  report: AuditReport;
+  /** Suggested exit code under the current strictness setting. */
+  exitCode: 0 | 1;
+}
+
+export async function runAuditCommand(options: AuditOptions = {}): Promise<AuditResult> {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const format: ReportFormat = options.format ?? 'markdown';
+  const strict = options.strict === true;
+  const write =
+    options.write ??
+    ((chunk: string) => {
+      process.stdout.write(chunk);
+    });
+
+  const report = await runAudit({ cwd });
+  write(formatReport(report, format));
+
+  const exitCode: 0 | 1 =
+    report.counts.HIGH > 0 || (strict && (report.counts.MEDIUM > 0 || report.counts.LOW > 0))
+      ? 1
+      : 0;
+
+  return { report, exitCode };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,15 @@
  * scaffolder (e.g. from another CLI, a test harness, or a custom tool).
  */
 
+export { runAudit } from './audit/index.js';
+export { runManifestRules } from './audit/manifest-rules.js';
+export type { ReportFormat } from './audit/reporter.js';
+export { formatReport } from './audit/reporter.js';
+export { runSourceRules } from './audit/source-rules.js';
+export type { AuditReport, RuleFn, RuleResult, Severity } from './audit/types.js';
+export { SEVERITY_RANK } from './audit/types.js';
+export type { AuditOptions, AuditResult } from './commands/audit.js';
+export { runAuditCommand } from './commands/audit.js';
 export type { BuildOptions } from './commands/build.js';
 export { emitReleaseZip, runBuild } from './commands/build.js';
 export type { DevOptions } from './commands/dev.js';


### PR DESCRIPTION
## Summary

Closes Track 1 by shipping the third subcommand. `vttforge audit [path]` scans a system or module project for the v13 footguns in the VTTForge audit catalog.

### Rules

| ID | Severity | Scope | What it catches |
|---|---|---|---|
| `VTTF-AUDIT-001` | HIGH | manifest | `flags.hotReload` array (v12) or missing required `extensions` key |
| `VTTF-AUDIT-002` | MEDIUM | manifest | Top-level `gridDistance` / `gridUnits` (v12) instead of `grid` object |
| `VTTF-AUDIT-003` | LOW | manifest | `styles: ["foo.css"]` strings instead of `[{src, layer?}]` |
| `VTTF-AUDIT-004` | MEDIUM | manifest + source | `HTMLField` / `FilePathField` not declared in `documentTypes.<Doc>.<subtype>` (XSS risk). Subtype-aware via `CONFIG.*.dataModels` + `registerSystem({ actorDataModels })` parsing; full-path matching through SchemaField nesting |
| `VTTF-AUDIT-005` | MEDIUM | source | `extends TypeDataModel` without `prepareBaseData()` (per-class) |
| `VTTF-AUDIT-006` | LOW | source | `_addDataFieldMigrations` override (real API is `static migrateData(source)` + singular `super._addDataFieldMigration`) |
| `VTTF-AUDIT-007` | MEDIUM | manifest + source | `primary/secondaryTokenAttribute` doesn't resolve to a `SchemaField({value, max})` at the exact dot-path |

### CLI

```bash
vttforge audit                # scan cwd, print markdown
vttforge audit ./my-project   # scan a different path
vttforge audit --json         # machine-readable JSON for CI piping
vttforge audit --strict       # exit 1 on any finding (default: HIGH only)
```

Exit code: `0` clean or MEDIUM/LOW-only (advisory); `1` HIGH or any finding in `--strict`. Uses `process.exitCode` (not `process.exit`) so piped reports aren't truncated.

## Verification

- 247 tests pass
- `pnpm typecheck` / `pnpm lint` / `pnpm format` / `pnpm publint` / `pnpm knip` all clean
- Smoke: `vttforge audit examples/simple-system` → zero findings
- Smoke: integration test scaffolds all four templates and audits each → zero findings
- Smoke: pathological "worst-case" manifest + source → all 7 rules fire correctly

## Deferred to follow-up PRs

Three known soundness gaps with safe defaults today, deferred to keep this PR focused:

1. **`filePathFields` object shape** — v13 manifests also accept `{ "portrait": ["IMAGE"] }`. My collector only reads the string-array form. Templates ship string arrays; the object form is a fix-forward.
2. **Rule 007 actor-model scoping** — currently any `SchemaField({value, max})` anywhere in source can satisfy `primaryTokenAttribute`. Should be constrained to classes registered as Actor data models.
3. **Module-prefixed subtype keys** — module-contributed types are registered with auto-prefixes (`CONFIG.Actor.dataModels['my-module.vehicle']`) but declared bare in `module.json`. My regex doesn't parse the prefixed form.

All three are P2 (advisory severity); the global-union fallback in rule 004 covers the common case meanwhile.

## Test plan

- CI green on Node 22 + 24
- `gh pr checks` passes
- Squash-merge with the `@vttforge/cli: minor` changeset