### PR TITLE
feat(cli): send saves to Foundry instead of asking for a refresh

### DIFF
--- a/.changeset/dev-hmr-bridge.md
+++ b/.changeset/dev-hmr-bridge.md
@@ -1,0 +1,23 @@
+---
+'@vttforge/cli': minor
+---
+
+`vttforge dev` now applies saves in place, without a page refresh.
+
+It opens a small WebSocket, links `@vttforge/dev-module` into Foundry's
+modules directory, and watches the build output — sending a payload per
+changed CSS, template or language file.
+
+The socket is hand-written rather than pulled from a package. The CLI ships
+to every consumer, so each dependency is one they install too, and what is
+needed here is a narrow slice of the protocol: accept the upgrade, send
+unmasked text frames, notice when a client leaves.
+
+Watching `dist/` rather than hooking into Vite keeps this correct across
+bundler versions, and gives the served path directly — `dist/` is what
+Foundry mounts.
+
+Failing to start the bridge costs hot reload, not the dev loop. A busy port
+or a missing companion package prints why and carries on watching.
+
+New: `--hmr-port` to move the bridge off 31313.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,9 @@ services:
       # tree (system.json + bundled main.mjs + bundled styles/ + lang/ + templates/).
       - ./examples/simple-system/dist:/data/Data/systems/vttforge-example:ro
       - ./examples/simple-module:/data/Data/modules/vttforge-example-module:ro
+      # The hot reload companion. A container cannot follow the symlink
+      # `vttforge dev` drops on the host, so it is mounted instead.
+      - ./packages/dev-module:/data/Data/modules/vttforge-dev:ro
     ports:
       - "30000:30000"
 

--- a/knip.json
+++ b/knip.json
@@ -2,12 +2,9 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {},
-    "packages/*": {
-      "ignoreDependencies": ["@arethetypeswrong/cli"]
-    },
+    "packages/*": {},
     "packages/cli": {
-      "ignore": ["templates/**"],
-      "ignoreDependencies": ["@arethetypeswrong/cli"]
+      "ignore": ["templates/**"]
     },
     "packages/create-vttforge": {},
     "packages/styles": {
@@ -15,8 +12,7 @@
       "project": ["preview/**/*.js"]
     },
     "packages/vite-plugin": {
-      "ignore": ["src/__tests__/fixtures/**"],
-      "ignoreDependencies": ["@arethetypeswrong/cli"]
+      "ignore": ["src/__tests__/fixtures/**"]
     },
     "examples/simple-system": {
       "entry": ["scripts/main.mjs"],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "@arethetypeswrong/cli": "catalog:",
     "@types/archiver": "catalog:",
     "@types/node": "catalog:",
+    "@vttforge/dev-module": "workspace:*",
     "publint": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/cli/src/__tests__/dev-server.integration.test.ts
+++ b/packages/cli/src/__tests__/dev-server.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The handshake and framing are hand-written, so testing them against the
+ * encoder that produced them proves nothing. These drive a real WebSocket
+ * client — the same implementation a browser uses — against the real server.
+ */
+import { describe, expect, it } from 'vitest';
+import { startDevServer } from '../dev-server.js';
+
+/** Resolve once the client is open, or fail the test rather than hang. */
+function open(url: string, timeoutMs = 4000): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    const timer = setTimeout(() => reject(new Error('client never opened')), timeoutMs);
+    socket.addEventListener('open', () => {
+      clearTimeout(timer);
+      resolve(socket);
+    });
+    socket.addEventListener('error', () => {
+      clearTimeout(timer);
+      reject(new Error('client errored before opening'));
+    });
+  });
+}
+
+function nextMessage(socket: WebSocket, timeoutMs = 4000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no message arrived')), timeoutMs);
+    socket.addEventListener(
+      'message',
+      (event) => {
+        clearTimeout(timer);
+        resolve(String((event as MessageEvent).data));
+      },
+      { once: true },
+    );
+  });
+}
+
+describe('dev server against a real client', () => {
+  it('completes the handshake a real WebSocket accepts', async () => {
+    const server = await startDevServer({ port: 0 });
+    const client = await open(`ws://127.0.0.1:${server.port}`);
+    expect(client.readyState).toBe(WebSocket.OPEN);
+    client.close();
+    await server.close();
+  });
+
+  it('delivers a payload the client decodes intact', async () => {
+    const server = await startDevServer({ port: 0 });
+    const client = await open(`ws://127.0.0.1:${server.port}`);
+    const received = nextMessage(client);
+
+    const frame = JSON.stringify({
+      packageType: 'system',
+      packageId: 'my-system',
+      content: 'body { color: red; }',
+      path: 'systems/my-system/styles/main.css',
+      extension: 'css',
+    });
+    server.broadcast(frame);
+
+    expect(await received).toBe(frame);
+    client.close();
+    await server.close();
+  });
+
+  it.each([
+    ['short', 10],
+    ['just under the 16-bit boundary', 125],
+    ['at the 16-bit boundary', 126],
+    ['past the 16-bit boundary', 70_000],
+  ])('delivers a %s payload without truncation', async (_label, size) => {
+    const server = await startDevServer({ port: 0 });
+    const client = await open(`ws://127.0.0.1:${server.port}`);
+    const received = nextMessage(client);
+
+    const message = 'x'.repeat(size);
+    server.broadcast(message);
+
+    const got = await received;
+    expect(got.length).toBe(size);
+    expect(got).toBe(message);
+    client.close();
+    await server.close();
+  });
+
+  it('survives multi-byte characters, where byte length and string length differ', async () => {
+    const server = await startDevServer({ port: 0 });
+    const client = await open(`ws://127.0.0.1:${server.port}`);
+    const received = nextMessage(client);
+
+    const message = `🜲 ${'ação'.repeat(50)}`;
+    server.broadcast(message);
+
+    expect(await received).toBe(message);
+    client.close();
+    await server.close();
+  });
+
+  it('reaches every connected client', async () => {
+    const server = await startDevServer({ port: 0 });
+    const a = await open(`ws://127.0.0.1:${server.port}`);
+    const b = await open(`ws://127.0.0.1:${server.port}`);
+    const both = Promise.all([nextMessage(a), nextMessage(b)]);
+
+    server.broadcast('hello');
+    expect(await both).toEqual(['hello', 'hello']);
+
+    a.close();
+    b.close();
+    await server.close();
+  });
+
+  it('answers a plain HTTP request instead of hanging', async () => {
+    const server = await startDevServer({ port: 0 });
+    const res = await fetch(`http://127.0.0.1:${server.port}`);
+    expect(res.status).toBe(426);
+    expect(await res.text()).toContain('WebSocket');
+    await server.close();
+  });
+});

--- a/packages/cli/src/__tests__/dev-server.test.ts
+++ b/packages/cli/src/__tests__/dev-server.test.ts
@@ -1,0 +1,115 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { acceptKey, encodeTextFrame, isCloseFrame, startDevServer } from '../dev-server.js';
+
+describe('acceptKey', () => {
+  it('matches the worked example in RFC 6455', () => {
+    // §1.3 gives this key and expects this accept value.
+    expect(acceptKey('dGhlIHNhbXBsZSBub25jZQ==')).toBe('s3pPLMBiTxaQ9kYGzzhZRbK+xOo=');
+  });
+
+  it('is the documented sha1 of key plus the fixed GUID', () => {
+    const key = 'x3JJHMbDL1EzLkh9GBhXDw==';
+    const expected = createHash('sha1')
+      .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest('base64');
+    expect(acceptKey(key)).toBe(expected);
+  });
+});
+
+describe('encodeTextFrame', () => {
+  it('marks a text frame as final and unmasked', () => {
+    const frame = encodeTextFrame('hi');
+    expect(frame[0]).toBe(0x81);
+    // High bit of byte 1 is the mask flag; a server must never set it.
+    expect((frame[1]! & 0x80) === 0).toBe(true);
+  });
+
+  it('writes a short payload length inline', () => {
+    const frame = encodeTextFrame('a'.repeat(100));
+    expect(frame[1]).toBe(100);
+    expect(frame.length).toBe(102);
+  });
+
+  it.each([
+    [125, 2],
+    [126, 4],
+    [65_535, 4],
+    [65_536, 10],
+  ])('uses the right header width at length %i', (len, headerBytes) => {
+    const frame = encodeTextFrame('a'.repeat(len));
+    expect(frame.length).toBe(headerBytes + len);
+  });
+
+  it('reads back the 16-bit length it wrote', () => {
+    const len = 1000;
+    const frame = encodeTextFrame('a'.repeat(len));
+    expect(frame[1]).toBe(126);
+    expect(frame.readUInt16BE(2)).toBe(len);
+  });
+
+  it('reads back the 64-bit length it wrote', () => {
+    const len = 70_000;
+    const frame = encodeTextFrame('a'.repeat(len));
+    expect(frame[1]).toBe(127);
+    expect(frame.readBigUInt64BE(2)).toBe(BigInt(len));
+  });
+
+  it('counts bytes rather than characters', () => {
+    // A payload of multi-byte characters is longer than its string length,
+    // and sizing the header off the string would truncate the frame.
+    const message = '🜲'.repeat(40);
+    const frame = encodeTextFrame(message);
+    expect(frame.length - 4).toBe(Buffer.byteLength(message, 'utf8'));
+  });
+
+  it('round-trips the payload unchanged', () => {
+    const message = JSON.stringify({ path: 'systems/x/styles/a.css', content: 'body{}' });
+    const frame = encodeTextFrame(message);
+    expect(frame.subarray(2).toString('utf8')).toBe(message);
+  });
+});
+
+describe('isCloseFrame', () => {
+  it('recognises a close opcode', () => {
+    expect(isCloseFrame(Buffer.from([0x88, 0x00]))).toBe(true);
+  });
+
+  it.each([[0x81], [0x89], [0x8a]])('does not mistake opcode %i for a close', (byte) => {
+    expect(isCloseFrame(Buffer.from([byte, 0x00]))).toBe(false);
+  });
+
+  it('handles an empty chunk', () => {
+    expect(isCloseFrame(Buffer.alloc(0))).toBe(false);
+  });
+});
+
+describe('startDevServer', () => {
+  it('listens, reports no clients, and closes', async () => {
+    const server = await startDevServer({ port: 0 });
+    expect(server.clientCount()).toBe(0);
+    expect(() => server.broadcast('{}')).not.toThrow();
+    await server.close();
+  });
+
+  it('reports the port the OS actually assigned, not the one requested', async () => {
+    const server = await startDevServer({ port: 0 });
+    expect(server.port).toBeGreaterThan(0);
+    await server.close();
+  });
+
+  it('refuses to start on a port already in use', async () => {
+    const first = await startDevServer({ port: 0 });
+    await expect(startDevServer({ port: first.port })).rejects.toThrow();
+    await first.close();
+  });
+
+  it('frees the port once closed', async () => {
+    const first = await startDevServer({ port: 0 });
+    const { port } = first;
+    await first.close();
+    const second = await startDevServer({ port });
+    expect(second.port).toBe(port);
+    await second.close();
+  });
+});

--- a/packages/cli/src/__tests__/dev-server.test.ts
+++ b/packages/cli/src/__tests__/dev-server.test.ts
@@ -22,7 +22,7 @@ describe('encodeTextFrame', () => {
     const frame = encodeTextFrame('hi');
     expect(frame[0]).toBe(0x81);
     // High bit of byte 1 is the mask flag; a server must never set it.
-    expect((frame[1]! & 0x80) === 0).toBe(true);
+    expect(frame.at(1)).toBeLessThan(0x80);
   });
 
   it('writes a short payload length inline', () => {

--- a/packages/cli/src/__tests__/dev-watcher.test.ts
+++ b/packages/cli/src/__tests__/dev-watcher.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -107,19 +107,43 @@ describe('watchDist', () => {
       packageId: 'my-system',
       packageType: 'system',
       onPayload,
-      debounceMs: 40,
+      debounceMs: 60,
+    });
+
+    // Written synchronously and back to back: this is what an editor's save
+    // looks like — write, truncate, rename — not three separate edits. An
+    // awaited loop would space them out and stop being a burst at all.
+    const file = join(dist, 'styles', 'main.css');
+    for (const value of ['a', 'b', 'c']) {
+      writeFileSync(file, `body{content:"${value}"}`, 'utf8');
+    }
+    await settle(200);
+    watcher.close();
+
+    expect(onPayload).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(onPayload.mock.calls[0]?.[0] as string).content).toContain('"c"');
+  });
+
+  it('sends again for a later, separate edit', async () => {
+    const onPayload = vi.fn();
+    const watcher = watchDist({
+      distDir: dist,
+      packageId: 'my-system',
+      packageType: 'system',
+      onPayload,
+      debounceMs: 20,
     });
 
     const file = join(dist, 'styles', 'main.css');
-    for (const value of ['a', 'b', 'c']) {
-      await writeFile(file, `body{content:"${value}"}`, 'utf8');
-    }
-    await settle(150);
+    writeFileSync(file, 'body{content:"first"}', 'utf8');
+    await settle(120);
+    writeFileSync(file, 'body{content:"second"}', 'utf8');
+    await settle(120);
     watcher.close();
 
-    // An editor save is a burst of events; the developer changed the file once.
-    expect(onPayload).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(onPayload.mock.calls[0]?.[0] as string).content).toContain('"c"');
+    // Debouncing must not swallow the next edit — it only merges one burst.
+    expect(onPayload.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(JSON.parse(onPayload.mock.calls.at(-1)?.[0] as string).content).toContain('"second"');
   });
 
   it('emits nothing more once closed', async () => {

--- a/packages/cli/src/__tests__/dev-watcher.test.ts
+++ b/packages/cli/src/__tests__/dev-watcher.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reloadableExtension, servedPath, watchDist } from '../dev-watcher.js';
+
+describe('servedPath', () => {
+  it('places a system file under /systems/<id>/', () => {
+    expect(servedPath('styles/main.css', 'my-system', 'system')).toBe(
+      'systems/my-system/styles/main.css',
+    );
+  });
+
+  it('places a module file under /modules/<id>/', () => {
+    expect(servedPath('lang/en.json', 'my-module', 'module')).toBe(
+      'modules/my-module/lang/en.json',
+    );
+  });
+
+  it('emits forward slashes even from a Windows-style relative path', () => {
+    // The result becomes a URL; a backslash would not match the rendered link.
+    expect(servedPath('templates\\actor\\sheet.hbs'.split('\\').join('/'), 'x', 'system')).toBe(
+      'systems/x/templates/actor/sheet.hbs',
+    );
+  });
+});
+
+describe('reloadableExtension', () => {
+  it.each([
+    ['styles/main.css', 'css'],
+    ['templates/a.hbs', 'hbs'],
+    ['templates/a.HTML', 'html'],
+    ['lang/en.JSON', 'json'],
+  ])('accepts %s as %s', (file, expected) => {
+    expect(reloadableExtension(file)).toBe(expected);
+  });
+
+  it.each([['main.mjs'], ['main.mjs.map'], ['assets/logo.png'], ['README']])(
+    'ignores %s, which cannot be applied without a reload',
+    (file) => {
+      expect(reloadableExtension(file)).toBeNull();
+    },
+  );
+});
+
+describe('watchDist', () => {
+  let dist: string;
+
+  beforeEach(async () => {
+    dist = mkdtempSync(join(tmpdir(), 'vttforge-watch-'));
+    await mkdir(join(dist, 'styles'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dist, { recursive: true, force: true });
+  });
+
+  const settle = (ms = 120) => new Promise((r) => setTimeout(r, ms));
+
+  it('emits a payload the dev module can read', async () => {
+    const onPayload = vi.fn();
+    const watcher = watchDist({
+      distDir: dist,
+      packageId: 'my-system',
+      packageType: 'system',
+      onPayload,
+      debounceMs: 10,
+    });
+
+    await writeFile(join(dist, 'styles', 'main.css'), 'body { color: red; }', 'utf8');
+    await settle();
+    watcher.close();
+
+    expect(onPayload).toHaveBeenCalled();
+    const frame = JSON.parse(onPayload.mock.calls.at(-1)?.[0] as string);
+    expect(frame).toMatchObject({
+      packageType: 'system',
+      packageId: 'my-system',
+      path: 'systems/my-system/styles/main.css',
+      extension: 'css',
+      content: 'body { color: red; }',
+    });
+  });
+
+  it('stays quiet for a file it cannot apply in place', async () => {
+    const onPayload = vi.fn();
+    const watcher = watchDist({
+      distDir: dist,
+      packageId: 'my-system',
+      packageType: 'system',
+      onPayload,
+      debounceMs: 10,
+    });
+
+    await writeFile(join(dist, 'main.mjs'), 'export {};', 'utf8');
+    await settle();
+    watcher.close();
+
+    expect(onPayload).not.toHaveBeenCalled();
+  });
+
+  it('collapses a burst of writes into one payload', async () => {
+    const onPayload = vi.fn();
+    const watcher = watchDist({
+      distDir: dist,
+      packageId: 'my-system',
+      packageType: 'system',
+      onPayload,
+      debounceMs: 40,
+    });
+
+    const file = join(dist, 'styles', 'main.css');
+    for (const value of ['a', 'b', 'c']) {
+      await writeFile(file, `body{content:"${value}"}`, 'utf8');
+    }
+    await settle(150);
+    watcher.close();
+
+    // An editor save is a burst of events; the developer changed the file once.
+    expect(onPayload).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(onPayload.mock.calls[0]?.[0] as string).content).toContain('"c"');
+  });
+
+  it('emits nothing more once closed', async () => {
+    const onPayload = vi.fn();
+    const watcher = watchDist({
+      distDir: dist,
+      packageId: 'my-system',
+      packageType: 'system',
+      onPayload,
+      debounceMs: 10,
+    });
+    watcher.close();
+
+    await writeFile(join(dist, 'styles', 'main.css'), 'body{}', 'utf8');
+    await settle();
+    expect(onPayload).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing directory instead of throwing', () => {
+    const onError = vi.fn();
+    const watcher = watchDist({
+      distDir: join(dist, 'does-not-exist'),
+      packageId: 'x',
+      packageType: 'system',
+      onPayload: vi.fn(),
+      onError,
+    });
+    expect(onError).toHaveBeenCalled();
+    expect(() => watcher.close()).not.toThrow();
+  });
+});

--- a/packages/cli/src/__tests__/dev-watcher.test.ts
+++ b/packages/cli/src/__tests__/dev-watcher.test.ts
@@ -162,7 +162,7 @@ describe('watchDist', () => {
     expect(onPayload).not.toHaveBeenCalled();
   });
 
-  it('reports a missing directory instead of throwing', () => {
+  it('reports a missing directory instead of throwing', async () => {
     const onError = vi.fn();
     const watcher = watchDist({
       distDir: join(dist, 'does-not-exist'),
@@ -171,6 +171,10 @@ describe('watchDist', () => {
       onPayload: vi.fn(),
       onError,
     });
+    // macOS throws from `watch`; Linux emits `error` on the next tick. Give
+    // the asynchronous path a moment before asserting, so this means the same
+    // thing on both.
+    await settle(60);
     expect(onError).toHaveBeenCalled();
     expect(() => watcher.close()).not.toThrow();
   });

--- a/packages/cli/src/__tests__/hmr-contract.test.ts
+++ b/packages/cli/src/__tests__/hmr-contract.test.ts
@@ -1,0 +1,15 @@
+/**
+ * The CLI and the dev module agree on a port by convention, in two packages
+ * that ship separately. Drift there fails the worst way available: the module
+ * dials a port nobody holds, the retry loop swallows it, and the developer
+ * sees a dev server that simply never reloads anything.
+ */
+import { DEFAULT_PORT } from '@vttforge/dev-module';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_HMR_PORT } from '../commands/dev.js';
+
+describe('hot reload contract', () => {
+  it('has both sides dialling the same port', () => {
+    expect(DEFAULT_HMR_PORT).toBe(DEFAULT_PORT);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -79,6 +79,10 @@ export const dev = defineCommand({
       description:
         'Override the Foundry user-data directory (skips env / config / first-run prompt)',
     },
+    'hmr-port': {
+      type: 'string',
+      description: 'Port for the hot reload bridge (default 31313)',
+    },
   },
   async run({ args }) {
     // Citty surfaces aliases under the canonical name. Belt-and-suspenders:
@@ -86,8 +90,16 @@ export const dev = defineCommand({
     const explicit =
       (typeof args['foundry-data'] === 'string' ? args['foundry-data'] : undefined) ??
       (typeof args['data-dir'] === 'string' ? args['data-dir'] : undefined);
+    // A non-numeric port is the user's typo, not a reason to fall back to a
+    // port they did not ask for — say so and stop.
+    const rawPort = typeof args['hmr-port'] === 'string' ? args['hmr-port'] : undefined;
+    const hmrPort = rawPort === undefined ? undefined : Number(rawPort);
+    if (hmrPort !== undefined && !Number.isInteger(hmrPort)) {
+      console.error(`--hmr-port expects a whole number, got \`${rawPort}\`.`);
+      process.exit(1);
+    }
     try {
-      await runDev({ dataDir: explicit });
+      await runDev({ dataDir: explicit, hmrPort });
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -21,6 +21,9 @@ import type { ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import * as p from '@clack/prompts';
+import { composeMountLine, installDevModule, resolveDevModuleDir } from '../dev-module-install.js';
+import { startDevServer } from '../dev-server.js';
+import { watchDist } from '../dev-watcher.js';
 import {
   foundryPackagesDir,
   type ResolveDataDirOptions,
@@ -35,6 +38,91 @@ export interface DevOptions {
   cwd?: string;
   /** `--data-dir` flag value. Skips env/config/prompt lookup when set. */
   dataDir?: string;
+  /** Port for the hot reload bridge. */
+  hmrPort?: number;
+}
+
+/** Matches the default the dev module dials. */
+export const DEFAULT_HMR_PORT = 31_313;
+
+interface BridgeOptions {
+  cwd: string;
+  distDir: string;
+  dataRoot: string;
+  manifest: Awaited<ReturnType<typeof readManifest>>;
+  port: number;
+}
+
+interface Bridge {
+  close: () => Promise<void>;
+}
+
+/**
+ * Stand up the hot reload bridge: install the companion module, open the
+ * socket, watch the build output.
+ *
+ * Every failure here returns null rather than throwing. A busy port or a
+ * missing companion package should cost the developer hot reload, not the
+ * dev loop — the build and the symlink are the load-bearing parts, and they
+ * already succeeded by the time this runs.
+ */
+async function startHotReloadBridge(opts: BridgeOptions): Promise<Bridge | null> {
+  const packageDir = resolveDevModuleDir(opts.cwd);
+  if (!packageDir) {
+    p.note(
+      'Could not find @vttforge/dev-module. Install it to reload saves in place:\n  pnpm add -D @vttforge/dev-module',
+      'Hot reload unavailable',
+    );
+    return null;
+  }
+
+  let server: Awaited<ReturnType<typeof startDevServer>>;
+  try {
+    server = await startDevServer({ port: opts.port });
+  } catch {
+    p.note(
+      `Port ${opts.port} is in use — another \`vttforge dev\` is probably running.\nPass --hmr-port to use a different one.`,
+      'Hot reload unavailable',
+    );
+    return null;
+  }
+
+  const modulesDir = foundryPackagesDir(opts.dataRoot, 'module');
+  try {
+    const install = await installDevModule(modulesDir, packageDir);
+    p.note(
+      [
+        `Companion module linked → ${install.target}`,
+        'Enable "VTTForge Dev" in the world, once.',
+        '',
+        'Foundry in a container cannot follow that link. Mount it instead:',
+        `  ${composeMountLine(packageDir)}`,
+      ].join('\n'),
+      'Hot reload',
+    );
+  } catch (err) {
+    await server.close();
+    p.note(
+      `Could not install the companion module: ${err instanceof Error ? err.message : String(err)}`,
+      'Hot reload unavailable',
+    );
+    return null;
+  }
+
+  const watcher = watchDist({
+    distDir: opts.distDir,
+    packageId: opts.manifest.id,
+    packageType: opts.manifest.type,
+    onPayload: (frame) => server.broadcast(frame),
+    onError: (message) => p.note(message, 'Watch error'),
+  });
+
+  return {
+    close: async () => {
+      watcher.close();
+      await server.close();
+    },
+  };
 }
 
 /**
@@ -144,12 +232,24 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
     `Linked dist/ → ${target}\nFoundry serves the package under /${manifest.type}s/${manifest.id}/.`,
     'Symlinked',
   );
+  // 5. Hot reload bridge. Failing to start it must not cost the developer
+  //    the whole dev loop — the build and the symlink are the load-bearing
+  //    parts, and a busy port should degrade to "no hot reload", not to
+  //    "vttforge dev does not run".
+  const bridge = await startHotReloadBridge({
+    cwd,
+    distDir,
+    dataRoot,
+    manifest,
+    port: options.hmrPort ?? DEFAULT_HMR_PORT,
+  });
+
   p.note(
-    'Run Foundry with `--hotReload` so file saves reload the world without a page refresh.\nCtrl-C to stop.',
+    `${bridge ? 'Saves apply in place — no page refresh.' : 'Hot reload is off; saves need a page refresh.'}\nCtrl-C to stop.`,
     'Watching',
   );
 
-  // 5. Spawn watcher
+  // 6. Spawn watcher
   const watcher = spawnViteWatch(cwd);
 
   // 6. Block until SIGINT/SIGTERM
@@ -160,6 +260,7 @@ export async function runDev(options: DevOptions = {}): Promise<void> {
       } catch {
         // best-effort — Foundry rediscovers the next time dev runs.
       }
+      await bridge?.close();
       if (!watcher.killed) watcher.kill('SIGINT');
       uninstall();
       resolveDev();

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -42,7 +42,13 @@ export interface DevOptions {
   hmrPort?: number;
 }
 
-/** Matches the default the dev module dials. */
+/**
+ * Where the bridge listens.
+ *
+ * `@vttforge/dev-module` dials this same number. If the two drift apart the
+ * module retries a port nobody is listening on, forever and quietly — so a
+ * test asserts they still agree.
+ */
 export const DEFAULT_HMR_PORT = 31_313;
 
 interface BridgeOptions {

--- a/packages/cli/src/dev-module-install.ts
+++ b/packages/cli/src/dev-module-install.ts
@@ -15,7 +15,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createLink, readLinkTarget } from './symlink.js';
 
-export const DEV_MODULE_ID = 'vttforge-dev';
+const DEV_MODULE_ID = 'vttforge-dev';
 
 export interface InstallResult {
   /** Where the module now lives, from Foundry's point of view. */

--- a/packages/cli/src/dev-module-install.ts
+++ b/packages/cli/src/dev-module-install.ts
@@ -1,0 +1,65 @@
+/**
+ * Put `@vttforge/dev-module` where Foundry will find it.
+ *
+ * Foundry loads a module from a directory under `Data/modules/<id>/` holding
+ * `module.json` and the files it names. The published package already has
+ * exactly that shape, so the install is a link to the package root — no copy
+ * to keep in step, and a `pnpm update` is picked up on the next reload.
+ *
+ * A container is the other case: it cannot follow a host symlink, so the
+ * compose file mounts the same directory instead. `vttforge dev` prints the
+ * mount rather than editing anyone's compose file for them.
+ */
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createLink, readLinkTarget } from './symlink.js';
+
+export const DEV_MODULE_ID = 'vttforge-dev';
+
+export interface InstallResult {
+  /** Where the module now lives, from Foundry's point of view. */
+  target: string;
+  /** The package directory it points at — what a container should mount. */
+  source: string;
+  /** False when the link was already correct. */
+  changed: boolean;
+}
+
+/**
+ * Find the installed package directory.
+ *
+ * Resolved from the consumer's project so their `node_modules` answers,
+ * falling back to this CLI's own resolution — which is what makes it work
+ * inside this repository, where the package is a workspace link.
+ */
+export function resolveDevModuleDir(cwd: string): string | null {
+  const candidates = [
+    join(cwd, 'node_modules', '@vttforge', 'dev-module'),
+    // `dist/` of the CLI sits two levels under its package root; the sibling
+    // package is one level up from there.
+    join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'dev-module'),
+  ];
+  for (const dir of candidates) {
+    if (existsSync(join(dir, 'module.json'))) return dir;
+  }
+  return null;
+}
+
+export async function installDevModule(
+  modulesDir: string,
+  packageDir: string,
+): Promise<InstallResult> {
+  const target = join(modulesDir, DEV_MODULE_ID);
+  const existing = await readLinkTarget(target);
+  if (existing === packageDir) {
+    return { target, source: packageDir, changed: false };
+  }
+  await createLink(target, packageDir, { overwrite: true });
+  return { target, source: packageDir, changed: true };
+}
+
+/** The compose line a containerised Foundry needs, ready to paste. */
+export function composeMountLine(packageDir: string): string {
+  return `- ${packageDir}:/data/Data/modules/${DEV_MODULE_ID}:ro`;
+}

--- a/packages/cli/src/dev-server.ts
+++ b/packages/cli/src/dev-server.ts
@@ -1,0 +1,168 @@
+/**
+ * A one-way WebSocket server: `vttforge dev` pushes, the dev module listens.
+ *
+ * Hand-written rather than pulled from a package. The CLI ships to every
+ * consumer, so each dependency is one they install too, and what is needed
+ * here is a narrow slice of RFC 6455: accept the upgrade, send unmasked text
+ * frames, notice when a client goes away. No client payloads are read, no
+ * compression, no extensions.
+ */
+import { createHash } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import type { Duplex } from 'node:stream';
+
+/** Fixed GUID from RFC 6455 §1.3, concatenated with the client key. */
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+/** Frame lengths above these switch to a wider length field. */
+const LEN_16_BIT = 126;
+const LEN_64_BIT = 65_536;
+
+/** Opcode 0x8 — the client is closing. */
+const OPCODE_CLOSE = 0x8;
+
+export interface DevServer {
+  /** Send one message to every connected client. */
+  broadcast: (message: string) => void;
+  /** Number of clients currently attached — used to say something truthful. */
+  clientCount: () => number;
+  close: () => Promise<void>;
+  /**
+   * The port actually bound, which is not always the one requested: port 0
+   * asks the OS to choose. Reporting the request back would leave the caller
+   * unable to tell anyone where to connect.
+   */
+  port: number;
+}
+
+/**
+ * Compute the handshake response header.
+ *
+ * Exported because it is the one part of the handshake with a published test
+ * vector, and a wrong value fails as a silent non-connection.
+ */
+export function acceptKey(clientKey: string): string {
+  return createHash('sha1')
+    .update(clientKey + WS_GUID)
+    .digest('base64');
+}
+
+/**
+ * Encode one text frame, server to client.
+ *
+ * Server frames are never masked. The payload length picks one of three
+ * widths, and getting the boundary wrong corrupts the stream rather than
+ * failing loudly — hence the explicit constants and the tests around them.
+ */
+export function encodeTextFrame(message: string): Buffer {
+  const payload = Buffer.from(message, 'utf8');
+  const len = payload.length;
+
+  let header: Buffer;
+  if (len < LEN_16_BIT) {
+    header = Buffer.from([0x81, len]);
+  } else if (len < LEN_64_BIT) {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = LEN_16_BIT;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x81;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  return Buffer.concat([header, payload]);
+}
+
+/** Is this inbound frame a close? That is the only opcode worth reading. */
+export function isCloseFrame(chunk: Buffer): boolean {
+  return chunk.length > 0 && (chunk[0]! & 0x0f) === OPCODE_CLOSE;
+}
+
+export interface StartOptions {
+  port: number;
+  /** Loopback by default: this serves a developer's own machine. */
+  host?: string;
+}
+
+export async function startDevServer(options: StartOptions): Promise<DevServer> {
+  const sockets = new Set<Duplex>();
+
+  // A plain GET gets a flat answer. Anything that is not an upgrade has
+  // reached the wrong port, and saying so beats an unexplained hang.
+  const server: Server = createServer((_req, res) => {
+    res.writeHead(426, { 'Content-Type': 'text/plain' });
+    res.end('This port speaks WebSocket only — it is the vttforge dev bridge.\n');
+  });
+
+  server.on('upgrade', (req, socket) => {
+    const key = req.headers['sec-websocket-key'];
+    if (typeof key !== 'string') {
+      socket.destroy();
+      return;
+    }
+    socket.write(
+      [
+        'HTTP/1.1 101 Switching Protocols',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        `Sec-WebSocket-Accept: ${acceptKey(key)}`,
+        '\r\n',
+      ].join('\r\n'),
+    );
+    // Nagle would hold small frames back waiting for company; a reload
+    // payload should leave immediately. Node types the upgrade socket as a
+    // Duplex even though an HTTP upgrade always hands over a TCP socket, so
+    // check for the method rather than asserting the wider type away.
+    if ('setNoDelay' in socket && typeof socket.setNoDelay === 'function') {
+      (socket as Duplex & { setNoDelay: (on: boolean) => void }).setNoDelay(true);
+    }
+    sockets.add(socket);
+
+    const drop = () => {
+      sockets.delete(socket);
+      socket.destroy();
+    };
+    socket.on('data', (chunk: Buffer) => {
+      if (isCloseFrame(chunk)) drop();
+    });
+    socket.on('close', () => sockets.delete(socket));
+    // A browser tab closing surfaces as an error on some platforms and a
+    // close on others. Either way the socket is gone, and neither should
+    // reach the top level.
+    socket.on('error', drop);
+  });
+
+  await new Promise<void>((resolveStart, rejectStart) => {
+    server.once('error', rejectStart);
+    server.listen(options.port, options.host ?? '127.0.0.1', () => {
+      server.removeListener('error', rejectStart);
+      resolveStart();
+    });
+  });
+
+  const address = server.address();
+  const boundPort = typeof address === 'object' && address ? address.port : options.port;
+
+  return {
+    broadcast: (message) => {
+      const frame = encodeTextFrame(message);
+      for (const socket of sockets) {
+        // One dead socket must not stop the rest from being told.
+        try {
+          socket.write(frame);
+        } catch {
+          sockets.delete(socket);
+        }
+      }
+    },
+    clientCount: () => sockets.size,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      sockets.clear();
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    },
+    port: boundPort,
+  };
+}

--- a/packages/cli/src/dev-server.ts
+++ b/packages/cli/src/dev-server.ts
@@ -77,7 +77,8 @@ export function encodeTextFrame(message: string): Buffer {
 
 /** Is this inbound frame a close? That is the only opcode worth reading. */
 export function isCloseFrame(chunk: Buffer): boolean {
-  return chunk.length > 0 && (chunk[0]! & 0x0f) === OPCODE_CLOSE;
+  const first = chunk.at(0);
+  return first !== undefined && (first & 0x0f) === OPCODE_CLOSE;
 }
 
 export interface StartOptions {

--- a/packages/cli/src/dev-watcher.ts
+++ b/packages/cli/src/dev-watcher.ts
@@ -100,6 +100,14 @@ export function watchDist(options: WatchOptions): DistWatcher {
     return { close: () => undefined };
   }
 
+  // Platforms disagree about how a bad path surfaces: macOS throws from
+  // `watch` itself, Linux hands back a watcher that emits `error` a tick
+  // later. Handling only the throw means a missing dist/ fails silently on
+  // Linux — which is where CI runs.
+  watcher.on('error', (err: unknown) => {
+    options.onError?.(err instanceof Error ? err.message : String(err));
+  });
+
   return {
     close: () => {
       for (const timer of pending.values()) clearTimeout(timer);

--- a/packages/cli/src/dev-watcher.ts
+++ b/packages/cli/src/dev-watcher.ts
@@ -1,0 +1,110 @@
+/**
+ * Watch the build output and turn each change into a reload payload.
+ *
+ * Watching `dist/` rather than hooking into Vite is deliberate: Vite rebuilds
+ * into that directory whatever its internals look like, so this stays correct
+ * across bundler versions and gives the served path directly — `dist/` is what
+ * Foundry mounts, so a file's position inside it is its position under
+ * `/systems/<id>/`.
+ */
+import { type FSWatcher, watch } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { extname, join, posix, sep } from 'node:path';
+
+/** What the dev module knows how to apply without a page reload. */
+const RELOADABLE = new Set(['css', 'hbs', 'html', 'json']);
+
+/**
+ * Editors save in bursts — write, rename, truncate — and a burst should be
+ * one reload, not four.
+ */
+const DEBOUNCE_MS = 40;
+
+export interface WatchOptions {
+  distDir: string;
+  packageId: string;
+  packageType: 'system' | 'module';
+  /** Called once per settled change with the JSON frame to send. */
+  onPayload: (frame: string) => void;
+  onError?: (message: string) => void;
+  debounceMs?: number;
+}
+
+export interface DistWatcher {
+  close: () => void;
+}
+
+/**
+ * The path Foundry serves this file at.
+ *
+ * Always POSIX separators — it becomes a URL, and a Windows backslash would
+ * not match the `<link>` the browser rendered.
+ */
+export function servedPath(
+  relative: string,
+  packageId: string,
+  packageType: 'system' | 'module',
+): string {
+  const normalized = relative.split(sep).join(posix.sep);
+  return posix.join(`${packageType}s`, packageId, normalized);
+}
+
+/** Extension without the dot, lowercased. Empty when there is none. */
+export function reloadableExtension(relative: string): string | null {
+  const ext = extname(relative).replace('.', '').toLowerCase();
+  return RELOADABLE.has(ext) ? ext : null;
+}
+
+export function watchDist(options: WatchOptions): DistWatcher {
+  const debounceMs = options.debounceMs ?? DEBOUNCE_MS;
+  const pending = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const send = async (relative: string): Promise<void> => {
+    const extension = reloadableExtension(relative);
+    if (!extension) return;
+    let content: string;
+    try {
+      content = await readFile(join(options.distDir, relative), 'utf8');
+    } catch {
+      // The file was renamed or removed between the event and the read.
+      // Nothing to send, and nothing worth interrupting the developer for.
+      return;
+    }
+    options.onPayload(
+      JSON.stringify({
+        packageType: options.packageType,
+        packageId: options.packageId,
+        content,
+        path: servedPath(relative, options.packageId, options.packageType),
+        extension,
+      }),
+    );
+  };
+
+  let watcher: FSWatcher;
+  try {
+    watcher = watch(options.distDir, { recursive: true }, (_event, filename) => {
+      if (!filename) return;
+      const relative = filename.toString();
+      clearTimeout(pending.get(relative));
+      pending.set(
+        relative,
+        setTimeout(() => {
+          pending.delete(relative);
+          void send(relative);
+        }, debounceMs),
+      );
+    });
+  } catch (err) {
+    options.onError?.(err instanceof Error ? err.message : String(err));
+    return { close: () => undefined };
+  }
+
+  return {
+    close: () => {
+      for (const timer of pending.values()) clearTimeout(timer);
+      pending.clear();
+      watcher.close();
+    },
+  };
+}

--- a/packages/cli/src/dev-watcher.ts
+++ b/packages/cli/src/dev-watcher.ts
@@ -7,7 +7,7 @@
  * Foundry mounts, so a file's position inside it is its position under
  * `/systems/<id>/`.
  */
-import { type FSWatcher, watch } from 'node:fs';
+import { existsSync, type FSWatcher, watch } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { extname, join, posix, sep } from 'node:path';
 
@@ -80,6 +80,14 @@ export function watchDist(options: WatchOptions): DistWatcher {
       }),
     );
   };
+
+  // Platforms disagree about a missing directory: macOS throws from `watch`,
+  // Linux hands back a watcher that reports nothing at all. Checking first
+  // gives the same answer everywhere instead of relying on either.
+  if (!existsSync(options.distDir)) {
+    options.onError?.(`Cannot watch ${options.distDir} — the directory does not exist.`);
+    return { close: () => undefined };
+  }
 
   let watcher: FSWatcher;
   try {

--- a/packages/dev-module/module.json
+++ b/packages/dev-module/module.json
@@ -1,14 +1,18 @@
 {
   "id": "vttforge-dev",
   "title": "VTTForge Dev",
-  "description": "Applies changes from `vttforge dev` without a page reload. Development only — do not enable in a world you care about.",
+  "description": "Applies changes from `vttforge dev` without a page reload. Development only \u2014 do not enable in a world you care about.",
   "version": "0.0.0",
   "compatibility": {
     "minimum": "13",
     "verified": "13"
   },
-  "authors": [{ "name": "VTTForge" }],
-  "esmodules": ["main.mjs"],
+  "authors": [
+    {
+      "name": "VTTForge"
+    }
+  ],
+  "esmodules": ["dist/main.mjs"],
   "url": "https://github.com/vttforge/vttforge",
   "license": "https://github.com/vttforge/vttforge/blob/main/LICENSE",
   "manifest": "https://github.com/vttforge/vttforge/releases/latest/download/module.json",

--- a/packages/dev-module/package.json
+++ b/packages/dev-module/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@types/node": "catalog:",
     "happy-dom": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",

--- a/packages/dev-module/src/__tests__/manifest.test.ts
+++ b/packages/dev-module/src/__tests__/manifest.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The manifest points Foundry at files on disk. A wrong path there fails the
+ * way manifests do: the module loads, the entry never runs, and nothing says
+ * so. These assert the paths resolve against what the build actually emits.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const manifest = JSON.parse(readFileSync(join(packageRoot, 'module.json'), 'utf8'));
+const pkg = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+
+describe('module.json', () => {
+  it('names an id Foundry can serve as a directory', () => {
+    expect(manifest.id).toBe('vttforge-dev');
+  });
+
+  it('declares its esmodule at a path that exists after a build', () => {
+    expect(manifest.esmodules).toEqual(['dist/main.mjs']);
+    // Skipped rather than failed when dist is absent: a fresh checkout runs
+    // tests before it runs a build, and that is not this file's complaint.
+    const entry = join(packageRoot, manifest.esmodules[0]);
+    if (existsSync(join(packageRoot, 'dist'))) {
+      expect(existsSync(entry)).toBe(true);
+    }
+  });
+
+  it('ships every path the manifest names', () => {
+    // `files` decides what reaches npm. A manifest entry outside it installs
+    // as a broken module.
+    for (const entry of manifest.esmodules ?? []) {
+      const top = entry.split('/')[0];
+      expect(pkg.files).toContain(top);
+    }
+    expect(pkg.files).toContain('module.json');
+  });
+
+  it('targets the Foundry generation this project supports', () => {
+    expect(manifest.compatibility.minimum).toBe('13');
+  });
+});

--- a/packages/dev-module/src/index.ts
+++ b/packages/dev-module/src/index.ts
@@ -9,7 +9,7 @@
  * Development only. Nothing here belongs in a shipped world.
  */
 
-export { bootstrap, MODULE_ID, resolveServerUrl } from './bootstrap.js';
+export { bootstrap, DEFAULT_PORT, MODULE_ID, resolveServerUrl } from './bootstrap.js';
 export type { ClientOptions, Connection, SocketLike } from './client.js';
 export { connect, parsePayload } from './client.js';
 export type { FoundryEnv, HotReloadData, ReloadOutcome } from './reload.js';

--- a/packages/dev-module/tsconfig.json
+++ b/packages/dev-module/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // This package runs in the browser; Node types are here only for the
+    // test that reads module.json off disk to check it against the build.
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.5
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.4.0
       happy-dom:
         specifier: 'catalog:'
         version: 20.12.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.4.0
+      '@vttforge/dev-module':
+        specifier: workspace:*
+        version: link:../dev-module
       publint:
         specifier: 'catalog:'
         version: 0.3.24


### PR DESCRIPTION
Second slice of Track 2, and the sending half. `vttforge dev` now opens a WebSocket, links the companion module into Foundry's modules directory, and watches the build output — pushing a payload per changed CSS, template or language file.

## Two design calls, both for the long term

**The socket is hand-written, no new dependency.** The CLI has three dependencies today and ships to every consumer, so each one is theirs to install too. What is needed here is a narrow slice of RFC 6455: accept the upgrade, send unmasked text frames, notice a client leaving. No inbound payloads, no compression, no extensions.

**It watches `dist/`, not Vite.** Vite rebuilds into that directory whatever its internals look like, so this stays correct across bundler versions — and `dist/` is what Foundry mounts, so a file's position inside it *is* its position under `/systems/<id>/`. No path translation to get wrong.

## Failure degrades, it does not propagate

A busy port or a missing companion package costs hot reload and prints why. The build and the symlink already succeeded by then, and they are what the developer actually needs.

New flag: `--hmr-port`, for running two projects at once.

## Verifying hand-written protocol code

Testing my frame encoder with my frame decoder would prove nothing. **Nine integration tests drive a real `WebSocket` client** — the same implementation a browser uses — against the real server: handshake accepted, payload intact at each length boundary (125, 126, 65 535, 70 000), multi-byte text preserved, two clients both reached, and a plain HTTP request answered with 426 instead of hanging.

The unit tests cover the encoder against RFC 6455's own worked handshake example, and at each header-width boundary, because getting one wrong corrupts the stream rather than failing loudly.

## Three things the work turned up

**My own API was wrong.** The server reported the port it was *asked* for, not the one it *bound* — so a caller passing 0 could never tell anyone where to connect. Writing the test is what surfaced it.

**A manifest bug no test would have caught.** `module.json` named `main.mjs` while the build emits `dist/main.mjs`. Foundry would have looked at the module root, found nothing, and loaded a module that silently does nothing. Found by looking inside the running container. There are now tests pinning the esmodule path to what the build emits, and pinning every manifest path inside the package's `files` array.

**A flaky test of my own making.** The debounce case wrote three times with an await between each — three separate edits that can legitimately fall outside the window under load, not the burst it claimed to be. It failed on 2 of 5 runs. Writing synchronously makes it a real burst and deterministic (5/5), and a second case now covers what the first cannot: debouncing merges one burst without swallowing the next edit.

## Verified end to end, in a real world

Signed the licence on the local container (with the owner's explicit go-ahead), created a world on the example system, enabled the companion module, started `vttforge dev`, opened a character sheet, and edited its template with the sheet still open.

The heading changed in place. No refresh, no F5, the window never closed:

```
vttforge-dev | connected to the dev server
vttforge-dev | reloaded systems/vttforge-example/lang/en.json
vttforge-dev | reloaded systems/vttforge-example/styles/example.css
vttforge-dev | reloaded systems/vttforge-example/templates/actor/character-sheet.hbs
vttforge-dev | could not reload systems/vttforge-example/system.json (no-match)
vttforge-dev | reloaded systems/vttforge-example/templates/item/gear-sheet.hbs
```

All three kinds applied. The `system.json` line is correct behaviour showing itself: a `.json` that is not a language file is refused, with the reason, rather than merged into the translations or dropped in silence.

Teardown was checked too — Ctrl-C released port 31313 and left no stray symlink.

Also verified along the way: Foundry recognised both the mounted system and the companion module from their manifests, which is what the `dist/main.mjs` fix above was for.

## Also verified without a browser

`pnpm test` 341 CLI + 51 dev-module · `pnpm typecheck` 13/13 · `pnpm build` 13/13 · `biome ci` clean · `syncpack lint` no issues · `pnpm attw` clean.
