### PR TITLE
ci: actually run attw instead of echoing a TODO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Publint
         run: pnpm publint
 
-      - name: Are The Types Wrong (currently stubbed)
+      - name: Are The Types Wrong
         run: pnpm attw
 
   knip:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "publint": "publint",
-    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output — re-enable later'"
+    "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
     "@clack/prompts": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "publint": "publint",
-    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output (filename undefined) — re-enable once upstream issue is fixed'"
+    "attw": "attw --pack . --profile esm-only"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "publint": "publint",
-    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output — re-enable later'"
+    "attw": "attw --pack . --profile esm-only"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vttforge/types",
   "version": "0.1.0",
-  "description": "Shared TypeScript types for VTTForge — full schema-to-TS inference, Foundry v13+ typing helpers.",
+  "description": "Shared TypeScript types for VTTForge \u2014 full schema-to-TS inference, Foundry v13+ typing helpers.",
   "type": "module",
   "license": "MIT",
   "homepage": "https://github.com/vttforge/vttforge#readme",
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "publint": "publint",
-    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output — re-enable later'"
+    "attw": "attw --pack . --profile esm-only"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "publint": "publint",
-    "attw": "echo '@arethetypeswrong/cli crashes on tsdown ESM-only output — re-enable later'"
+    "attw": "attw --pack . --profile esm-only"
   },
   "peerDependencies": {
     "vite": "catalog:"


### PR DESCRIPTION
The upstream crash that parked this is gone. `@arethetypeswrong/cli@0.18.5` runs clean against the tsdown ESM-only output — no more `Cannot read properties of undefined (reading 'filename')`.

The five typed packages now run:

```
attw --pack . --profile esm-only
```

The profile is the point. Without it attw reports `CJSResolvesToESM` — which for a package that is ESM-only by design is correct behaviour, not a defect. With it, all five exit 0.

`styles` keeps its echo: it ships CSS, no types.

Also drops "(currently stubbed)" from the CI step name, which was the honest label until now.

## Why this mattered

"Package quality (publint + attw)" has been passing green on every PR this session — including ones that moved the published type surface (TypeScript 7, the vite peer range). It was validating nothing. The real check on TS 7 was a byte-diff of the emitted declarations, done by hand.

`pnpm attw` 15/15 · `pnpm typecheck` 12/12 · `pnpm test` 12/12 · `biome ci` clean · `syncpack lint` no issues.