### PR TITLE
feat(dev-module): add the Foundry side of vttforge dev

### DIFF
--- a/.changeset/dev-module.md
+++ b/.changeset/dev-module.md
@@ -1,0 +1,19 @@
+---
+'@vttforge/dev-module': minor
+---
+
+Add `@vttforge/dev-module`, the Foundry side of `vttforge dev`.
+
+It applies stylesheet, template and language changes to a running world
+without a page reload, and fires the `hotReload` veto hook first so a module
+that suppresses Foundry's own hot reload suppresses this one too.
+
+Foundry's dispatcher could not be reused: its socket handler is a private
+method, and the `hotReload` hook fired inside it is a veto rather than an
+entry point — calling that hook from outside notifies listeners and does
+nothing else. The three handlers are reimplemented here against public API.
+
+One deliberate difference from Foundry's own behaviour: a stylesheet is
+matched on its resolved pathname, not on `link.href` compared against the
+payload's root-relative path. Those two never match, so that branch does not
+fire.

--- a/packages/dev-module/README.md
+++ b/packages/dev-module/README.md
@@ -1,0 +1,52 @@
+# @vttforge/dev-module
+
+The Foundry side of `vttforge dev`. It applies stylesheet, template and
+language changes to a running world without a page reload.
+
+Development only. It opens a socket to your machine and applies whatever
+arrives; nothing about that belongs in a world you care about.
+
+## Why it exists
+
+Foundry can hot reload on its own, but only when the server is started with
+the right flag and the files sit where its watcher looks. `vttforge dev`
+builds with Vite instead, so the files Foundry serves are build output that
+its watcher never sees.
+
+This module takes delivery into its own hands: `vttforge dev` pushes a
+payload per changed file, and this end applies it.
+
+## What it does with each file
+
+| Extension | Effect |
+| --- | --- |
+| `css` | Swaps the stylesheet in place |
+| `hbs`, `html` | Recompiles the template and re-renders open windows |
+| `json` | Merges a language file, if it is one you are viewing |
+
+Anything else is ignored — the watcher may cover more file types than can be
+applied without a reload.
+
+## Vetoing a reload
+
+The `hotReload` hook fires before anything is applied, exactly as Foundry's
+own does. Returning `false` cancels it:
+
+```js
+Hooks.on('hotReload', (data) => {
+  if (data.extension === 'css') return false;
+});
+```
+
+## Pointing it somewhere else
+
+It connects to `ws://localhost:31313`, or to `host.docker.internal` when
+Foundry is not served from a local address — which is what a containerised
+Foundry needs to reach the CLI on your machine. To override:
+
+```js
+globalThis.VTTFORGE_DEV_SERVER_URL = 'ws://192.168.1.10:31313';
+```
+
+A dropped connection is expected: the CLI stops between runs. Reconnection
+backs off rather than hammering a closed port.

--- a/packages/dev-module/module.json
+++ b/packages/dev-module/module.json
@@ -1,0 +1,20 @@
+{
+  "id": "vttforge-dev",
+  "title": "VTTForge Dev",
+  "description": "Applies changes from `vttforge dev` without a page reload. Development only — do not enable in a world you care about.",
+  "version": "0.0.0",
+  "compatibility": {
+    "minimum": "13",
+    "verified": "13"
+  },
+  "authors": [{ "name": "VTTForge" }],
+  "esmodules": ["main.mjs"],
+  "url": "https://github.com/vttforge/vttforge",
+  "license": "https://github.com/vttforge/vttforge/blob/main/LICENSE",
+  "manifest": "https://github.com/vttforge/vttforge/releases/latest/download/module.json",
+  "flags": {
+    "vttforge-dev": {
+      "developmentOnly": true
+    }
+  }
+}

--- a/packages/dev-module/package.json
+++ b/packages/dev-module/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@vttforge/dev-module",
+  "version": "0.0.0",
+  "description": "Foundry-side companion for `vttforge dev` \u2014 applies CSS, template and language changes in place, without a page reload.",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/vttforge/vttforge#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vttforge/vttforge.git",
+    "directory": "packages/dev-module"
+  },
+  "bugs": "https://github.com/vttforge/vttforge/issues",
+  "keywords": [
+    "foundryvtt",
+    "hmr",
+    "hot-reload",
+    "development",
+    "vttforge"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "./module.json": "./module.json",
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist",
+    "module.json",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "sideEffects": [
+    "./dist/main.mjs"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "publint": "publint",
+    "attw": "attw --pack . --profile esm-only"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "catalog:",
+    "happy-dom": "catalog:",
+    "publint": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "unrun": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=26.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": false
+  }
+}

--- a/packages/dev-module/src/__tests__/bootstrap.test.ts
+++ b/packages/dev-module/src/__tests__/bootstrap.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { bootstrap, buildEnv, DEFAULT_PORT, resolveServerUrl } from '../bootstrap.js';
+
+function foundryGlobals(over: Record<string, unknown> = {}) {
+  return {
+    game: { i18n: { lang: 'en', translations: {} } },
+    Handlebars: { compile: () => ({}), registerPartial: () => undefined },
+    Hooks: { call: () => true },
+    foundry: { utils: { mergeObject: (t: object) => t }, applications: { instances: new Map() } },
+    ui: { windows: {} },
+    document: globalThis.document,
+    ...over,
+  };
+}
+
+describe('resolveServerUrl', () => {
+  it.each([['localhost'], ['127.0.0.1'], ['[::1]']])(
+    'keeps %s as-is when Foundry is served locally',
+    (hostname) => {
+      expect(resolveServerUrl(hostname)).toBe(`ws://${hostname}:${DEFAULT_PORT}`);
+    },
+  );
+
+  it('reaches back to the host when Foundry is not local — the container case', () => {
+    expect(resolveServerUrl('192.168.1.40')).toBe(`ws://host.docker.internal:${DEFAULT_PORT}`);
+  });
+
+  it('honours an explicit override over any guess', () => {
+    expect(resolveServerUrl('192.168.1.40', 1234, 'ws://elsewhere:9999')).toBe(
+      'ws://elsewhere:9999',
+    );
+  });
+
+  it('uses the port it is given', () => {
+    expect(resolveServerUrl('localhost', 4000)).toBe('ws://localhost:4000');
+  });
+});
+
+describe('buildEnv', () => {
+  it('builds an environment from Foundry globals', () => {
+    const env = buildEnv({
+      globals: foundryGlobals(),
+      location: { hostname: 'localhost' },
+      createSocket: () => ({ addEventListener: () => undefined, close: () => undefined }),
+      setTimer: () => undefined,
+      log: () => undefined,
+    });
+    expect(env).not.toBeNull();
+    expect(env?.callHook('hotReload', {} as never)).toBe(true);
+  });
+
+  it.each([['game'], ['Handlebars'], ['Hooks'], ['foundry'], ['document']])(
+    'returns null when %s is missing',
+    (missing) => {
+      const globals = foundryGlobals();
+      delete (globals as Record<string, unknown>)[missing];
+      const env = buildEnv({
+        globals,
+        location: { hostname: 'localhost' },
+        createSocket: () => ({ addEventListener: () => undefined, close: () => undefined }),
+        setTimer: () => undefined,
+        log: () => undefined,
+      });
+      expect(env).toBeNull();
+    },
+  );
+});
+
+describe('bootstrap', () => {
+  it('does not connect outside Foundry, and says so', () => {
+    const log = vi.fn();
+    const createSocket = vi.fn();
+    const result = bootstrap({
+      globals: {},
+      location: { hostname: 'localhost' },
+      createSocket,
+      setTimer: () => undefined,
+      log,
+    });
+    expect(result).toBeNull();
+    expect(createSocket).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('Foundry globals are not available — not connecting.');
+  });
+
+  it('connects to the resolved address inside Foundry', () => {
+    const createSocket = vi.fn(() => ({
+      addEventListener: () => undefined,
+      close: () => undefined,
+    }));
+    const conn = bootstrap({
+      globals: foundryGlobals(),
+      location: { hostname: 'localhost' },
+      createSocket,
+      setTimer: () => undefined,
+      log: () => undefined,
+    });
+    expect(conn).not.toBeNull();
+    expect(createSocket).toHaveBeenCalledWith(`ws://localhost:${DEFAULT_PORT}`);
+  });
+});

--- a/packages/dev-module/src/__tests__/client.test.ts
+++ b/packages/dev-module/src/__tests__/client.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import { connect, parsePayload, type SocketLike } from '../client.js';
+import type { FoundryEnv } from '../reload.js';
+
+/** A socket whose events the test fires by hand. */
+function fakeSocket() {
+  const listeners = new Map<string, Array<(event: { data?: unknown }) => void>>();
+  const socket: SocketLike & {
+    fire: (t: string, e?: { data?: unknown }) => void;
+    closed: boolean;
+  } = {
+    addEventListener: (type, listener) => {
+      const list = listeners.get(type) ?? [];
+      list.push(listener);
+      listeners.set(type, list);
+    },
+    close: () => {
+      socket.closed = true;
+    },
+    fire: (type, event = {}) => {
+      for (const l of listeners.get(type) ?? []) l(event);
+    },
+    closed: false,
+  };
+  return socket;
+}
+
+const env = { callHook: () => false } as unknown as FoundryEnv;
+
+describe('parsePayload', () => {
+  it('reads a well-formed frame and lowercases the extension', () => {
+    const raw = JSON.stringify({
+      packageType: 'system',
+      packageId: 'my-system',
+      content: 'body{}',
+      path: 'systems/my-system/styles/main.css',
+      extension: 'CSS',
+    });
+    expect(parsePayload(raw)?.extension).toBe('css');
+  });
+
+  it.each([
+    ['not json at all'],
+    [JSON.stringify({ path: 'a' })],
+    [JSON.stringify({ path: 'a', content: 'b', extension: 'css' })],
+    [JSON.stringify({ path: 1, content: 'b', extension: 'css', packageId: 'x' })],
+  ])('drops a frame it cannot trust: %j', (raw) => {
+    expect(parsePayload(raw)).toBeNull();
+  });
+
+  it.each([[null], [undefined], [42], [{}]])('drops a non-string frame: %j', (raw) => {
+    expect(parsePayload(raw)).toBeNull();
+  });
+
+  it('defaults an unrecognised packageType to system rather than dropping the frame', () => {
+    const raw = JSON.stringify({
+      packageType: 'nonsense',
+      packageId: 'my-system',
+      content: '',
+      path: 'a.css',
+      extension: 'css',
+    });
+    expect(parsePayload(raw)?.packageType).toBe('system');
+  });
+});
+
+describe('connect', () => {
+  it('reconnects with backoff after the socket closes', () => {
+    const sockets: ReturnType<typeof fakeSocket>[] = [];
+    const timers: Array<{ fn: () => void; ms: number }> = [];
+    connect({
+      url: 'ws://localhost:31313',
+      env,
+      createSocket: () => {
+        const s = fakeSocket();
+        sockets.push(s);
+        return s;
+      },
+      setTimer: (fn, ms) => timers.push({ fn, ms }),
+      log: () => undefined,
+      retryDelays: [10, 20, 40],
+    });
+
+    sockets[0]?.fire('close');
+    expect(timers[0]?.ms).toBe(10);
+    timers[0]?.fn();
+
+    sockets[1]?.fire('close');
+    expect(timers[1]?.ms).toBe(20);
+  });
+
+  it('holds at the final delay instead of growing without bound', () => {
+    const sockets: ReturnType<typeof fakeSocket>[] = [];
+    const timers: Array<{ fn: () => void; ms: number }> = [];
+    connect({
+      url: 'ws://x',
+      env,
+      createSocket: () => {
+        const s = fakeSocket();
+        sockets.push(s);
+        return s;
+      },
+      setTimer: (fn, ms) => timers.push({ fn, ms }),
+      log: () => undefined,
+      retryDelays: [10, 20],
+    });
+
+    for (let i = 0; i < 4; i += 1) {
+      sockets[i]?.fire('close');
+      timers[i]?.fn();
+    }
+    expect(timers.at(-1)?.ms).toBe(20);
+  });
+
+  it('resets the backoff once a connection succeeds', () => {
+    const sockets: ReturnType<typeof fakeSocket>[] = [];
+    const timers: Array<{ fn: () => void; ms: number }> = [];
+    connect({
+      url: 'ws://x',
+      env,
+      createSocket: () => {
+        const s = fakeSocket();
+        sockets.push(s);
+        return s;
+      },
+      setTimer: (fn, ms) => timers.push({ fn, ms }),
+      log: () => undefined,
+      retryDelays: [10, 20, 40],
+    });
+
+    sockets[0]?.fire('close');
+    timers[0]?.fn();
+    sockets[1]?.fire('open');
+    sockets[1]?.fire('close');
+    expect(timers[1]?.ms).toBe(10);
+  });
+
+  it('stops reconnecting once told to stop', () => {
+    const sockets: ReturnType<typeof fakeSocket>[] = [];
+    const timers: Array<{ fn: () => void; ms: number }> = [];
+    const conn = connect({
+      url: 'ws://x',
+      env,
+      createSocket: () => {
+        const s = fakeSocket();
+        sockets.push(s);
+        return s;
+      },
+      setTimer: (fn, ms) => timers.push({ fn, ms }),
+      log: () => undefined,
+    });
+
+    conn.stop();
+    expect(sockets[0]?.closed).toBe(true);
+    sockets[0]?.fire('close');
+    expect(timers).toHaveLength(0);
+  });
+
+  it('survives a malformed frame rather than dropping the connection', () => {
+    const sockets: ReturnType<typeof fakeSocket>[] = [];
+    connect({
+      url: 'ws://x',
+      env,
+      createSocket: () => {
+        const s = fakeSocket();
+        sockets.push(s);
+        return s;
+      },
+      setTimer: () => undefined,
+      log: () => undefined,
+    });
+
+    expect(() => sockets[0]?.fire('message', { data: '{{{' })).not.toThrow();
+  });
+
+  it('reports a payload it could not apply, but stays quiet about a veto', () => {
+    const sockets: ReturnType<typeof fakeSocket>[] = [];
+    const log = vi.fn();
+    connect({
+      url: 'ws://x',
+      env,
+      createSocket: () => {
+        const s = fakeSocket();
+        sockets.push(s);
+        return s;
+      },
+      setTimer: () => undefined,
+      log,
+    });
+
+    const frame = JSON.stringify({
+      packageType: 'system',
+      packageId: 'my-system',
+      content: '',
+      path: 'a.css',
+      extension: 'css',
+    });
+    sockets[0]?.fire('message', { data: frame });
+    // env vetoes, so nothing beyond the initial connect message is logged
+    expect(log.mock.calls.flat()).not.toContain('could not reload a.css (no-match)');
+  });
+});

--- a/packages/dev-module/src/__tests__/reload.test.ts
+++ b/packages/dev-module/src/__tests__/reload.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyHotReload, type FoundryEnv, type HotReloadData } from '../reload.js';
+
+const NOW = 1_700_000_000_000;
+
+function makeEnv(overrides: Partial<FoundryEnv> = {}): FoundryEnv {
+  const rendered: Array<{ render: () => void }> = [];
+  return {
+    Handlebars: {
+      compile: vi.fn((input: string) => ({ compiled: input })),
+      registerPartial: vi.fn(),
+    },
+    game: {
+      i18n: { lang: 'en', translations: {} },
+      system: { languages: [{ path: 'systems/my-system/lang/en.json', lang: 'en' }] },
+      modules: { get: () => undefined },
+    },
+    ui: { windows: {} },
+    applicationInstances: () => rendered,
+    mergeObject: vi.fn((target: object, source: object) => Object.assign(target, source)),
+    callHook: vi.fn(() => true),
+    document: globalThis.document,
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+function payload(over: Partial<HotReloadData> = {}): HotReloadData {
+  return {
+    packageType: 'system',
+    packageId: 'my-system',
+    content: '',
+    path: 'systems/my-system/styles/main.css',
+    extension: 'css',
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  document.head.innerHTML = '';
+  document.body.innerHTML = '';
+});
+
+describe('veto hook', () => {
+  it('does nothing when a listener returns false', () => {
+    const env = makeEnv({ callHook: vi.fn(() => false) });
+    expect(applyHotReload(payload(), env)).toEqual({ applied: false, reason: 'vetoed' });
+  });
+
+  it('fires the hook before acting, matching core', () => {
+    const env = makeEnv();
+    applyHotReload(payload({ extension: 'hbs', content: '<p></p>' }), env);
+    expect(env.callHook).toHaveBeenCalledWith(
+      'hotReload',
+      expect.objectContaining({ extension: 'hbs' }),
+    );
+  });
+
+  it('ignores an extension it cannot apply in place', () => {
+    expect(applyHotReload(payload({ extension: 'mjs' }), makeEnv())).toEqual({
+      applied: false,
+      reason: 'unsupported-extension',
+    });
+  });
+});
+
+describe('css', () => {
+  it('cache-busts the matching stylesheet link', () => {
+    const link = document.createElement('link');
+    link.href = 'systems/my-system/styles/main.css';
+    document.head.append(link);
+
+    expect(applyHotReload(payload(), makeEnv())).toEqual({ applied: true, kind: 'css' });
+    expect(link.getAttribute('href')).toBe(`systems/my-system/styles/main.css?${NOW}`);
+  });
+
+  it('replaces an existing cache-buster rather than stacking one on', () => {
+    const link = document.createElement('link');
+    link.href = 'systems/my-system/styles/main.css?999';
+    document.head.append(link);
+
+    applyHotReload(payload(), makeEnv());
+    expect(link.getAttribute('href')).toBe(`systems/my-system/styles/main.css?${NOW}`);
+  });
+
+  it('falls back to an @import inside a style block', () => {
+    const style = document.createElement('style');
+    style.textContent = '@import "systems/my-system/styles/main.css";';
+    document.head.append(style);
+
+    expect(applyHotReload(payload(), makeEnv())).toEqual({ applied: true, kind: 'css' });
+    expect(style.textContent).toBe(`@import "systems/my-system/styles/main.css?${NOW}";`);
+  });
+
+  it('leaves an unrelated stylesheet alone and reports no match', () => {
+    const link = document.createElement('link');
+    link.href = 'systems/other/styles/other.css';
+    document.head.append(link);
+
+    expect(applyHotReload(payload(), makeEnv())).toEqual({ applied: false, reason: 'no-match' });
+    expect(link.getAttribute('href')).toBe('systems/other/styles/other.css');
+  });
+
+  it('treats a path with regex characters as a path, not a pattern', () => {
+    const style = document.createElement('style');
+    style.textContent = '@import "systems/my.system/styles/a+b.css";';
+    document.head.append(style);
+
+    const result = applyHotReload(payload({ path: 'systems/my.system/styles/a+b.css' }), makeEnv());
+    expect(result).toEqual({ applied: true, kind: 'css' });
+    expect(style.textContent).toContain(`a+b.css?${NOW}`);
+  });
+});
+
+describe('templates', () => {
+  it('registers the recompiled template under its path', () => {
+    const env = makeEnv();
+    const data = payload({
+      extension: 'hbs',
+      content: '<div>{{name}}</div>',
+      path: 'systems/my-system/templates/actor.hbs',
+    });
+
+    expect(applyHotReload(data, env)).toEqual({ applied: true, kind: 'html' });
+    expect(env.Handlebars.registerPartial).toHaveBeenCalledWith(
+      'systems/my-system/templates/actor.hbs',
+      { compiled: '<div>{{name}}</div>' },
+    );
+  });
+
+  it('re-renders both application generations', () => {
+    const v1 = { render: vi.fn() };
+    const v2 = { render: vi.fn() };
+    const env = makeEnv({ ui: { windows: { 1: v1 } }, applicationInstances: () => [v2] });
+
+    applyHotReload(payload({ extension: 'hbs', content: '<p></p>' }), env);
+    expect(v1.render).toHaveBeenCalledOnce();
+    expect(v2.render).toHaveBeenCalledOnce();
+  });
+
+  it('reports a broken template instead of throwing', () => {
+    const env = makeEnv({
+      Handlebars: {
+        compile: () => {
+          throw new Error('unclosed block');
+        },
+        registerPartial: vi.fn(),
+      },
+    });
+    expect(applyHotReload(payload({ extension: 'hbs', content: '{{#if' }), env)).toEqual({
+      applied: false,
+      reason: 'parse-error',
+    });
+    expect(env.Handlebars.registerPartial).not.toHaveBeenCalled();
+  });
+
+  it('accepts html the same way as hbs', () => {
+    expect(applyHotReload(payload({ extension: 'html', content: '<p></p>' }), makeEnv())).toEqual({
+      applied: true,
+      kind: 'html',
+    });
+  });
+});
+
+describe('language files', () => {
+  const langPath = 'systems/my-system/lang/en.json';
+
+  it('merges a declared file for the active language', () => {
+    const env = makeEnv();
+    const data = payload({ extension: 'json', path: langPath, content: '{"KEY":"value"}' });
+
+    expect(applyHotReload(data, env)).toEqual({ applied: true, kind: 'json' });
+    expect(env.mergeObject).toHaveBeenCalledWith(env.game.i18n.translations, { KEY: 'value' });
+  });
+
+  it('skips a file for a language the user is not viewing', () => {
+    const env = makeEnv();
+    env.game.i18n.lang = 'pt-BR';
+    const data = payload({ extension: 'json', path: langPath, content: '{"KEY":"value"}' });
+
+    expect(applyHotReload(data, env)).toEqual({ applied: false, reason: 'no-match' });
+    expect(env.mergeObject).not.toHaveBeenCalled();
+  });
+
+  it('skips a json file the manifest never declared as a language', () => {
+    const env = makeEnv();
+    const data = payload({
+      extension: 'json',
+      path: 'systems/my-system/template.json',
+      content: '{}',
+    });
+
+    expect(applyHotReload(data, env)).toEqual({ applied: false, reason: 'no-match' });
+  });
+
+  it('reads a module language file off the module, not the system', () => {
+    const env = makeEnv({
+      game: {
+        i18n: { lang: 'en', translations: {} },
+        system: { languages: [] },
+        modules: {
+          get: (id) =>
+            id === 'my-module'
+              ? { languages: [{ path: 'modules/my-module/lang/en.json', lang: 'en' }] }
+              : undefined,
+        },
+      },
+    });
+    const data = payload({
+      packageType: 'module',
+      packageId: 'my-module',
+      extension: 'json',
+      path: 'modules/my-module/lang/en.json',
+      content: '{"A":"b"}',
+    });
+
+    expect(applyHotReload(data, env)).toEqual({ applied: true, kind: 'json' });
+  });
+
+  it('reports malformed json instead of throwing', () => {
+    const env = makeEnv();
+    const data = payload({ extension: 'json', path: langPath, content: '{ not json' });
+
+    expect(applyHotReload(data, env)).toEqual({ applied: false, reason: 'parse-error' });
+    expect(env.mergeObject).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dev-module/src/bootstrap.ts
+++ b/packages/dev-module/src/bootstrap.ts
@@ -1,0 +1,96 @@
+/**
+ * Wiring: read the address, build the Foundry surface, connect.
+ *
+ * Kept apart from the entry point so every decision here — which host to
+ * reach, what counts as a usable global — can be tested without a browser.
+ */
+import { type Connection, connect, type SocketLike } from './client.js';
+import type { FoundryEnv } from './reload.js';
+
+export const MODULE_ID = 'vttforge-dev';
+
+/** Where `vttforge dev` listens unless told otherwise. */
+export const DEFAULT_PORT = 31313;
+
+/**
+ * Work out the dev server address.
+ *
+ * Foundry commonly runs in a container while the CLI runs on the host, and
+ * from inside a container `localhost` is the container. Docker publishes the
+ * host as `host.docker.internal`, so when the page is not served from a local
+ * address that is the better guess — a wrong guess here just fails to
+ * connect, which is visible and harmless.
+ */
+export function resolveServerUrl(
+  hostname: string,
+  port: number = DEFAULT_PORT,
+  override?: string | null,
+): string {
+  if (override) return override;
+  const isLocal = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+  const host = isLocal ? hostname : 'host.docker.internal';
+  return `ws://${host}:${port}`;
+}
+
+export interface BootstrapDeps {
+  globals: Record<string, unknown>;
+  location: { hostname: string };
+  createSocket: (url: string) => SocketLike;
+  setTimer: (fn: () => void, ms: number) => unknown;
+  log: (message: string, ...rest: unknown[]) => void;
+  port?: number;
+  override?: string | null;
+}
+
+/**
+ * Build the environment the handlers need out of Foundry's globals.
+ *
+ * Returns null when the globals are not there. That is not a failure worth
+ * shouting about — it means this ran outside Foundry, and refusing to connect
+ * is the correct response.
+ */
+export function buildEnv(deps: BootstrapDeps): FoundryEnv | null {
+  const g = deps.globals;
+  const foundry = g.foundry as
+    | {
+        applications?: { instances?: Map<unknown, { render: () => void }> };
+        utils?: { mergeObject?: FoundryEnv['mergeObject'] };
+      }
+    | undefined;
+  const game = g.game as FoundryEnv['game'] | undefined;
+  const Handlebars = g.Handlebars as FoundryEnv['Handlebars'] | undefined;
+  const Hooks = g.Hooks as { call: (name: string, data: unknown) => boolean } | undefined;
+  const mergeObject = foundry?.utils?.mergeObject;
+  const doc = g.document as Document | undefined;
+
+  if (!game || !Handlebars || !Hooks || !mergeObject || !doc) return null;
+
+  return {
+    Handlebars,
+    game,
+    ui: g.ui as FoundryEnv['ui'],
+    applicationInstances: () => foundry?.applications?.instances?.values() ?? [],
+    mergeObject,
+    callHook: (name, data) => Hooks.call(name, data),
+    document: doc,
+    now: () => Date.now(),
+  };
+}
+
+/** Connect, or explain why not. Returns null when there is nothing to do. */
+export function bootstrap(deps: BootstrapDeps): Connection | null {
+  const env = buildEnv(deps);
+  if (!env) {
+    deps.log('Foundry globals are not available — not connecting.');
+    return null;
+  }
+  const url = resolveServerUrl(deps.location.hostname, deps.port, deps.override);
+  deps.log(`watching for changes from ${url}`);
+  return connect({
+    url,
+    env,
+    createSocket: deps.createSocket,
+    setTimer: deps.setTimer,
+    log: deps.log,
+  });
+}

--- a/packages/dev-module/src/client.ts
+++ b/packages/dev-module/src/client.ts
@@ -1,0 +1,129 @@
+/**
+ * The WebSocket client.
+ *
+ * `vttforge dev` runs `vite build --watch`, which has no server of its own,
+ * so the CLI stands up a small socket and pushes a payload per changed file.
+ * This end listens and applies it.
+ *
+ * The socket is expected to disappear often — the CLI stops between runs, the
+ * developer restarts it — so a dropped connection is normal, not an error, and
+ * reconnection backs off rather than hammering a port nobody is listening on.
+ */
+import { applyHotReload, type FoundryEnv, type HotReloadData } from './reload.js';
+
+export interface ClientOptions {
+  url: string;
+  env: FoundryEnv;
+  /** Injected so tests do not need a real WebSocket. */
+  createSocket: (url: string) => SocketLike;
+  /** Injected so tests do not wait in real time. */
+  setTimer: (fn: () => void, ms: number) => unknown;
+  log: (message: string, ...rest: unknown[]) => void;
+  /** Backoff schedule in ms; the last value repeats. */
+  retryDelays?: readonly number[];
+}
+
+/** The slice of WebSocket this module uses. */
+export interface SocketLike {
+  addEventListener: (type: string, listener: (event: { data?: unknown }) => void) => void;
+  close: () => void;
+}
+
+const DEFAULT_RETRY_DELAYS = [500, 1000, 2000, 5000] as const;
+
+export interface Connection {
+  /** Stop reconnecting and drop the current socket. */
+  stop: () => void;
+}
+
+export function connect(options: ClientOptions): Connection {
+  const retryDelays = options.retryDelays ?? DEFAULT_RETRY_DELAYS;
+  let attempt = 0;
+  let stopped = false;
+  let socket: SocketLike | null = null;
+
+  const open = (): void => {
+    if (stopped) return;
+    socket = options.createSocket(options.url);
+
+    socket.addEventListener('open', () => {
+      attempt = 0;
+      options.log('connected to the dev server');
+    });
+
+    socket.addEventListener('message', (event) => {
+      const data = parsePayload(event.data);
+      if (!data) return;
+      const outcome = applyHotReload(data, options.env);
+      if (outcome.applied) {
+        options.log(`reloaded ${data.path}`);
+      } else if (outcome.reason !== 'vetoed') {
+        // A veto is somebody's deliberate choice; the rest mean the payload
+        // arrived but nothing on the page matched it, which is worth saying
+        // out loud rather than failing silently.
+        options.log(`could not reload ${data.path} (${outcome.reason})`);
+      }
+    });
+
+    socket.addEventListener('close', () => {
+      socket = null;
+      if (stopped) return;
+      const delay = retryDelays[Math.min(attempt, retryDelays.length - 1)] ?? 5000;
+      attempt += 1;
+      options.setTimer(open, delay);
+    });
+
+    // A failed connection also emits `close`, so reconnection is handled
+    // there. Swallowing `error` keeps a routine "nothing listening yet" out
+    // of the console as an uncaught event.
+    socket.addEventListener('error', () => undefined);
+  };
+
+  open();
+
+  return {
+    stop: () => {
+      stopped = true;
+      socket?.close();
+      socket = null;
+    },
+  };
+}
+
+/**
+ * Read one frame.
+ *
+ * The payload crosses a process boundary, so nothing about its shape is
+ * assumed. A malformed frame is dropped rather than allowed to throw inside
+ * the socket listener, where it would take the connection down with it.
+ */
+export function parsePayload(raw: unknown): HotReloadData | null {
+  if (typeof raw !== 'string') return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const p = parsed as Record<string, unknown>;
+  if (
+    typeof p.path !== 'string' ||
+    typeof p.content !== 'string' ||
+    typeof p.extension !== 'string' ||
+    typeof p.packageId !== 'string'
+  ) {
+    return null;
+  }
+  const packageType =
+    p.packageType === 'system' || p.packageType === 'module' || p.packageType === 'world'
+      ? p.packageType
+      : 'system';
+  return {
+    packageType,
+    packageId: p.packageId,
+    content: p.content,
+    path: p.path,
+    extension: p.extension.toLowerCase(),
+  };
+}

--- a/packages/dev-module/src/index.ts
+++ b/packages/dev-module/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * `@vttforge/dev-module` — the Foundry side of `vttforge dev`.
+ *
+ * Foundry can hot reload on its own, but only when the server is started with
+ * the right flag and the files sit where that watcher looks. `vttforge dev`
+ * builds with Vite instead, so this module takes delivery into its own hands:
+ * the CLI pushes a payload per changed file and this end applies it.
+ *
+ * Development only. Nothing here belongs in a shipped world.
+ */
+
+export { bootstrap, MODULE_ID, resolveServerUrl } from './bootstrap.js';
+export type { ClientOptions, Connection, SocketLike } from './client.js';
+export { connect, parsePayload } from './client.js';
+export type { FoundryEnv, HotReloadData, ReloadOutcome } from './reload.js';
+export { applyHotReload } from './reload.js';

--- a/packages/dev-module/src/main.ts
+++ b/packages/dev-module/src/main.ts
@@ -1,0 +1,23 @@
+/**
+ * Foundry entry point. Loaded by `module.json`, runs in the browser.
+ *
+ * Everything of substance lives in `bootstrap`; this file only supplies the
+ * real globals, the real socket, and the real timer.
+ */
+import { bootstrap, MODULE_ID } from './bootstrap.js';
+
+const PREFIX = `${MODULE_ID} |`;
+
+Hooks.once('ready', () => {
+  const override = (globalThis as Record<string, unknown>).VTTFORGE_DEV_SERVER_URL ?? null;
+  bootstrap({
+    globals: globalThis as unknown as Record<string, unknown>,
+    location: globalThis.location,
+    createSocket: (url) => new WebSocket(url),
+    setTimer: (fn, ms) => globalThis.setTimeout(fn, ms),
+    log: (message, ...rest) => console.info(PREFIX, message, ...rest),
+    override: typeof override === 'string' ? override : null,
+  });
+});
+
+declare const Hooks: { once: (name: string, fn: () => void) => void };

--- a/packages/dev-module/src/main.ts
+++ b/packages/dev-module/src/main.ts
@@ -15,6 +15,10 @@ Hooks.once('ready', () => {
     location: globalThis.location,
     createSocket: (url) => new WebSocket(url),
     setTimer: (fn, ms) => globalThis.setTimeout(fn, ms),
+    // The console is this module's only interface. A developer watching for
+    // "reloaded …" has nowhere else to look, and a dev-only module has no
+    // reason to route it through Foundry's notifications.
+    // biome-ignore lint/suspicious/noConsole: the console is the output here
     log: (message, ...rest) => console.info(PREFIX, message, ...rest),
     override: typeof override === 'string' ? override : null,
   });

--- a/packages/dev-module/src/reload.ts
+++ b/packages/dev-module/src/reload.ts
@@ -1,0 +1,174 @@
+/**
+ * The reload handlers.
+ *
+ * Foundry ships an equivalent dispatcher, but it is unreachable: the socket
+ * handler is a private method, and the `hotReload` hook fired inside it is a
+ * veto — returning `false` cancels the reload. Calling that hook from outside
+ * notifies listeners and nothing else.
+ *
+ * So the work is reimplemented here. It is a small surface and uses only
+ * public API. Behaviour is kept deliberately identical to core's, including
+ * firing the veto hook first, so a module that suppresses Foundry's own hot
+ * reload suppresses this one too.
+ */
+
+/** The payload shape Foundry's own hot reload uses. */
+export interface HotReloadData {
+  packageType: 'system' | 'module' | 'world';
+  packageId: string;
+  /** Full file contents, already read by the sender. */
+  content: string;
+  /** Path as Foundry serves it, e.g. `systems/my-system/styles/main.css`. */
+  path: string;
+  /** Lowercase, no dot: `css`, `hbs`, `html`, `json`. */
+  extension: string;
+}
+
+/** What a reload attempt did, so callers can log something truthful. */
+export type ReloadOutcome =
+  | { applied: true; kind: 'css' | 'html' | 'json' }
+  | { applied: false; reason: 'vetoed' | 'unsupported-extension' | 'no-match' | 'parse-error' };
+
+/**
+ * Swap a stylesheet in place by cache-busting its href.
+ *
+ * Falls back to rewriting an `@import` inside a `<style>` block, which is how
+ * a bundled stylesheet pulled in by another one shows up in the document.
+ */
+function reloadCss(path: string, doc: Document, now: number): ReloadOutcome {
+  for (const link of doc.querySelectorAll('link')) {
+    if (linkPointsAt(link, path)) {
+      link.setAttribute('href', `${path}?${now}`);
+      return { applied: true, kind: 'css' };
+    }
+  }
+  // Escape the path before it becomes a pattern — a stylesheet name is not
+  // a trusted regular expression.
+  const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const importRe = new RegExp(`@import "${escaped}(?:\\?[^"]+)?"`);
+  for (const style of doc.querySelectorAll('style')) {
+    const [match] = style.textContent?.match(importRe) ?? [];
+    if (match) {
+      style.textContent = (style.textContent ?? '').replace(match, `@import "${path}?${now}"`);
+      return { applied: true, kind: 'css' };
+    }
+  }
+  return { applied: false, reason: 'no-match' };
+}
+
+/**
+ * Does this `<link>` serve the file at `path`?
+ *
+ * The payload carries a root-relative path (`systems/x/styles/main.css`)
+ * while `HTMLLinkElement.href` always reads back as a fully resolved URL.
+ * Comparing those two directly never matches, so this checks the authored
+ * attribute as well as the resolved pathname and accepts either. Both are
+ * compared with any cache-buster stripped, so re-reloading the same file
+ * keeps matching instead of matching only once.
+ */
+function linkPointsAt(link: HTMLLinkElement, path: string): boolean {
+  const target = path.replace(/^\//, '');
+  const authored = (link.getAttribute('href') ?? '').split('?')[0]?.replace(/^\//, '');
+  if (authored === target) return true;
+  try {
+    const resolved = new URL(link.href, 'http://localhost').pathname.replace(/^\//, '');
+    return resolved === target;
+  } catch {
+    return false;
+  }
+}
+
+/** Recompile a template, re-register it, and re-render what is open. */
+function reloadHtml(data: HotReloadData, env: FoundryEnv): ReloadOutcome {
+  let template: unknown;
+  try {
+    template = env.Handlebars.compile(data.content);
+  } catch {
+    return { applied: false, reason: 'parse-error' };
+  }
+  env.Handlebars.registerPartial(data.path, template);
+  renderOpenApplications(env);
+  return { applied: true, kind: 'html' };
+}
+
+/**
+ * Merge a language file into the active translations.
+ *
+ * Only the file matching the user's current language is worth applying —
+ * merging another language's strings would replace the visible ones.
+ */
+function reloadJson(data: HotReloadData, env: FoundryEnv): ReloadOutcome {
+  const currentLang = env.game.i18n.lang;
+  const pkg =
+    data.packageType === 'system' ? env.game.system : env.game.modules?.get(data.packageId);
+  const declared = pkg?.languages?.some((l) => l.path === data.path && l.lang === currentLang);
+  if (!declared) return { applied: false, reason: 'no-match' };
+
+  let translations: object;
+  try {
+    translations = JSON.parse(data.content);
+  } catch {
+    return { applied: false, reason: 'parse-error' };
+  }
+  env.mergeObject(env.game.i18n.translations, translations);
+  renderOpenApplications(env);
+  return { applied: true, kind: 'json' };
+}
+
+/** Re-render every open window, both application generations. */
+function renderOpenApplications(env: FoundryEnv): void {
+  for (const app of Object.values(env.ui?.windows ?? {})) app.render();
+  for (const app of env.applicationInstances()) app.render();
+}
+
+/**
+ * The Foundry surface this module touches, named explicitly.
+ *
+ * Passing it in rather than reaching for globals is what makes the handlers
+ * testable without booting Foundry — and it documents the whole dependency
+ * in one place.
+ */
+export interface FoundryEnv {
+  Handlebars: {
+    compile: (input: string) => unknown;
+    registerPartial: (name: string, template: unknown) => void;
+  };
+  game: {
+    i18n: { lang: string; translations: object };
+    system?: { languages?: Array<{ path: string; lang: string }> };
+    modules?: {
+      get: (id: string) => { languages?: Array<{ path: string; lang: string }> } | undefined;
+    };
+  };
+  ui?: { windows?: Record<string, { render: () => void }> };
+  applicationInstances: () => Iterable<{ render: () => void }>;
+  mergeObject: (target: object, source: object) => object;
+  /** Fires the veto hook; a `false` return cancels the reload. */
+  callHook: (name: string, data: HotReloadData) => boolean;
+  document: Document;
+  now: () => number;
+}
+
+/**
+ * Apply one hot reload payload.
+ *
+ * Mirrors core's dispatch: veto hook first, then switch on extension. An
+ * unknown extension is a no-op rather than an error — the sender may watch
+ * more file types than the client knows how to apply in place.
+ */
+export function applyHotReload(data: HotReloadData, env: FoundryEnv): ReloadOutcome {
+  if (env.callHook('hotReload', data) === false) {
+    return { applied: false, reason: 'vetoed' };
+  }
+  switch (data.extension) {
+    case 'css':
+      return reloadCss(data.path, env.document, env.now());
+    case 'html':
+    case 'hbs':
+      return reloadHtml(data, env);
+    case 'json':
+      return reloadJson(data, env);
+    default:
+      return { applied: false, reason: 'unsupported-extension' };
+  }
+}

--- a/packages/dev-module/tsconfig.json
+++ b/packages/dev-module/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dev-module/tsdown.config.mjs
+++ b/packages/dev-module/tsdown.config.mjs
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  // `index` is the importable API — the CLI reads it, the tests exercise it.
+  // `main` is what Foundry loads: it must sit beside module.json as a
+  // browser-ready ES module with no bare specifiers left to resolve.
+  //
+  // The two entries share code, so the bundler emits a chunk alongside them.
+  // That is fine for Foundry, which resolves the relative import, but it does
+  // mean the install step copies the whole `dist/` directory rather than
+  // naming files — a file list would silently drop the chunk and leave a
+  // module that loads and then fails.
+  entry: ['src/index.ts', 'src/main.ts'],
+  format: 'esm',
+  platform: 'browser',
+  target: 'es2022',
+  sourcemap: true,
+  dts: true,
+  clean: true,
+  outExtensions: () => ({ js: '.mjs', dts: '.d.mts' }),
+});

--- a/packages/dev-module/vitest.config.mts
+++ b/packages/dev-module/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // The reload handlers touch `document` directly — that is the whole job
+    // of the CSS path — so they need a DOM to act on.
+    environment: 'happy-dom',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,30 @@ importers:
         specifier: workspace:*
         version: link:../cli
 
+  packages/dev-module:
+    devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: 'catalog:'
+        version: 0.18.5
+      happy-dom:
+        specifier: 'catalog:'
+        version: 20.12.0
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.24
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.14(@arethetypeswrong/core@0.18.5)(oxc-resolver@11.24.2)(publint@0.3.24)(typescript@7.0.2)(unrun@0.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      unrun:
+        specifier: 'catalog:'
+        version: 0.3.1
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@types/node@26.4.0)(happy-dom@20.12.0)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0))
+
   packages/styles:
     devDependencies:
       publint:


### PR DESCRIPTION
First slice of Track 2. This is the Foundry end: it receives a payload per changed file and applies it to a running world — stylesheets swap in place, templates recompile and re-render, language files merge into the active translations.

The sender lands in the next PR.

## The plan of record was wrong, and reading the client is what caught it

Option A was written as: the dev module calls `Hooks.call("hotReload", data)` and Foundry's dispatcher does the rest. **That does not work.**

```js
#handleHotReload(data) {                       // private
  const proceed = Hooks.call("hotReload", data);
  if ( proceed === false ) return;             // a veto, not an entry point
  switch ( data.extension ) { ... }            // handlers are private too
}
```

Calling that hook from outside notifies listeners and nothing else. So the three handlers are reimplemented here — cheap, because they use only public API — and the veto hook fires first, so a module that suppresses Foundry's hot reload suppresses this one too.

The internal note that carried the wrong assumption has been corrected.

## One deliberate divergence from core

Foundry matches a stylesheet with `link.href.split("?")[0] === path`. But `HTMLLinkElement.href` always reads back as a fully resolved URL, while the payload carries a root-relative path (the server sends `n.startsWith("/") ? n.slice(1) : n`). Those never match, so that branch does not fire.

This matches on the authored attribute **and** the resolved pathname, either of which works, and strips any existing cache-buster so reloading the same file twice keeps matching.

## Testability was a design constraint, not an afterthought

Nothing reaches for a global. The Foundry surface is one named `FoundryEnv` interface passed in, which is what lets **47 tests** cover the handlers, the socket backoff and the address resolution without booting Foundry.

Covered: the veto path, an unsupported extension, a broken template, malformed JSON, a language file for a language you are not viewing, a module language file read off the module rather than the system, a stylesheet path containing regex characters, backoff growth and reset, and a malformed frame that must not take the connection down.

## Container-aware by default

Foundry commonly runs in a container while the CLI runs on your machine, and from inside a container `localhost` is the container. When the page is not served from a local address the module reaches `host.docker.internal` instead. Overridable via `globalThis.VTTFORGE_DEV_SERVER_URL`.

## Packaging note

The two entries share code, so the bundler emits a chunk beside them. Foundry resolves the relative import fine, but it means the install step in the next PR copies the whole `dist/` directory rather than naming files — a file list would silently drop the chunk and leave a module that loads and then fails. That reasoning sits in the build config where it will be read.

`pnpm test` 47 new tests · `pnpm typecheck` 13/13 · `pnpm build` 10/10 · `biome ci` clean · `syncpack lint` no issues · `pnpm attw` clean.
