### PR TITLE
fix(core): correct what InferSchema says a ColorField and an absent field hold

### DIFF
--- a/.changeset/color-and-presence.md
+++ b/.changeset/color-and-presence.md
@@ -1,0 +1,24 @@
+---
+'@vttforge/core': minor
+---
+
+Fix two things `InferSchema` got wrong about a field's runtime type.
+
+`ColorField` inferred as `string`. It stores a CSS string but initializes
+into a `Color` instance, so `system.tint` is an object with `.css`, `.rgb`
+and friends — and the old typing made every property access on it a lie the
+compiler accepted. It is also nullable by default, unlike the other
+string-backed fields: the field's own defaults are `nullable: true,
+initial: null`, so reading `.css` off a fresh document was a real crash the
+types allowed. It now infers as `Color | null`, and drops the null when
+`nullable: false` is set.
+
+Presence was half-implemented. Only `nullable: true` widened the type;
+`required: false` did not. A field that resolves to `undefined` when absent
+was typed as always present. The rule now follows how a field actually
+resolves a missing value: an explicit `initial` always fills, so it never
+widens; otherwise `required: false` admits `undefined` and `nullable: true`
+admits `null`, and the two compose.
+
+`Color` is described structurally rather than imported, so the inference
+surface still carries no dependency on a Foundry type package.

--- a/.changeset/template-pin-core-06.md
+++ b/.changeset/template-pin-core-06.md
@@ -1,0 +1,9 @@
+---
+'@vttforge/cli': patch
+---
+
+Point the templates at the core version this release publishes.
+
+The `ColorField` and presence fixes take `@vttforge/core` to 0.6.0, and a
+caret pins the minor on a 0.x version, so the templates' `^0.5.0` would not
+have matched.

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.5.0"
+    "@vttforge/core": "^0.6.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.4.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.5.0"
+    "@vttforge/core": "^0.6.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.4.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.5.0",
+    "@vttforge/core": "^0.6.0",
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.5.0",
+    "@vttforge/core": "^0.6.0",
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/infer-schema.test.ts
+++ b/packages/core/src/__tests__/infer-schema.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
+import type { Color } from '../data/color.js';
 import {
   type ArrayFieldInstance,
   type BooleanFieldInstance,
@@ -84,8 +85,18 @@ describe('InferField<F> — scalar fields', () => {
     expectTypeOf<InferField<HTMLFieldInstance>>().toEqualTypeOf<string>();
   });
 
-  it('ColorField → string', () => {
-    expectTypeOf<InferField<ColorFieldInstance>>().toEqualTypeOf<string>();
+  it('ColorField → Color | null, because it is neither a string nor non-null by default', () => {
+    // The field stores a CSS string but initializes into a Color instance,
+    // and its own defaults are `nullable: true, initial: null` — so reading
+    // `.css` off a fresh document is a real crash the old `string` typing
+    // let through.
+    expectTypeOf<InferField<ColorFieldInstance>>().toEqualTypeOf<Color | null>();
+  });
+
+  it('ColorField drops the null once nullable is turned off', () => {
+    expectTypeOf<
+      InferField<ColorFieldInstance<{ required: true; nullable: false }>>
+    >().toEqualTypeOf<Color>();
   });
 
   it('FilePathField → string', () => {
@@ -173,5 +184,61 @@ describe('InferSchema<S>', () => {
       name: StringFieldInstance;
     }>;
     expectTypeOf<T>().toEqualTypeOf<{ hp: number | null; name: string }>();
+  });
+});
+
+/**
+ * How a field's options widen its type.
+ *
+ * Taken from how a field resolves a missing value: an explicit `initial`
+ * always wins; otherwise a non-required field resolves to `undefined`, and a
+ * required nullable one to `null`. Validation then admits `null` only when
+ * nullable and `undefined` only when not required. So the two widenings are
+ * independent and compose.
+ */
+describe('presence and nullability', () => {
+  it('required and non-nullable is just the type', () => {
+    expectTypeOf<
+      InferField<NumberFieldInstance<{ required: true; nullable: false }>>
+    >().toEqualTypeOf<number>();
+  });
+
+  it('nullable admits null', () => {
+    expectTypeOf<
+      InferField<NumberFieldInstance<{ required: true; nullable: true }>>
+    >().toEqualTypeOf<number | null>();
+  });
+
+  it('not required, with no initial, admits undefined', () => {
+    expectTypeOf<InferField<NumberFieldInstance<{ required: false }>>>().toEqualTypeOf<
+      number | undefined
+    >();
+  });
+
+  it('an explicit initial keeps undefined out, even when not required', () => {
+    // The field always resolves to the initial, so the value is never absent.
+    expectTypeOf<
+      InferField<NumberFieldInstance<{ required: false; initial: 0 }>>
+    >().toEqualTypeOf<number>();
+  });
+
+  it('neither required nor non-nullable admits both', () => {
+    expectTypeOf<
+      InferField<NumberFieldInstance<{ required: false; nullable: true }>>
+    >().toEqualTypeOf<number | null | undefined>();
+  });
+
+  it('applies the same rule through a SchemaField', () => {
+    type Nested = InferField<
+      SchemaFieldInstance<{ hp: NumberFieldInstance<{ required: false }> }, { nullable: true }>
+    >;
+    expectTypeOf<Nested>().toEqualTypeOf<{ hp: number | undefined } | null>();
+  });
+
+  it('applies it to an array’s element type as well as the array', () => {
+    type Tags = InferField<
+      ArrayFieldInstance<StringFieldInstance<{ required: false }>, { required: true }>
+    >;
+    expectTypeOf<Tags>().toEqualTypeOf<(string | undefined)[]>();
   });
 });

--- a/packages/core/src/data/color.ts
+++ b/packages/core/src/data/color.ts
@@ -1,0 +1,34 @@
+/**
+ * The shape a `ColorField` hands back.
+ *
+ * Foundry initializes the field into one of its own `Color` instances — a
+ * boxed 24-bit integer with derived accessors — rather than the CSS string it
+ * stores. Described structurally here rather than imported, because the
+ * inference surface deliberately does not depend on the Foundry type package.
+ *
+ * Members mirror the documented public accessors. `toString(radix)` is
+ * included because a colour is routinely interpolated straight into markup.
+ */
+export interface Color {
+  /** False when the underlying value is not a valid colour. */
+  readonly valid: boolean;
+  /** CSS hexadecimal string, e.g. `#ff0000`. */
+  readonly css: string;
+  /** Normalized `[r, g, b]`, each 0–1. */
+  readonly rgb: [number, number, number];
+  readonly r: number;
+  readonly g: number;
+  readonly b: number;
+  /** The largest of the three channels. */
+  readonly maximum: number;
+  /** The smallest of the three channels. */
+  readonly minimum: number;
+  /** Byte order flipped, for APIs that want BGR. */
+  readonly littleEndian: number;
+  readonly hsv: [number, number, number];
+  readonly hsl: [number, number, number];
+  /** The colour in linear space, for shader work. */
+  readonly linear: Color;
+  toString: (radix?: number) => string;
+  valueOf: () => number;
+}

--- a/packages/core/src/data/infer-schema.ts
+++ b/packages/core/src/data/infer-schema.ts
@@ -13,6 +13,7 @@
  * still need real-world validation against shipped systems.
  */
 
+import type { Color } from './color.js';
 import type {
   ArrayFieldInstance,
   BooleanFieldInstance,
@@ -32,7 +33,48 @@ import type {
  */
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
-type ApplyNullability<O, T> = O extends { nullable: true } ? T | null : T;
+/**
+ * Whether a field's options gave an explicit `initial`.
+ *
+ * A field with an initial is always populated, so it never widens to
+ * `undefined` no matter what `required` says. Presence of the key is the
+ * question, not its value — `{ initial: undefined }` is not an initial.
+ */
+type HasInitial<O> = O extends { initial: unknown } ? true : false;
+
+/**
+ * Widen a field's base type by what its options allow it to be.
+ *
+ * Two independent widenings, derived from how a field resolves a value:
+ *
+ * - `nullable: true` admits `null`, and a required nullable field with no
+ *   initial resolves to `null`.
+ * - `required: false` with no explicit initial resolves to `undefined`.
+ *
+ * They compose: a field that is neither required nor nullable, with no
+ * initial, is `T | undefined`; add `nullable` and it is `T | null | undefined`.
+ */
+type ApplyPresence<O, T> =
+  | T
+  | (O extends { nullable: true } ? null : never)
+  | (O extends { required: false } ? (HasInitial<O> extends true ? never : undefined) : never);
+
+/**
+ * What a `ColorField` holds once the model is initialized.
+ *
+ * Not a string. The field casts its stored value to a CSS string, but
+ * `initialize` hands back a `Color` instance — so `system.tint` is an object
+ * with `.css`, `.rgb`, `.hex` and friends, and typing it as `string` makes
+ * every property access on it a lie the compiler accepts.
+ *
+ * It is also nullable by default, unlike every other string-backed field:
+ * the field's own defaults set `nullable: true, initial: null`. Writing
+ * `new fields.ColorField()` and reading `.css` off it crashes on a fresh
+ * document, which is exactly what this type now refuses.
+ */
+type ColorFieldValue<O> = O extends { nullable: false }
+  ? ApplyPresence<O, Color>
+  : ApplyPresence<O, Color> | null;
 
 /**
  * Map a single field instance to its runtime TypeScript type. `never` for
@@ -41,21 +83,21 @@ type ApplyNullability<O, T> = O extends { nullable: true } ? T | null : T;
  */
 export type InferField<F> =
   F extends NumberFieldInstance<infer O>
-    ? ApplyNullability<O, number>
+    ? ApplyPresence<O, number>
     : F extends StringFieldInstance<infer O>
-      ? ApplyNullability<O, string>
+      ? ApplyPresence<O, string>
       : F extends BooleanFieldInstance<infer O>
-        ? ApplyNullability<O, boolean>
+        ? ApplyPresence<O, boolean>
         : F extends HTMLFieldInstance<infer O>
-          ? ApplyNullability<O, string>
+          ? ApplyPresence<O, string>
           : F extends ColorFieldInstance<infer O>
-            ? ApplyNullability<O, string>
+            ? ColorFieldValue<O>
             : F extends FilePathFieldInstance<infer O>
-              ? ApplyNullability<O, string>
+              ? ApplyPresence<O, string>
               : F extends ArrayFieldInstance<infer Inner, infer O>
-                ? ApplyNullability<O, InferField<Inner>[]>
+                ? ApplyPresence<O, InferField<Inner>[]>
                 : F extends SchemaFieldInstance<infer S, infer O>
-                  ? ApplyNullability<O, InferSchema<S>>
+                  ? ApplyPresence<O, InferSchema<S>>
                   : never;
 
 /**


### PR DESCRIPTION
First slice of Track 4. Two things `InferSchema` said about a field's runtime value were wrong — both confirmed against the field implementations rather than inferred from option names.

## `ColorField` is not a string, and is nullable by default

It **stores** a CSS string but **initializes** into a `Color` instance, so `system.tint` is an object with `.css`, `.rgb`, `.hex` and friends. Typing it as `string` made every property access on it a lie the compiler accepted.

It is also the one string-backed field that is nullable out of the box — its own defaults are `nullable: true, initial: null`. So:

```ts
tint: new fields.ColorField()
// old: string        → `system.tint.css` compiles, crashes on a fresh document
// new: Color | null  → the compiler makes you handle the null
```

Setting `nullable: false` drops the null, as it should.

`Color` is described structurally in `data/color.ts` rather than imported, so the inference surface still carries no dependency on a Foundry type package.

## Presence was half-implemented

Only `nullable: true` widened the type. `required: false` did nothing — a field that resolves to `undefined` when absent was typed as always present.

The rule now mirrors how a field actually resolves a missing value: an explicit `initial` always fills and never widens; otherwise `required: false` admits `undefined` and `nullable: true` admits `null`. The two are independent and compose:

| options | inferred |
| --- | --- |
| `{ required: true, nullable: false }` | `T` |
| `{ required: true, nullable: true }` | `T \| null` |
| `{ required: false }` | `T \| undefined` |
| `{ required: false, initial: 0 }` | `T` — the initial always fills |
| `{ required: false, nullable: true }` | `T \| null \| undefined` |

## Tests

The existing `ColorField → string` test asserted the wrong answer; it now asserts the right one, and a second case covers `nullable: false`. Seven more cover the presence matrix, including through a `SchemaField` and an `ArrayField`'s element type — an array of optional strings is `(string | undefined)[]`, not `string[]`.

`@vttforge/core` goes from 103 to 110 tests.

## Not in this PR

The rest of Track 4 — class-level inference, `$inferData`, `EmbeddedDataField` / `EmbeddedDocumentField` / `TypedSchemaField`, `SetField` as a `Set`, `ForeignDocumentField` as the getter it actually is, and re-enabling `checkJs` on the example. This one is scoped to correcting what already ships.

`pnpm typecheck` 14/14 · `pnpm test` 14/14 · `pnpm build` 10/10 · `biome ci` clean · `syncpack lint` no issues · `knip` clean · template pins OK.

(The template pin bump to `@vttforge/core@^0.6.0` rides along — the pin guard caught it before commit this time, which is what it is for.)
