### PR TITLE
feat(dev-module): redraw only the sheets a template change affects

### DIFF
--- a/.changeset/scoped-rerender.md
+++ b/.changeset/scoped-rerender.md
@@ -1,0 +1,22 @@
+---
+'@vttforge/dev-module': minor
+'@vttforge/cli': minor
+---
+
+Redraw only the sheets a template change actually affects.
+
+A sheet declares its templates in `static PARTS`, so the mapping is on the
+open window itself — no build-time graph needed. Each part names a primary
+`template` and may list further `templates`, which is where a partial it
+pulls in appears. Only the affected parts re-render, so scroll position and
+focus survive everywhere else. When nothing claims the file the whole screen
+still redraws, because a partial can be reached without any part naming it.
+
+The watcher now also skips a file whose content did not change. Vite rewrites
+its entire output on every build, so a filesystem event alone means "the
+bundler ran", not "the developer edited this" — and without this the language
+file gets resent untouched on every save, and the JSON path redraws every open
+window, undoing the scoping on the file that did change.
+
+Measured in a running world with 21 applications open: editing one sheet
+template went from 35 renders to 1.

--- a/packages/cli/src/__tests__/dev-watcher.test.ts
+++ b/packages/cli/src/__tests__/dev-watcher.test.ts
@@ -146,6 +146,52 @@ describe('watchDist', () => {
     expect(JSON.parse(onPayload.mock.calls.at(-1)?.[0] as string).content).toContain('"second"');
   });
 
+  it('stays quiet when a rebuild rewrites a file without changing it', async () => {
+    // Vite rewrites its whole output every build. Without this, one edited
+    // template would also resend the language file, and the JSON path
+    // redraws every open window — undoing the scoped re-render entirely.
+    const file = join(dist, 'styles', 'main.css');
+    writeFileSync(file, 'body{color:red}', 'utf8');
+
+    const onPayload = vi.fn();
+    const watcher = watchDist({
+      distDir: dist,
+      packageId: 'my-system',
+      packageType: 'system',
+      onPayload,
+      debounceMs: 20,
+    });
+    await settle(80);
+
+    writeFileSync(file, 'body{color:red}', 'utf8');
+    await settle(120);
+    watcher.close();
+
+    expect(onPayload).not.toHaveBeenCalled();
+  });
+
+  it('still sends when the content really changed', async () => {
+    const file = join(dist, 'styles', 'main.css');
+    writeFileSync(file, 'body{color:red}', 'utf8');
+
+    const onPayload = vi.fn();
+    const watcher = watchDist({
+      distDir: dist,
+      packageId: 'my-system',
+      packageType: 'system',
+      onPayload,
+      debounceMs: 20,
+    });
+    await settle(80);
+
+    writeFileSync(file, 'body{color:blue}', 'utf8');
+    await settle(120);
+    watcher.close();
+
+    expect(onPayload).toHaveBeenCalled();
+    expect(JSON.parse(onPayload.mock.calls.at(-1)?.[0] as string).content).toContain('blue');
+  });
+
   it('emits nothing more once closed', async () => {
     const onPayload = vi.fn();
     const watcher = watchDist({

--- a/packages/cli/src/dev-watcher.ts
+++ b/packages/cli/src/dev-watcher.ts
@@ -7,7 +7,8 @@
  * Foundry mounts, so a file's position inside it is its position under
  * `/systems/<id>/`.
  */
-import { existsSync, type FSWatcher, watch } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, type FSWatcher, readdirSync, readFileSync, watch } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { extname, join, posix, sep } from 'node:path';
 
@@ -55,9 +56,59 @@ export function reloadableExtension(relative: string): string | null {
   return RELOADABLE.has(ext) ? ext : null;
 }
 
+const digest = (content: string): string => createHash('sha1').update(content).digest('hex');
+
+/**
+ * Record what every reloadable file already contains.
+ *
+ * Vite rewrites its whole output on each build, so without a baseline the
+ * first rebuild after startup looks like every file changed at once.
+ *
+ * Read synchronously and before the watcher exists, on purpose. Doing it
+ * asynchronously races the very first change: the walk can pick up a file
+ * written a moment ago and then the change event finds a matching hash and
+ * drops a real edit. The output tree is small; correctness is worth the wait.
+ */
+function seedDigests(distDir: string): Map<string, string> {
+  const seen = new Map<string, string>();
+  const walk = (dir: string, prefix: string): void => {
+    let items: Array<{ name: string; isDirectory: () => boolean }>;
+    try {
+      items = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const item of items) {
+      const rel = prefix ? `${prefix}/${item.name}` : item.name;
+      if (item.isDirectory()) {
+        walk(join(dir, item.name), rel);
+        continue;
+      }
+      if (!reloadableExtension(rel)) continue;
+      try {
+        seen.set(rel, digest(readFileSync(join(distDir, rel), 'utf8')));
+      } catch {
+        // Unreadable now; the first change will record it.
+      }
+    }
+  };
+  walk(distDir, '');
+  return seen;
+}
+
 export function watchDist(options: WatchOptions): DistWatcher {
   const debounceMs = options.debounceMs ?? DEBOUNCE_MS;
   const pending = new Map<string, ReturnType<typeof setTimeout>>();
+  /**
+   * Last content seen per file.
+   *
+   * A rebuild rewrites every output file, changed or not, so the filesystem
+   * event alone says "the bundler ran", not "the developer edited this".
+   * Comparing content is what makes a reload mean the second thing — and it
+   * matters: a language file rewritten untouched would redraw every open
+   * window, undoing the scoped re-render on the file that did change.
+   */
+  const digests = seedDigests(options.distDir);
 
   const send = async (relative: string): Promise<void> => {
     const extension = reloadableExtension(relative);
@@ -70,6 +121,11 @@ export function watchDist(options: WatchOptions): DistWatcher {
       // Nothing to send, and nothing worth interrupting the developer for.
       return;
     }
+
+    const hash = digest(content);
+    if (digests.get(relative) === hash) return;
+    digests.set(relative, hash);
+
     options.onPayload(
       JSON.stringify({
         packageType: options.packageType,

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -14,7 +14,7 @@
     "@vttforge/core": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.3.0",
+    "@vttforge/cli": "^0.4.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -15,7 +15,7 @@
     "@vttforge/core": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.3.0",
+    "@vttforge/cli": "^0.4.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -15,7 +15,7 @@
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.3.0",
+    "@vttforge/cli": "^0.4.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -16,7 +16,7 @@
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.3.0",
+    "@vttforge/cli": "^0.4.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/dev-module/src/__tests__/reload.test.ts
+++ b/packages/dev-module/src/__tests__/reload.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { applyHotReload, type FoundryEnv, type HotReloadData } from '../reload.js';
+import { type AppV2Like, applyHotReload, type FoundryEnv, type HotReloadData } from '../reload.js';
 
 const NOW = 1_700_000_000_000;
 
 function makeEnv(overrides: Partial<FoundryEnv> = {}): FoundryEnv {
-  const rendered: Array<{ render: () => void }> = [];
+  const rendered: AppV2Like[] = [];
   return {
     Handlebars: {
       compile: vi.fn((input: string) => ({ compiled: input })),
@@ -223,5 +223,124 @@ describe('language files', () => {
 
     expect(applyHotReload(data, env)).toEqual({ applied: false, reason: 'parse-error' });
     expect(env.mergeObject).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Scoped re-render. A template change should redraw the sheets that use it
+ * and leave the rest alone — redrawing everything loses scroll position and
+ * focus in windows the edit never touched.
+ */
+describe('scoped re-render', () => {
+  const CHANGED = 'systems/my-system/templates/actor/character-sheet.hbs';
+
+  /** An open AppV2 whose class declares `parts`. */
+  function sheet(parts: Record<string, { template?: string; templates?: string[] }>) {
+    const render = vi.fn();
+    return { app: { render, constructor: { PARTS: parts } }, render };
+  }
+
+  it('renders only the sheet that declares the template', () => {
+    const match = sheet({ body: { template: CHANGED } });
+    const other = sheet({ body: { template: 'systems/my-system/templates/item/gear.hbs' } });
+    const env = makeEnv({ applicationInstances: () => [match.app, other.app] });
+
+    const result = applyHotReload(
+      payload({ extension: 'hbs', content: '<p></p>', path: CHANGED }),
+      env,
+    );
+
+    expect(result).toEqual({ applied: true, kind: 'html', scoped: 1 });
+    expect(match.render).toHaveBeenCalledOnce();
+    expect(other.render).not.toHaveBeenCalled();
+  });
+
+  it('renders only the affected part, not the whole sheet', () => {
+    const match = sheet({
+      header: { template: 'systems/my-system/templates/actor/header.hbs' },
+      body: { template: CHANGED },
+    });
+    const env = makeEnv({ applicationInstances: () => [match.app] });
+
+    applyHotReload(payload({ extension: 'hbs', content: '<p></p>', path: CHANGED }), env);
+
+    // Redrawing the header too would throw away its scroll and focus.
+    expect(match.render).toHaveBeenCalledWith({ parts: ['body'] });
+  });
+
+  it('matches a template listed under a part’s `templates`, where partials appear', () => {
+    const match = sheet({ body: { template: 'other.hbs', templates: [CHANGED] } });
+    const env = makeEnv({ applicationInstances: () => [match.app] });
+
+    const result = applyHotReload(
+      payload({ extension: 'hbs', content: '<p></p>', path: CHANGED }),
+      env,
+    );
+
+    expect(result).toMatchObject({ scoped: 1 });
+    expect(match.render).toHaveBeenCalledWith({ parts: ['body'] });
+  });
+
+  it('renders every sheet that uses the template, not just the first', () => {
+    const a = sheet({ body: { template: CHANGED } });
+    const b = sheet({ main: { template: CHANGED } });
+    const env = makeEnv({ applicationInstances: () => [a.app, b.app] });
+
+    const result = applyHotReload(
+      payload({ extension: 'hbs', content: '<p></p>', path: CHANGED }),
+      env,
+    );
+
+    expect(result).toMatchObject({ scoped: 2 });
+    expect(a.render).toHaveBeenCalledOnce();
+    expect(b.render).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to redrawing everything when nothing claims the file', () => {
+    // A partial reached through `{{> x}}` appears in no part descriptor.
+    // Leaving the screen stale would be worse than redrawing too much.
+    const unrelated = sheet({ body: { template: 'systems/my-system/templates/item/gear.hbs' } });
+    const v1 = { render: vi.fn() };
+    const env = makeEnv({
+      ui: { windows: { 1: v1 } },
+      applicationInstances: () => [unrelated.app],
+    });
+
+    const result = applyHotReload(
+      payload({
+        extension: 'hbs',
+        content: '<p></p>',
+        path: 'systems/my-system/templates/_partial.hbs',
+      }),
+      env,
+    );
+
+    expect(result).toEqual({ applied: true, kind: 'html' });
+    expect(unrelated.render).toHaveBeenCalledOnce();
+    expect(v1.render).toHaveBeenCalledOnce();
+  });
+
+  it('matches an older application on its options.template', () => {
+    const v1 = { render: vi.fn(), options: { template: CHANGED } };
+    const env = makeEnv({ ui: { windows: { 1: v1 } }, applicationInstances: () => [] });
+
+    const result = applyHotReload(
+      payload({ extension: 'hbs', content: '<p></p>', path: CHANGED }),
+      env,
+    );
+
+    expect(result).toMatchObject({ scoped: 1 });
+    expect(v1.render).toHaveBeenCalledWith(true);
+  });
+
+  it('survives a sheet class with no PARTS at all', () => {
+    const bare = { render: vi.fn() };
+    const env = makeEnv({ applicationInstances: () => [bare] });
+
+    expect(() =>
+      applyHotReload(payload({ extension: 'hbs', content: '<p></p>', path: CHANGED }), env),
+    ).not.toThrow();
+    // Nothing claimed it, so the fallback redraws — including this one.
+    expect(bare.render).toHaveBeenCalled();
   });
 });

--- a/packages/dev-module/src/bootstrap.ts
+++ b/packages/dev-module/src/bootstrap.ts
@@ -5,7 +5,7 @@
  * reach, what counts as a usable global — can be tested without a browser.
  */
 import { type Connection, connect, type SocketLike } from './client.js';
-import type { FoundryEnv } from './reload.js';
+import type { AppV2Like, FoundryEnv } from './reload.js';
 
 export const MODULE_ID = 'vttforge-dev';
 
@@ -69,7 +69,8 @@ export function buildEnv(deps: BootstrapDeps): FoundryEnv | null {
     Handlebars,
     game,
     ui: g.ui as FoundryEnv['ui'],
-    applicationInstances: () => foundry?.applications?.instances?.values() ?? [],
+    applicationInstances: (): Iterable<AppV2Like> =>
+      foundry?.applications?.instances?.values() ?? [],
     mergeObject,
     callHook: (name, data) => Hooks.call(name, data),
     document: doc,

--- a/packages/dev-module/src/reload.ts
+++ b/packages/dev-module/src/reload.ts
@@ -26,7 +26,12 @@ export interface HotReloadData {
 
 /** What a reload attempt did, so callers can log something truthful. */
 export type ReloadOutcome =
-  | { applied: true; kind: 'css' | 'html' | 'json' }
+  | {
+      applied: true;
+      kind: 'css' | 'html' | 'json';
+      /** How many applications were targeted, when the change could be attributed. */
+      scoped?: number;
+    }
   | { applied: false; reason: 'vetoed' | 'unsupported-extension' | 'no-match' | 'parse-error' };
 
 /**
@@ -87,6 +92,14 @@ function reloadHtml(data: HotReloadData, env: FoundryEnv): ReloadOutcome {
     return { applied: false, reason: 'parse-error' };
   }
   env.Handlebars.registerPartial(data.path, template);
+
+  const targets = findRenderTargets(data.path, env);
+  if (targets.length > 0) {
+    for (const target of targets) target.render();
+    return { applied: true, kind: 'html', scoped: targets.length };
+  }
+  // Nothing claimed the file. It may be a partial nobody declares, so redraw
+  // everything rather than leave a stale sheet on screen.
   renderOpenApplications(env);
   return { applied: true, kind: 'html' };
 }
@@ -115,6 +128,69 @@ function reloadJson(data: HotReloadData, env: FoundryEnv): ReloadOutcome {
   return { applied: true, kind: 'json' };
 }
 
+/**
+ * One open window of either generation. Only the shape this module reads.
+ */
+export interface AppV1Like {
+  render: (force?: boolean) => void;
+  options?: { template?: string };
+}
+
+export interface AppV2Like {
+  render: (options?: { parts?: string[] }) => void;
+}
+
+/** One entry of a sheet's `static PARTS`, as far as this module reads it. */
+interface PartDescriptor {
+  template?: string;
+  templates?: string[];
+}
+
+/** An open application and, when known, the parts the change touched. */
+interface RenderTarget {
+  render: () => void;
+}
+
+/**
+ * Find the applications a changed template actually feeds.
+ *
+ * A sheet declares its templates in `static PARTS`, so the mapping is right
+ * there on the open window — no build-time graph needed. Each part names a
+ * primary `template` and may list further `templates`, which is where a
+ * partial it pulls in shows up.
+ *
+ * Returns an empty array when nothing claims the file. That is not a failure:
+ * a template can be reached through `{{> partial}}` without any part naming
+ * it, and the caller falls back to re-rendering everything rather than
+ * quietly updating nothing.
+ */
+export function findRenderTargets(path: string, env: FoundryEnv): RenderTarget[] {
+  const targets: RenderTarget[] = [];
+
+  for (const app of Object.values(env.ui?.windows ?? {})) {
+    if (app.options?.template === path) targets.push({ render: () => app.render(true) });
+  }
+
+  for (const app of env.applicationInstances()) {
+    // PARTS is a static on the sheet class and may be absent — it is probed,
+    // not required, so it stays out of the interface above, which describes
+    // only what this module calls.
+    const parts =
+      (app as { constructor?: { PARTS?: Record<string, PartDescriptor> } }).constructor?.PARTS ??
+      {};
+    const affected = Object.entries(parts)
+      .filter(([, part]) => part?.template === path || part?.templates?.includes(path))
+      .map(([id]) => id);
+    if (affected.length > 0) {
+      // Re-render only the parts that changed. Redrawing the whole sheet
+      // would throw away scroll position and focus in every other part.
+      targets.push({ render: () => app.render({ parts: affected }) });
+    }
+  }
+
+  return targets;
+}
+
 /** Re-render every open window, both application generations. */
 function renderOpenApplications(env: FoundryEnv): void {
   for (const app of Object.values(env.ui?.windows ?? {})) app.render();
@@ -140,8 +216,8 @@ export interface FoundryEnv {
       get: (id: string) => { languages?: Array<{ path: string; lang: string }> } | undefined;
     };
   };
-  ui?: { windows?: Record<string, { render: () => void }> };
-  applicationInstances: () => Iterable<{ render: () => void }>;
+  ui?: { windows?: Record<string, AppV1Like> };
+  applicationInstances: () => Iterable<AppV2Like>;
   mergeObject: (target: object, source: object) => object;
   /** Fires the veto hook; a `false` return cancels the reload. */
   callHook: (name: string, data: HotReloadData) => boolean;

--- a/packages/dev-module/src/reload.ts
+++ b/packages/dev-module/src/reload.ts
@@ -131,7 +131,7 @@ function reloadJson(data: HotReloadData, env: FoundryEnv): ReloadOutcome {
 /**
  * One open window of either generation. Only the shape this module reads.
  */
-export interface AppV1Like {
+interface AppV1Like {
   render: (force?: boolean) => void;
   options?: { template?: string };
 }
@@ -164,7 +164,7 @@ interface RenderTarget {
  * it, and the caller falls back to re-rendering everything rather than
  * quietly updating nothing.
  */
-export function findRenderTargets(path: string, env: FoundryEnv): RenderTarget[] {
+function findRenderTargets(path: string, env: FoundryEnv): RenderTarget[] {
   const targets: RenderTarget[] = [];
 
   for (const app of Object.values(env.ui?.windows ?? {})) {


### PR DESCRIPTION
Closes the deferred slice of Foundry-aware hot reload: a template change now redraws the sheets that use it and leaves the other windows alone.

## The mapping needed no build graph

The plan called for the Vite module graph. It is not necessary — a sheet declares its templates in `static PARTS`, so the mapping sits on the open window:

```js
static PARTS = { sheet: { template: 'systems/my-system/templates/actor/character-sheet.hbs' } }
```

Each part names a primary `template` and may list further `templates`, which is where a partial it pulls in appears. Only the matching parts re-render (`app.render({ parts })`), so scroll position and focus survive in every other part of the same sheet.

When nothing claims the file, the whole screen still redraws. A partial reached through `{{> x}}` appears in no part descriptor, and a stale sheet is worse than redrawing too much.

## Scoping alone did nothing, and only the real world showed why

First measurement in a running world with 21 applications open: **35 renders**. Everything still redrew.

Vite rewrites its *entire* output on every build. Editing one template also resent the language file, the stylesheet and the other sheet — and the JSON path redraws every open window, undoing the scoping on the file that had actually changed:

```
reloaded .../lang/en.json                          ← untouched, but rewritten
reloaded .../styles/example.css                    ← untouched, but rewritten
reloaded .../templates/actor/character-sheet.hbs   ← the actual edit
reloaded .../templates/item/gear-sheet.hbs         ← untouched, but rewritten
```

So the watcher now compares content and skips a file rewritten unchanged. That is what makes a reload mean *the developer edited this* rather than *the bundler ran*.

## Measured, not asserted

Same world, same 21 applications, same edit, after the fix:

```
totalRenders: 1
quais: { CharacterSheet: 1 }
```

**35 renders → 1.** The console shows only `character-sheet.hbs` being sent; the untouched files are no longer broadcast.

## A race the tests caught

Seeding the content hashes was asynchronous at first. That races the very first change: the walk can pick up a file written a moment earlier, and the change event then finds a matching hash and drops a real edit. Three existing tests failed on it, consistently. Seeding is now synchronous and happens before the watcher exists — the output tree is small and correctness is worth the wait.

## Tests

`@vttforge/dev-module` 58 (up from 51), covering: only the declaring sheet renders, only the affected part renders, a template matched through a part's `templates` list, several sheets sharing one template, the fallback when nothing claims the file, an older application matched on `options.template`, and a sheet class with no PARTS at all.

`@vttforge/cli` gains two: a rewritten-but-unchanged file stays quiet, and a genuinely changed one still sends.

`pnpm typecheck` 14/14 · `pnpm test` 14/14 · `pnpm build` 14/14 · `biome ci` clean · `syncpack lint` no issues · `knip` clean · template pins OK.
