### PR TITLE
chore: ignore the release zips vttforge build writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ Thumbs.db
 # npm pack outputs
 *.tgz
 
+# Release zips written by `vttforge build`
+*.zip
+
 # Changeset working files (committed changesets stay tracked)
 # .changeset/*.md  ← intentionally NOT ignored
 


### PR DESCRIPTION
Running `vttforge build` in `examples/simple-system` drops a 41KB zip at the project root. The scaffolding templates already carry `*.zip` in their gitignore, but the repo itself did not — so the artifact sat untracked and any `git add -A` would stage it.

Hit this while verifying the archiver 8 migration end to end.