### PR TITLE
fix(cli): point the templates at the CLI version this release publishes

### DIFF
--- a/.changeset/template-pin-cli.md
+++ b/.changeset/template-pin-cli.md
@@ -1,0 +1,10 @@
+---
+'@vttforge/cli': patch
+---
+
+Point the templates at the CLI version this release publishes.
+
+The templates asked for `@vttforge/cli@^0.2.0` while the release takes it to
+0.3.0. A caret pins the minor on a 0.x version, so that range would not have
+matched — every project scaffolded after the release would ask for a version
+the release had just superseded.

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -14,7 +14,7 @@
     "@vttforge/core": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.2.0",
+    "@vttforge/cli": "^0.3.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -15,7 +15,7 @@
     "@vttforge/core": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.2.0",
+    "@vttforge/cli": "^0.3.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -15,7 +15,7 @@
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.2.0",
+    "@vttforge/cli": "^0.3.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -16,7 +16,7 @@
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.2.0",
+    "@vttforge/cli": "^0.3.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"


### PR DESCRIPTION
Blocks #75.

The templates pin `@vttforge/cli@^0.2.0` while the pending release takes the CLI to 0.3.0. A caret pins the **minor** on a 0.x version, so `^0.2.0` means `>=0.2.0 <0.3.0` — it would not match, and every project scaffolded after the release would ask for a version the release had just superseded.

Verified by running the version step and comparing both sides:

| Package | After release | Template pin |
| --- | --- | --- |
| `@vttforge/cli` | 0.3.0 | `^0.3.0` (this PR) |
| `@vttforge/core` | 0.5.0 | `^0.5.0` already matched |
| `@vttforge/vite-plugin` | 0.3.0 | `^0.3.0` already matched |
| `@vttforge/styles` | 0.3.0 | `^0.3.0` already matched |

The changeset is a `patch`, absorbed by the `minor` already queued for the CLI, so it still lands on the 0.3.0 the templates now name.

**This is the third time.** Same cause each time: no CI job builds a scaffolded project, so the mismatch is invisible until after publish. Worth a check that walks the templates against the versions a release would produce — filing that separately rather than widening this.