### PR TITLE
fix(core): stop stamping the package version into the tracked error docs

### DIFF
--- a/docs/errors/VTTF-0001.md
+++ b/docs/errors/VTTF-0001.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0001` |
 | Name | `SystemAlreadyRegistered` |
-| Package | `@vttforge/core@0.4.0` |
+| Package | `@vttforge/core` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/docs/errors/VTTF-0002.md
+++ b/docs/errors/VTTF-0002.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0002` |
 | Name | `MissingFoundryGlobals` |
-| Package | `@vttforge/core@0.4.0` |
+| Package | `@vttforge/core` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/docs/errors/VTTF-0003.md
+++ b/docs/errors/VTTF-0003.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0003` |
 | Name | `UnknownSetting` |
-| Package | `@vttforge/core@0.4.0` |
+| Package | `@vttforge/core` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/docs/errors/VTTF-0004.md
+++ b/docs/errors/VTTF-0004.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0004` |
 | Name | `MigrationFailed` |
-| Package | `@vttforge/core@0.4.0` |
+| Package | `@vttforge/core` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/docs/errors/VTTF-0005.md
+++ b/docs/errors/VTTF-0005.md
@@ -7,7 +7,7 @@
 |---|---|
 | Code | `VTTF-0005` |
 | Name | `WorldTooOldForMigration` |
-| Package | `@vttforge/core@0.4.0` |
+| Package | `@vttforge/core` |
 | Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
 
 ---

--- a/packages/core/scripts/codegen-errors.mjs
+++ b/packages/core/scripts/codegen-errors.mjs
@@ -42,7 +42,20 @@ async function loadEntries() {
   return mod.listErrorEntries();
 }
 
-function renderStub(entry, pkgVersion) {
+/**
+ * The stub deliberately carries no package version.
+ *
+ * These pages are tracked in git, so stamping the version in would rewrite
+ * every one of them on each release — and the release step bumps
+ * package.json without running a build, so they would name the previous
+ * version until someone rebuilt by hand. It also meant any build on any
+ * branch dirtied five tracked files for reasons unrelated to the change.
+ *
+ * The version still travels with the package in `dist/errors-manifest.json`,
+ * which is published and not tracked. A reader who needs it looks there, or
+ * at the docs site, which knows the version it was built from.
+ */
+function renderStub(entry) {
   const lines = [
     `# ${entry.code} — ${entry.name}`,
     '',
@@ -53,7 +66,7 @@ function renderStub(entry, pkgVersion) {
     '|---|---|',
     `| Code | \`${entry.code}\` |`,
     `| Name | \`${entry.name}\` |`,
-    `| Package | \`@vttforge/core@${pkgVersion}\` |`,
+    '| Package | `@vttforge/core` |',
     `| Source | [\`${SOURCE_RELATIVE}\`](${SOURCE_URL}) |`,
   ];
   if (entry.deprecated) {
@@ -99,12 +112,12 @@ async function writeManifest(entries, pkgVersion) {
   return manifest;
 }
 
-async function writeStubs(entries, pkgVersion) {
+async function writeStubs(entries) {
   await mkdir(DOCS_DIR, { recursive: true });
   for (const entry of entries) {
     const path = resolve(DOCS_DIR, `${entry.code}.md`);
     await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, renderStub(entry, pkgVersion), 'utf8');
+    await writeFile(path, renderStub(entry), 'utf8');
   }
 }
 
@@ -114,7 +127,7 @@ async function main() {
     throw new Error('Error registry is empty — refusing to overwrite docs/errors with nothing.');
   }
   const manifest = await writeManifest(entries, pkgVersion);
-  await writeStubs(entries, pkgVersion);
+  await writeStubs(entries);
   console.warn(
     `[codegen-errors] wrote ${entries.length} entries → dist/errors-manifest.json + docs/errors/`,
   );


### PR DESCRIPTION
The generated pages under `docs/errors/` carried a `| Package | @vttforge/core@<version> |` row, read from `package.json` at build time. Those files are tracked, so the stamp coupled all five to the version — and that coupling drifted in two directions.

## The two symptoms

**Stale after every release.** The Changesets workflow bumps `package.json` and `CHANGELOG.md` but never runs a build, so the pages kept naming the previous version until someone rebuilt by hand. That just happened: #40 took core to 0.4.0 and the docs stayed on 0.3.0 until #62 regenerated them.

**Dirty tree between releases.** Any `pnpm build` on any branch rewrote all five for reasons unrelated to the change in hand. This broke a `git stash pop` during #62, on files nobody had touched.

No CI job checks for a dirty tree after a build, so neither symptom failed anything. It just drifted.

## The fix

The version appears in two places, and only one was a problem:

| Where | Tracked | Published | Verdict |
| --- | --- | --- | --- |
| `dist/errors-manifest.json` → `packageVersion` | no | yes | **keep** — the right home for it |
| `docs/errors/*.md` → `Package` row | **yes** | no | **drop the version** |

The row now reads `@vttforge/core` with no version, which is the part that does not rot. A reader who needs the version looks at the manifest, or at the docs site, which knows the version it was built from.

Chose this over making the release run a build and commit the regenerated docs: that is heavier, and it makes the release step depend on a working build.

## Verification

Build is now idempotent from a clean tree — twice in a row, `git status` empty both times.

The regression test that matters is the version bump itself. Set core to a fake `9.9.9` and rebuilt:

```
=== dirty files after the fake bump ===
 M packages/core/package.json

=== did the docs change? ===
(nothing)

=== manifest still carries it ===
packageVersion = 9.9.9
```

Only the file I edited moved. Before this change, that same bump rewrote all five tracked pages.

`pnpm typecheck` 12/12 · `pnpm test` 12/12 · `pnpm build` 9/9 · `biome ci` clean · `syncpack lint` no issues.

No changeset: core publishes `dist`, `README.md` and `CHANGELOG.md`, and `docs/` is not among them, so the tarball is unchanged.