### PR TITLE
fix(cli): move prompts to @clack/prompts 1.x and tighten the id validator

### DIFF
--- a/.changeset/clack-1.md
+++ b/.changeset/clack-1.md
@@ -1,0 +1,16 @@
+---
+'@vttforge/cli': patch
+---
+
+Move the prompts to `@clack/prompts` 1.x, and fix a validator that let a
+missing package id through.
+
+Clack 1.x hands validators `string | undefined` instead of `string`, since
+it calls them before anything is typed. Widening the signatures surfaced a
+latent bug in the package-id check: it called `RegExp.test` on the raw
+value, and an undefined value coerces to the string `"undefined"`, which
+matches the allowed pattern. A missing id therefore passed validation. The
+check now coalesces first.
+
+The three validators are exported and covered by tests. They were only
+reachable through the interactive prompt before, so nothing exercised them.

--- a/packages/cli/src/__tests__/init-validators.test.ts
+++ b/packages/cli/src/__tests__/init-validators.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { validateMetadata, validatePackageId, validateRequiredMetadata } from '../commands/init.js';
+
+describe('validatePackageId', () => {
+  it.each([['my-system'], ['a'], ['sys2'], ['a-b-c-1']])('accepts %j', (id) => {
+    expect(validatePackageId(id)).toBeUndefined();
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['1leading', 'leading digit'],
+    ['-leading', 'leading dash'],
+    ['Upper', 'uppercase'],
+    ['has space', 'space'],
+    ['has.dot', 'dot'],
+    ['has/slash', 'slash'],
+  ])('rejects %j (%s)', (id) => {
+    expect(validatePackageId(id)).toMatch(/must start with a letter/);
+  });
+
+  it('rejects undefined rather than coercing it to the string "undefined"', () => {
+    expect(validatePackageId(undefined)).toMatch(/must start with a letter/);
+  });
+});
+
+describe('validateMetadata', () => {
+  it.each([['A plain title'], ["Vex's Grimoire"], ['Dashes - and, commas']])(
+    'accepts %j',
+    (value) => {
+      expect(validateMetadata(value)).toBeUndefined();
+    },
+  );
+
+  it.each([
+    ['a "quoted" word', 'double quote'],
+    ['back\\slash', 'backslash'],
+    ['line\nbreak', 'newline'],
+    ['tab\there', 'tab'],
+  ])('rejects %j (%s) — it would break the generated manifest', (value) => {
+    expect(validateMetadata(value)).toMatch(/backslashes, double quotes/);
+  });
+
+  it('rejects a block-comment terminator, which would truncate generated headers', () => {
+    expect(validateMetadata('ends the */ header')).toMatch(/closes block comments/);
+  });
+
+  it.each([[undefined], ['']])('treats %j as blank, which is allowed here', (value) => {
+    expect(validateMetadata(value)).toBeUndefined();
+  });
+});
+
+describe('validateRequiredMetadata', () => {
+  it('accepts a filled value', () => {
+    expect(validateRequiredMetadata('My System')).toBeUndefined();
+  });
+
+  it.each([[undefined], [''], ['   ']])('rejects %j', (value) => {
+    expect(validateRequiredMetadata(value)).toMatch(/Required/);
+  });
+
+  it('still applies the metadata rules on top of the blank check', () => {
+    expect(validateRequiredMetadata('a "quoted" title')).toMatch(/backslashes, double quotes/);
+  });
+});

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -62,7 +62,7 @@ function createDataDirPrompt(): NonNullable<ResolveDataDirOptions['prompt']> {
       message:
         'Foundry user-data directory (the folder that contains Data/, e.g. ~/Library/Application Support/FoundryVTT)',
       placeholder: autoDetected ?? '/path/to/FoundryVTT',
-      validate: (value: string) => {
+      validate: (value: string | undefined) => {
         if (!value || value.trim().length === 0) return 'A path is required';
         return undefined;
       },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -42,7 +42,11 @@ export type TemplateVariant = 'system-ts' | 'system-js' | 'module-ts' | 'module-
 const PACKAGE_ID_RE = /^[a-z][a-z0-9-]*$/;
 const UNSAFE_METADATA_CHARS_RE = /["\\\r\n\t]/;
 
-function validateMetadata(value: string): string | undefined {
+// Clack hands validators `string | undefined` — the prompt calls them before
+// anything is typed. Blank metadata is allowed here; only the `Required`
+// variant below rejects it.
+export function validateMetadata(value: string | undefined): string | undefined {
+  if (!value) return undefined;
   // Reject characters that would break JSON string contexts in the
   // generated manifests/i18n catalogues. Apostrophes are fine — every JS
   // string literal in the templates is double-quoted, every JSON value is
@@ -61,11 +65,21 @@ function validateMetadata(value: string): string | undefined {
   return undefined;
 }
 
-function validateRequiredMetadata(value: string): string | undefined {
+export function validateRequiredMetadata(value: string | undefined): string | undefined {
   if (!value || value.trim().length === 0) {
     return 'Required — Foundry rejects packages with a blank title.';
   }
   return validateMetadata(value);
+}
+
+export function validatePackageId(value: string | undefined): string | undefined {
+  // Coalesce before the test. `PACKAGE_ID_RE.test(undefined)` coerces to the
+  // string "undefined", which matches the pattern and would let a missing id
+  // through.
+  if (!PACKAGE_ID_RE.test(value ?? '')) {
+    return 'Package id must start with a letter and contain only lowercase letters, digits, dashes';
+  }
+  return undefined;
 }
 
 /**
@@ -125,7 +139,7 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
     const answer = await p.text({
       message: 'Directory name (also the default manifest id)',
       placeholder: 'my-system',
-      validate: (value: string) => {
+      validate: (value: string | undefined) => {
         const trimmed = value?.trim() ?? '';
         if (trimmed.length === 0) return 'Name is required';
         if (!PACKAGE_ID_RE.test(trimmed)) {
@@ -184,12 +198,7 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
   const idAnswer = await p.text({
     message: 'Package id (used as the folder Foundry serves under /<systems|modules>/<id>/)',
     initialValue: defaultId,
-    validate: (value: string) => {
-      if (!PACKAGE_ID_RE.test(value)) {
-        return 'Package id must start with a letter and contain only lowercase letters, digits, dashes';
-      }
-      return undefined;
-    },
+    validate: validatePackageId,
   });
   if (isCancelled(idAnswer)) bail('Scaffold cancelled.');
   const id = String(idAnswer);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^2.31.0
       version: 2.31.0
     '@clack/prompts':
-      specifier: ^0.11.0
-      version: 0.11.0
+      specifier: ^1.7.0
+      version: 1.7.0
     '@types/archiver':
       specifier: ^8.0.0
       version: 8.0.0
@@ -134,7 +134,7 @@ importers:
     dependencies:
       '@clack/prompts':
         specifier: 'catalog:'
-        version: 0.11.0
+        version: 1.7.0
       archiver:
         specifier: 'catalog:'
         version: 8.0.0
@@ -417,11 +417,13 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clack/core@0.5.0':
-    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@0.11.0':
-    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1637,6 +1639,15 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3036,15 +3047,16 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@clack/core@0.5.0':
+  '@clack/core@1.4.3':
     dependencies:
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.11.0':
+  '@clack/prompts@1.7.0':
     dependencies:
-      '@clack/core': 0.5.0
-      picocolors: 1.1.1
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@colors/colors@1.5.0':
@@ -3984,6 +3996,16 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ catalog:
   '@arethetypeswrong/cli': ^0.18.5
   '@biomejs/biome': ^2.5.11
   '@changesets/cli': ^2.31.0
-  '@clack/prompts': ^0.11.0
+  '@clack/prompts': ^1.7.0
   '@types/archiver': ^8.0.0
   '@types/node': ^25.9.1
   archiver: ^8.0.0


### PR DESCRIPTION
Supersedes #43, which targeted 1.5.0 three months ago and failed typecheck. This goes to 1.7.0 and fixes the actual cause — the CI log for #43 had expired, so the break was found by running it.

## What broke

Clack 1.x changed the validator contract:

```ts
type Validate<TValue> =
  ((value: TValue | undefined) => string | Error | undefined)
  | StandardSchemaV1<TValue | undefined, unknown>;
```

The value is now `string | undefined`, because the prompt calls the validator before anything is typed. All six of ours declared `(value: string)`, so none were assignable. That is the whole migration: no prompt call shape changed, and none of them passed explicit type arguments.

## The bug it surfaced

The package-id validator called `RegExp.test` on the raw value:

```js
> /^[a-z][a-z0-9-]*$/.test(undefined)
true
```

`undefined` coerces to the string `"undefined"`, which matches the allowed pattern — so a missing package id passed validation. It now coalesces to an empty string first, which correctly fails.

## Tests

The three validators were reachable only through the interactive prompt, so nothing exercised them, which is why the coercion sat there unnoticed. They are now exported and covered by 27 tests, including the rules an earlier round added on purpose: rejecting backslashes, double quotes and line breaks that would break the generated manifest, and rejecting a block-comment terminator that would truncate generated source headers.

CLI suite goes from 247 to 274 tests.

`pnpm typecheck` 12/12 · `pnpm test` 12/12 · `pnpm build` 9/9 · `biome ci` clean · `syncpack lint` no issues · `pnpm install --frozen-lockfile` passes.