### PR TITLE
ci: hold changesets/action on v1 until the CLI moves with it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,14 @@ updates:
     groups:
       actions:
         patterns: ['*']
+    ignore:
+      # changesets/action v2 renames every input the release workflow passes
+      # (version, commit, title) and reads the token from a `github-token`
+      # input rather than the environment. It also requires Changesets CLI v3,
+      # which changes `changeset version` to exit non-zero when there is
+      # nothing to release — and our `changeset:version` script chains on
+      # `&&`. Taking the tag alone stops the version PR being generated, and
+      # nothing catches it: the release workflow only runs on push to main.
+      # Lift this once the workflow inputs and the CLI move together.
+      - dependency-name: changesets/action
+        update-types: [version-update:semver-major]


### PR DESCRIPTION
Follow-up to #51, which I closed after splitting out the safe half (#55, checkout v7).

Closing that PR closed a PR, not the pendência. Dependabot's `github-actions` group matches `patterns: ['*']` with no exclusions, so it re-proposes the same v2 bump next Monday — and whoever picks it up will not have the analysis.

## Why v2 cannot be taken alone

The workflow passes inputs v2 renamed:

| Passed today | v2 expects |
| --- | --- |
| `version:` | `version-script:` |
| `commit:` | `commit-message:` |
| `title:` | `pr-title:` |
| `GITHUB_TOKEN` env | `github-token:` input |

And v2 requires Changesets CLI v3, which brings its own break: `changeset version` now exits non-zero when there is nothing to release, while our script is `changeset version && pnpm install --lockfile-only`.

Nothing catches any of this, because `changesets.yml` only runs on push to `main` — a PR's CI never exercises it.

## What this does

Adds an ignore for `changesets/action` majors, with the reasoning inline so it does not have to be re-derived. Minor and patch bumps still flow.

Lift it when the workflow inputs and the CLI move together.