### PR TITLE
chore: require Node 26 and pin it in CI

### DIFF
--- a/.changeset/node-26.md
+++ b/.changeset/node-26.md
@@ -1,0 +1,32 @@
+---
+'@vttforge/core': minor
+'@vttforge/cli': minor
+'@vttforge/vite-plugin': minor
+'@vttforge/styles': minor
+'@vttforge/types': minor
+'@vttforge/testing': minor
+'create-vttforge': minor
+---
+
+Require Node 26.
+
+The floor moves from `>=22.14.0` to `>=26.0.0` across every package and the
+four scaffolding templates, and the bundler target for the Node-side
+packages moves from `node22` to `node26`.
+
+Node 22 entered maintenance in October 2025 and receives security fixes
+only. Node 26 becomes the active LTS line on 2026-10-28.
+
+This is breaking for anyone on Node 22 or 24. It is marked `minor` rather
+than `major` on purpose: these packages are still on 0.x, where a minor
+signals the break, and a major would push every package to 1.0.0 — a claim
+of API stability that has not been audited, on packages two of which are
+still stubs.
+
+The templates move to the versions this release publishes. On 0.x a caret
+pins the minor, so their old ranges would not have matched.
+
+CI now pins Node through `actions/setup-node` instead of inheriting whatever
+the runner image ships, so the version the packages declare is the version
+they are tested on. It was not before: the workflow took the image's Node,
+and nothing enforced the declared floor because `engine-strict` is not set.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
+
       - name: Activate pnpm via Corepack
         run: |
           npm install -g corepack@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Self-hosted GCP runner from fcsouza/infra (gcp/runners/).
-# Pre-installed: Node 22.11, Bun 1.3.14, gh CLI, actionlint, Chrome, Playwright.
+# Node is pinned via actions/setup-node rather than taken from the runner image,
+# so the version CI validates on is the one the packages declare in `engines`.
 # Corepack ships with Node — we activate pnpm@10.34.5 via `corepack prepare`.
-# Node 24 matrix testing is parked until the runner image ships Node 24.
 
 jobs:
   lint:
@@ -24,6 +24,10 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
 
       - name: Activate pnpm via Corepack
         run: |
@@ -43,6 +47,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
+
       - name: Activate pnpm via Corepack
         run: |
           npm install -g corepack@latest
@@ -61,6 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
+
       - name: Activate pnpm via Corepack
         run: |
           npm install -g corepack@latest
@@ -78,6 +90,10 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
 
       - name: Activate pnpm via Corepack
         run: |
@@ -107,6 +123,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
+
       - name: Activate pnpm via Corepack
         run: |
           npm install -g corepack@latest
@@ -131,6 +151,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
 
       - name: Activate pnpm via Corepack
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
+
       - name: Activate pnpm via Corepack
         run: |
           npm install -g corepack@latest

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "pnpm@10.34.5",
   "engines": {
-    "node": ">=22.14.0",
+    "node": ">=26.0.0",
     "pnpm": ">=10.0.0"
   },
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "publint": "publint",
-    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output — re-enable later'"
+    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output \u2014 re-enable later'"
   },
   "dependencies": {
     "@clack/prompts": "catalog:",
@@ -59,7 +59,7 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=26.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,14 +11,14 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.4.0"
+    "@vttforge/core": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.1.0",
-    "@vttforge/vite-plugin": "^0.2.0",
+    "@vttforge/cli": "^0.2.0",
+    "@vttforge/vite-plugin": "^0.3.0",
     "vite": "^8.2.2"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=26"
   }
 }

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,15 +12,15 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.4.0"
+    "@vttforge/core": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.1.0",
-    "@vttforge/vite-plugin": "^0.2.0",
+    "@vttforge/cli": "^0.2.0",
+    "@vttforge/vite-plugin": "^0.3.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=26"
   }
 }

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,15 +11,15 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.4.0",
-    "@vttforge/styles": "^0.2.0"
+    "@vttforge/core": "^0.5.0",
+    "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.1.0",
-    "@vttforge/vite-plugin": "^0.2.0",
+    "@vttforge/cli": "^0.2.0",
+    "@vttforge/vite-plugin": "^0.3.0",
     "vite": "^8.2.2"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=26"
   }
 }

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,16 +12,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.4.0",
-    "@vttforge/styles": "^0.2.0"
+    "@vttforge/core": "^0.5.0",
+    "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.1.0",
-    "@vttforge/vite-plugin": "^0.2.0",
+    "@vttforge/cli": "^0.2.0",
+    "@vttforge/vite-plugin": "^0.3.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=26"
   }
 }

--- a/packages/cli/tsdown.config.mjs
+++ b/packages/cli/tsdown.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ['src/index.ts', 'src/bin.ts'],
   format: 'esm',
   platform: 'node',
-  target: 'node22',
+  target: 'node26',
   sourcemap: true,
   dts: true,
   clean: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "publint": "publint",
-    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output (filename undefined) — re-enable once upstream issue is fixed'"
+    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output (filename undefined) \u2014 re-enable once upstream issue is fixed'"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
@@ -52,7 +52,7 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=26.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-vttforge/package.json
+++ b/packages/create-vttforge/package.json
@@ -28,7 +28,7 @@
     "@vttforge/cli": "workspace:*"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=26.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -38,17 +38,17 @@
   ],
   "scripts": {
     "build": "node build-tokens.mjs",
-    "typecheck": "echo 'styles is CSS-only — no typecheck'",
+    "typecheck": "echo 'styles is CSS-only \u2014 no typecheck'",
     "test": "echo 'styles has no tests yet'",
     "publint": "publint",
-    "attw": "echo 'styles is CSS-only — no types'"
+    "attw": "echo 'styles is CSS-only \u2014 no types'"
   },
   "devDependencies": {
     "publint": "catalog:",
     "style-dictionary": "catalog:"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=26.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=26.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=26.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "publint": "publint",
-    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output — re-enable later'"
+    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output \u2014 re-enable later'"
   },
   "peerDependencies": {
     "vite": "catalog:"
@@ -54,7 +54,7 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=26.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/vite-plugin/tsdown.config.mjs
+++ b/packages/vite-plugin/tsdown.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: 'esm',
   platform: 'node',
-  target: 'node22',
+  target: 'node26',
   sourcemap: true,
   dts: true,
   clean: true,


### PR DESCRIPTION
Node 22 entered maintenance in October 2025 and now receives security fixes only. Node 26 becomes the active LTS line on 2026-10-28.

| | Was | Now |
| --- | --- | --- |
| `engines.node` (7 packages) | `>=22.14.0` | `>=26.0.0` |
| `engines.node` (4 templates) | `>=22` | `>=26` |
| tsdown target (cli, vite-plugin) | `node22` | `node26` |
| CI Node | whatever the runner image ships | pinned via `actions/setup-node@v7` |

## Without the CI pin this bump would be text

The workflows never pinned Node — no `setup-node` step, so every job used the image's. And nothing enforced the declared floor either: there is no `engine-strict` in `.npmrc`, so pnpm only warns. We would have declared 26 and validated on 22.

The header comment claiming the image ships Node 22.11 — *below* our own previous floor of 22.14.0 — goes with it, along with the stale note about the Node 24 matrix being parked on the image.

## Two things run rather than reasoned about

**Marked `minor`, not `major`.** Ran the version step with `major` first: it takes every package to **1.0.0**. That claims an API stability nobody has audited, on packages two of which (`types`, `testing`) are still 4-line stubs. On 0.x a minor is what signals a break — the same call made for the vite peer range.

**The template pins had to move too.** With `minor`, the release publishes core 0.5.0, vite-plugin 0.3.0, cli 0.2.0, styles 0.3.0. The templates pinned `^0.4.0`, `^0.2.0`, `^0.1.0`, `^0.2.0` — and on 0.x a caret pins the minor, so **all four would have missed**. Same trap as #61. Verified by running the version step and comparing both sides:

```
core        0.5.0   template ^0.5.0
cli         0.2.0   template ^0.2.0
vite-plugin 0.3.0   template ^0.3.0
styles      0.3.0   template ^0.3.0
```

## Verification

`pnpm typecheck` 12/12 · `pnpm test` 12/12 (421 tests) · `pnpm build` 9/9 · `biome ci` clean · `syncpack lint` no issues · `pnpm install --frozen-lockfile` passes.

All four templates built for real against the workspace under the `node26` target — each produces `dist/main.mjs` and its manifest.

## One thing worth stating plainly

Node 26 is **Current, not LTS**, until 2026-10-28. Requiring it means consumers run a non-LTS Node for the next eight weeks. That was the deliberate call: skip 24 rather than break the contract twice.
