### PR TITLE
ci: move to actions/checkout v7

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     if: github.repository == 'vttforge/vttforge'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Lint (biome + syncpack)
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Activate pnpm via Corepack
         run: |
@@ -41,7 +41,7 @@ jobs:
     name: Typecheck
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Activate pnpm via Corepack
         run: |
@@ -59,7 +59,7 @@ jobs:
     name: Test
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Activate pnpm via Corepack
         run: |
@@ -77,7 +77,7 @@ jobs:
     name: Build
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Activate pnpm via Corepack
         run: |
@@ -105,7 +105,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Activate pnpm via Corepack
         run: |
@@ -130,7 +130,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Activate pnpm via Corepack
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     environment: npm-publish
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Activate pnpm via Corepack
         run: |


### PR DESCRIPTION
Takes the checkout half of the grouped bump in #51.

The v7 major has one behaviour change: it blocks checking out a fork PR head under `pull_request_target` and `workflow_run`. Neither trigger appears in any workflow here, so nothing changes for us.

`changesets/action` v2 is deliberately left out. Dependabot bumped the tag without touching the inputs, and v2 renamed all of them:

| Workflow passes today | v2 expects |
| --- | --- |
| `version:` | `version-script:` |
| `commit:` | `commit-message:` |
| `title:` | `pr-title:` |
| `GITHUB_TOKEN` env | `github-token:` input |

It also requires Changesets CLI v3, and the catalog is on 2.x. Merging that half as-is would stop the version PR from being generated, and CI would not catch it because the changesets workflow only runs on push to main. It gets its own PR alongside the CLI bump.