### PR TITLE
fix(cli): point the templates at the versions the next release publishes

### DIFF
--- a/.changeset/template-pins.md
+++ b/.changeset/template-pins.md
@@ -1,0 +1,11 @@
+---
+'@vttforge/cli': patch
+---
+
+Point the scaffolding templates at the versions this release publishes.
+
+The templates asked for `@vttforge/core@^0.3.0` and
+`@vttforge/vite-plugin@^0.1.0`. On a 0.x version a caret pins the minor, so
+`^0.3.0` means `>=0.3.0 <0.4.0` — and this release takes core to 0.4.0 and
+the plugin to 0.2.0. Left alone, every project scaffolded after the release
+would ask for versions the release had just superseded.

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,11 +11,11 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.3.0"
+    "@vttforge/core": "^0.4.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.1.0",
-    "@vttforge/vite-plugin": "^0.1.0",
+    "@vttforge/vite-plugin": "^0.2.0",
     "vite": "^8.2.2"
   },
   "engines": {

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,11 +12,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.3.0"
+    "@vttforge/core": "^0.4.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.1.0",
-    "@vttforge/vite-plugin": "^0.1.0",
+    "@vttforge/vite-plugin": "^0.2.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,12 +11,12 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.3.0",
+    "@vttforge/core": "^0.4.0",
     "@vttforge/styles": "^0.2.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.1.0",
-    "@vttforge/vite-plugin": "^0.1.0",
+    "@vttforge/vite-plugin": "^0.2.0",
     "vite": "^8.2.2"
   },
   "engines": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,12 +12,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.3.0",
+    "@vttforge/core": "^0.4.0",
     "@vttforge/styles": "^0.2.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.1.0",
-    "@vttforge/vite-plugin": "^0.1.0",
+    "@vttforge/vite-plugin": "^0.2.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },


### PR DESCRIPTION
Blocks #40. Merge that first and every project scaffolded afterwards asks for versions the release just superseded.

## The problem

The four `vttforge init` templates pin:

```json
"@vttforge/core": "^0.3.0",
"@vttforge/vite-plugin": "^0.1.0"
```

On a 0.x version a caret pins the **minor**, so `^0.3.0` means `>=0.3.0 <0.4.0`. The pending release takes core to 0.4.0 and the plugin to 0.2.0 — neither satisfies the template range. Same class as the vite peer problem in #58, one layer up, and again no CI job builds a scaffolded project.

## Verified, not assumed

Ran the version step locally and read the result:

| Package | After release | Template pin |
| --- | --- | --- |
| `@vttforge/core` | 0.4.0 | `^0.4.0` ✅ |
| `@vttforge/vite-plugin` | 0.2.0 | `^0.2.0` ✅ |
| `@vttforge/cli` | 0.1.0 | `^0.1.0` — already matched |
| `@vttforge/styles` | 0.2.0 | `^0.2.0` — already matched |

Only the two stale pins move.

## No circularity

The changeset here is a `patch` for `@vttforge/cli`, and the cli already has a `minor` queued. Changesets takes the highest bump, so the cli still lands on 0.1.0 — the same version the templates name. Confirmed in the same local run.