### PR TITLE
chore: editorial polish — tighten internal references in docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ concurrency:
 # Self-hosted GCP runner from fcsouza/infra (gcp/runners/).
 # Pre-installed: Node 22.11, Bun 1.3.14, gh CLI, actionlint, Chrome, Playwright.
 # Corepack ships with Node — we activate pnpm@10.33.4 via `corepack prepare`.
-# Node 24 matrix testing is parked until the runner image ships Node 24
-# (plans/to-revise.md).
+# Node 24 matrix testing is parked until the runner image ships Node 24.
 
 jobs:
   lint:
@@ -123,7 +122,7 @@ jobs:
       - name: Publint
         run: pnpm publint
 
-      - name: Are The Types Wrong (currently stubbed — see plans/to-revise.md)
+      - name: Are The Types Wrong (currently stubbed)
         run: pnpm attw
 
   knip:

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -44,10 +44,10 @@
   `listErrorEntries()`, wrapped in a typed `ErrorManifest` envelope with a
   stable `version: 1` field for future format migrations.
 
-  Plan deviation: the original `plans/v0.1-next-steps.md` PR 8 spec said
-  `prebuild`, but `postbuild` lets the script import the just-built ESM
-  directly instead of needing `tsx`/`unrun` to load the TS source.
-  Documented inline in the codegen script.
+  Plan deviation: the codegen runs as `postbuild` (not `prebuild`) so the
+  script imports the just-built ESM directly instead of needing
+  `tsx`/`unrun` to load the TS source. Documented inline in the codegen
+  script.
 
 - 0896bb0: Add `createMigrationRunner()` for declarative schema migrations, plus
   `onReady` lifecycle on `registerSystem()`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,5 +12,3 @@ Core runtime utilities for VTTForge — the modern SDK for building [FoundryVTT]
 - `registerSystem()` — one-call init that replaces the manual `Hooks.once("init", …)` block.
 - `createMigrationRunner` — declarative data migrations with version gates.
 - Error registry — `VttfError` + central `VTTF-NNNN` codes with `docsUrl` pointing at `vttforge.dev/errors/`.
-
-See [PRD §7](../../plans/PRD.md) for the full design (planning doc, not shipped publicly).

--- a/packages/core/scripts/codegen-errors.mjs
+++ b/packages/core/scripts/codegen-errors.mjs
@@ -13,9 +13,8 @@
  *      These are committed so the `docsUrl` resolves to a real page once
  *      the docs site goes live in v0.3.
  *
- * The plan in `plans/v0.1-next-steps.md` originally said `prebuild`, but
- * `postbuild` is much simpler: we get to import the built ESM directly
- * instead of needing tsx / unrun to load the TS source.
+ * Runs as `postbuild` (not `prebuild`) so the script imports the built
+ * ESM directly instead of needing tsx / unrun to load the TS source.
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -40,4 +40,4 @@ Initial functional release (v0.1 MVP slice).
 
 ### Pending
 
-- Real Foundry Theme V2 (`CONST.CSS_THEMES`) binding once we wire that surface in. Tracked in `plans/TODO.md §3`.
+- Real Foundry Theme V2 (`CONST.CSS_THEMES`) binding once we wire that surface in.


### PR DESCRIPTION
## Summary

Light sweep removing internal planning-doc references from a handful of public-facing files. No runtime behaviour changes.

## Files touched

- `.github/workflows/ci.yml` — comment cleanup
- `packages/core/CHANGELOG.md` — reword plan-deviation note
- `packages/core/README.md` — drop trailing planning-doc link
- `packages/core/scripts/codegen-errors.mjs` — JSDoc header trim
- `packages/styles/CHANGELOG.md` — drop tracking-doc pointer

## Verification

- `pnpm format` / `pnpm typecheck` / `pnpm test` all green