### PR TITLE
fix(core): infer each field against its own defaults

### DIFF
--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -1,0 +1,15 @@
+---
+'@vttforge/core': minor
+---
+
+Give each field its own defaults when inferring a schema.
+
+Every field class picks its own defaults, and they disagree. The inference treated them as if they agreed, so three fields were typed as shapes they cannot hold:
+
+- `NumberField` is optional and nullable out of the box. `new fields.NumberField()` is `number | null | undefined`, not `number`.
+- `StringField` is optional. A bare one is `string | undefined`.
+- `FilePathField` starts at `null`, the way `ColorField` does. A bare one is `string | null`.
+
+The rest were already right, for reasons worth naming: booleans and HTML fields are required and supply their own initial; arrays, sets and schemas are required and build their own empty value; document references are required but nullable.
+
+This will surface errors in schemas that leave the options off. The fix is to declare what you meant — `{ required: true, nullable: false, initial: 0 }` — which is what the field needed all along.

--- a/packages/core/src/__tests__/infer-schema.test.ts
+++ b/packages/core/src/__tests__/infer-schema.test.ts
@@ -32,6 +32,17 @@ declare class FakeActor {
   readonly name: string;
 }
 
+/**
+ * A document class shaped more like a real one: a constructor that takes
+ * arguments, and an overload. The `DocumentClass` bound has to accept these
+ * or it only works against the synthetic case above.
+ */
+declare class FakeItem {
+  constructor(data: { name: string }, context?: { parent?: FakeActor });
+  readonly name: string;
+  readonly parent: FakeActor | null;
+}
+
 beforeEach(() => {
   (globalThis as Record<string, unknown>).foundry = {
     data: {
@@ -81,20 +92,30 @@ describe('fields()', () => {
   });
 });
 
-describe('InferField<F> — scalar fields', () => {
-  it('NumberField → number', () => {
-    expectTypeOf<InferField<NumberFieldInstance>>().toEqualTypeOf<number>();
+describe('InferField<F> — scalar fields, with nothing declared', () => {
+  // Each field class picks its own defaults, and they disagree. These cases
+  // pin what an author gets from `new fields.X()` with no options — the
+  // shape that used to be typed as the bare scalar across the board.
+
+  it('NumberField is optional and nullable, so it is neither', () => {
+    expectTypeOf<InferField<NumberFieldInstance>>().toEqualTypeOf<number | null | undefined>();
   });
 
-  it('StringField → string', () => {
-    expectTypeOf<InferField<StringFieldInstance>>().toEqualTypeOf<string>();
+  it('NumberField becomes a plain number once the schema says so', () => {
+    expectTypeOf<
+      InferField<NumberFieldInstance<{ required: true; nullable: false; initial: 0 }>>
+    >().toEqualTypeOf<number>();
   });
 
-  it('BooleanField → boolean', () => {
+  it('StringField is optional, but not nullable', () => {
+    expectTypeOf<InferField<StringFieldInstance>>().toEqualTypeOf<string | undefined>();
+  });
+
+  it('BooleanField is required and starts at false', () => {
     expectTypeOf<InferField<BooleanFieldInstance>>().toEqualTypeOf<boolean>();
   });
 
-  it('HTMLField → string', () => {
+  it('HTMLField is required and blank-friendly, so it is always a string', () => {
     expectTypeOf<InferField<HTMLFieldInstance>>().toEqualTypeOf<string>();
   });
 
@@ -112,74 +133,81 @@ describe('InferField<F> — scalar fields', () => {
     >().toEqualTypeOf<Color>();
   });
 
-  it('FilePathField → string', () => {
-    expectTypeOf<InferField<FilePathFieldInstance>>().toEqualTypeOf<string>();
+  it('FilePathField starts at null, like ColorField', () => {
+    expectTypeOf<InferField<FilePathFieldInstance>>().toEqualTypeOf<string | null>();
+  });
+
+  it('FilePathField drops the null once nullable is turned off', () => {
+    expectTypeOf<InferField<FilePathFieldInstance<{ nullable: false }>>>().toEqualTypeOf<string>();
   });
 });
 
 describe('InferField<F> — composite fields', () => {
-  it('ArrayField of NumberField → number[]', () => {
+  it('ArrayField is required and builds its own empty array', () => {
+    // The container is never absent. Its elements still carry whatever the
+    // element field's own defaults allow.
     type T = InferField<ArrayFieldInstance<NumberFieldInstance>>;
-    expectTypeOf<T>().toEqualTypeOf<number[]>();
+    expectTypeOf<T>().toEqualTypeOf<(number | null | undefined)[]>();
   });
 
-  it('ArrayField of StringField → string[]', () => {
-    type T = InferField<ArrayFieldInstance<StringFieldInstance>>;
+  it('ArrayField of a declared StringField → string[]', () => {
+    type T = InferField<ArrayFieldInstance<StringFieldInstance<{ required: true }>>>;
     expectTypeOf<T>().toEqualTypeOf<string[]>();
   });
 
   it('SchemaField → recursive object', () => {
     type T = InferField<
       SchemaFieldInstance<{
-        value: NumberFieldInstance;
-        max: NumberFieldInstance;
+        value: NumberFieldInstance<{ required: true; nullable: false; initial: 0 }>;
+        max: NumberFieldInstance<{ required: true; nullable: false; initial: 0 }>;
       }>
     >;
     expectTypeOf<T>().toEqualTypeOf<{ value: number; max: number }>();
   });
 
   it('SchemaField nested inside ArrayField → object[]', () => {
-    type T = InferField<ArrayFieldInstance<SchemaFieldInstance<{ name: StringFieldInstance }>>>;
+    type T = InferField<
+      ArrayFieldInstance<SchemaFieldInstance<{ name: StringFieldInstance<{ required: true }> }>>
+    >;
     expectTypeOf<T>().toEqualTypeOf<{ name: string }[]>();
   });
 });
 
-describe('InferField<F> — nullability (v0.1 single rule)', () => {
-  it('nullable: true → T | null', () => {
-    type T = InferField<NumberFieldInstance<{ nullable: true }>>;
+describe('InferField<F> — what the schema declares beats the default', () => {
+  it('nullable: true admits null', () => {
+    type T = InferField<NumberFieldInstance<{ required: true; nullable: true }>>;
     expectTypeOf<T>().toEqualTypeOf<number | null>();
   });
 
-  it('nullable: false (default) → T', () => {
-    type T = InferField<NumberFieldInstance<{ nullable: false }>>;
+  it('nullable: false takes it away, even from a field that defaults to nullable', () => {
+    type T = InferField<NumberFieldInstance<{ required: true; nullable: false }>>;
     expectTypeOf<T>().toEqualTypeOf<number>();
   });
 
-  it('no nullable option → T', () => {
-    type T = InferField<StringFieldInstance>;
-    expectTypeOf<T>().toEqualTypeOf<string>();
+  it('required: false takes it away from a field that defaults to required', () => {
+    type T = InferField<BooleanFieldInstance<{ required: false }>>;
+    // The initial is the field's own, not the schema's, so it still applies.
+    expectTypeOf<T>().toEqualTypeOf<boolean>();
   });
 });
 
 describe('InferSchema<S>', () => {
   it('flat schema of three scalar fields', () => {
     type T = InferSchema<{
-      level: NumberFieldInstance;
-      name: StringFieldInstance;
+      level: NumberFieldInstance<{ required: true; nullable: false; initial: 1 }>;
+      name: StringFieldInstance<{ required: true }>;
       active: BooleanFieldInstance;
     }>;
     expectTypeOf<T>().toEqualTypeOf<{ level: number; name: string; active: boolean }>();
   });
 
   it('character-shaped schema with nested SchemaField and ArrayField', () => {
+    type Score = NumberFieldInstance<{ required: true; nullable: false; initial: 0 }>;
     type T = InferSchema<{
-      level: NumberFieldInstance;
-      health: SchemaFieldInstance<{
-        value: NumberFieldInstance;
-        max: NumberFieldInstance;
-      }>;
+      level: NumberFieldInstance<{ required: true; nullable: false; initial: 1 }>;
+      health: SchemaFieldInstance<{ value: Score; max: Score }>;
       biography: HTMLFieldInstance;
-      nicknames: ArrayFieldInstance<StringFieldInstance>;
+      nicknames: ArrayFieldInstance<StringFieldInstance<{ required: true }>>;
       portrait: FilePathFieldInstance;
     }>;
     expectTypeOf<T>().toEqualTypeOf<{
@@ -187,14 +215,14 @@ describe('InferSchema<S>', () => {
       health: { value: number; max: number };
       biography: string;
       nicknames: string[];
-      portrait: string;
+      portrait: string | null;
     }>();
   });
 
   it('propagates nullability through the schema', () => {
     type T = InferSchema<{
-      hp: NumberFieldInstance<{ nullable: true }>;
-      name: StringFieldInstance;
+      hp: NumberFieldInstance<{ required: true; nullable: true }>;
+      name: StringFieldInstance<{ required: true }>;
     }>;
     expectTypeOf<T>().toEqualTypeOf<{ hp: number | null; name: string }>();
   });
@@ -223,15 +251,15 @@ describe('presence and nullability', () => {
   });
 
   it('not required, with no initial, admits undefined', () => {
-    expectTypeOf<InferField<NumberFieldInstance<{ required: false }>>>().toEqualTypeOf<
-      number | undefined
-    >();
+    expectTypeOf<
+      InferField<NumberFieldInstance<{ required: false; nullable: false }>>
+    >().toEqualTypeOf<number | undefined>();
   });
 
   it('an explicit initial keeps undefined out, even when not required', () => {
     // The field always resolves to the initial, so the value is never absent.
     expectTypeOf<
-      InferField<NumberFieldInstance<{ required: false; initial: 0 }>>
+      InferField<NumberFieldInstance<{ required: false; nullable: false; initial: 0 }>>
     >().toEqualTypeOf<number>();
   });
 
@@ -243,7 +271,10 @@ describe('presence and nullability', () => {
 
   it('applies the same rule through a SchemaField', () => {
     type Nested = InferField<
-      SchemaFieldInstance<{ hp: NumberFieldInstance<{ required: false }> }, { nullable: true }>
+      SchemaFieldInstance<
+        { hp: NumberFieldInstance<{ required: false; nullable: false }> },
+        { nullable: true }
+      >
     >;
     expectTypeOf<Nested>().toEqualTypeOf<{ hp: number | undefined } | null>();
   });
@@ -258,7 +289,7 @@ describe('presence and nullability', () => {
 
 describe('InferField<F> — SetField', () => {
   it('is a Set, not an array', () => {
-    type T = InferField<SetFieldInstance<StringFieldInstance>>;
+    type T = InferField<SetFieldInstance<StringFieldInstance<{ required: true }>>>;
     expectTypeOf<T>().toEqualTypeOf<Set<string>>();
     // The distinction is the whole point: a Set has no push and no index
     // access, so typing one as an array hands the author two methods that
@@ -267,7 +298,9 @@ describe('InferField<F> — SetField', () => {
   });
 
   it('carries the element type through', () => {
-    expectTypeOf<InferField<SetFieldInstance<NumberFieldInstance>>>().toEqualTypeOf<Set<number>>();
+    expectTypeOf<
+      InferField<SetFieldInstance<NumberFieldInstance<{ required: true; nullable: false }>>>
+    >().toEqualTypeOf<Set<number>>();
   });
 
   it('applies presence to the element and to the set', () => {
@@ -278,7 +311,9 @@ describe('InferField<F> — SetField', () => {
   });
 
   it('holds a set of objects when the element is a SchemaField', () => {
-    type T = InferField<SetFieldInstance<SchemaFieldInstance<{ id: StringFieldInstance }>>>;
+    type T = InferField<
+      SetFieldInstance<SchemaFieldInstance<{ id: StringFieldInstance<{ required: true }> }>>
+    >;
     expectTypeOf<T>().toEqualTypeOf<Set<{ id: string }>>();
   });
 });
@@ -310,5 +345,18 @@ describe('InferField<F> — ForeignDocumentField', () => {
       ownerId: ForeignDocumentFieldInstance<typeof FakeActor, { idOnly: true }>;
     }>;
     expectTypeOf<T>().toEqualTypeOf<{ owner: FakeActor | null; ownerId: string | null }>();
+  });
+});
+
+describe('DocumentClass — the bound accepts real document shapes', () => {
+  it('takes a class whose constructor has parameters', () => {
+    type T = InferField<ForeignDocumentFieldInstance<typeof FakeItem>>;
+    expectTypeOf<T>().toEqualTypeOf<FakeItem | null>();
+  });
+
+  it('resolves to the instance type, not the class', () => {
+    type T = InferField<ForeignDocumentFieldInstance<typeof FakeItem, { nullable: false }>>;
+    expectTypeOf<T>().toHaveProperty('parent');
+    expectTypeOf<T>().not.toEqualTypeOf<typeof FakeItem>();
   });
 });

--- a/packages/core/src/data/infer-schema.ts
+++ b/packages/core/src/data/infer-schema.ts
@@ -37,39 +37,71 @@ export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 /**
  * Whether a field's options gave an explicit `initial`.
  *
- * A field with an initial is always populated, so it never widens to
- * `undefined` no matter what `required` says. Presence of the key is the
- * question, not its value — `{ initial: undefined }` is not an initial.
+ * Presence of the key is the question, not its value — `{ initial: undefined }`
+ * is not an initial.
  */
 type HasInitial<O> = O extends { initial: unknown } ? true : false;
 
 /**
- * Widen a field's base type by what its options allow it to be.
+ * What a field class decides on its own behalf, for the options a schema
+ * leaves out.
  *
- * Two independent widenings, derived from how a field resolves a value:
- *
- * - `nullable: true` admits `null`, and a required nullable field with no
- *   initial resolves to `null`.
- * - `required: false` with no explicit initial resolves to `undefined`.
- *
- * They compose: a field that is neither required nor nullable, with no
- * initial, is `T | undefined`; add `nullable` and it is `T | null | undefined`.
+ * Every field type sets its own defaults, and they disagree. A number field
+ * is optional and nullable out of the box; a boolean field is required and
+ * starts at `false`. Reading a schema without knowing which defaults apply
+ * gets the shape wrong for exactly the fields people write most.
  */
-type ApplyPresence<O, T> =
-  | T
-  | (O extends { nullable: true } ? null : never)
-  | (O extends { required: false } ? (HasInitial<O> extends true ? never : undefined) : never);
+interface FieldDefaults {
+  /** Whether the field is required when the schema does not say. */
+  required: boolean;
+  /** Whether the field admits `null` when the schema does not say. */
+  nullable: boolean;
+  /** Whether the field supplies a value when the schema gives no `initial`. */
+  populated: boolean;
+}
+
+/** Read an option the schema may have set, falling back to the field's default. */
+type Resolve<O, Key extends string, Fallback extends boolean> =
+  O extends Record<Key, true> ? true : O extends Record<Key, false> ? false : Fallback;
 
 /**
- * Presence for a field whose own defaults already admit `null`.
+ * Widen a field's base type by what it can actually hold.
  *
- * Most fields are non-nullable until the schema asks otherwise. A few invert
- * that — they hold `null` out of the box, and only an explicit
- * `nullable: false` takes it away.
+ * Two independent widenings:
+ *
+ * - nullable admits `null`.
+ * - not required, with nothing to fall back on, admits `undefined`: cleaning
+ *   asks the field for an initial value and keeps whatever it gets, which is
+ *   `undefined` when there is no initial to give.
+ *
+ * A required field never widens to `undefined`. It would fail validation
+ * before the document existed, so there is no state to type.
  */
-type PresenceNullableByDefault<O, T> = O extends { nullable: false }
-  ? ApplyPresence<O, T>
-  : ApplyPresence<O, T> | null;
+type Presence<O, T, D extends FieldDefaults> =
+  | T
+  | (Resolve<O, 'nullable', D['nullable']> extends true ? null : never)
+  | (Resolve<O, 'required', D['required']> extends true
+      ? never
+      : HasInitial<O> extends true
+        ? never
+        : D['populated'] extends true
+          ? never
+          : undefined);
+
+/** Optional, nullable, nothing to fall back on. */
+type NumberDefaults = { required: false; nullable: true; populated: false };
+/** Optional and non-nullable, so an unset one is simply absent. */
+type StringDefaults = { required: false; nullable: false; populated: false };
+/** Required, and starts at `false`. */
+type BooleanDefaults = { required: true; nullable: false; populated: true };
+/** Required and blank-friendly, so an unset one is the empty string. */
+type HTMLDefaults = { required: true; nullable: false; populated: true };
+/** Optional and nullable, but starts at `null` rather than absent. */
+type NullStartDefaults = { required: false; nullable: true; populated: true };
+/** Required, and builds its own empty value. */
+type ContainerDefaults = { required: true; nullable: false; populated: true };
+/** Required but nullable — an id that points at nothing is `null`. */
+type ReferenceDefaults = { required: true; nullable: true; populated: false };
 
 /**
  * What a `ColorField` holds once the model is initialized.
@@ -79,11 +111,10 @@ type PresenceNullableByDefault<O, T> = O extends { nullable: false }
  * with `.css`, `.rgb`, `.hex` and friends, and typing it as `string` makes
  * every property access on it a lie the compiler accepts.
  *
- * It is also nullable by default, unlike every other string-backed field.
- * Writing `new fields.ColorField()` and reading `.css` off it crashes on a
- * fresh document, which is exactly what this type now refuses.
+ * It starts at `null`, so reading `.css` off a fresh document crashes unless
+ * the schema gives it an initial. That is what this type refuses.
  */
-type ColorFieldValue<O> = PresenceNullableByDefault<O, Color>;
+type ColorFieldValue<O> = Presence<O, Color, NullStartDefaults>;
 
 /**
  * What a `ForeignDocumentField` holds once the model is initialized.
@@ -94,18 +125,22 @@ type ColorFieldValue<O> = PresenceNullableByDefault<O, Color>;
  * `null` when the id points at nothing, or when the parent lives in a
  * compendium.
  *
- * Nullable by default, so `null` is in both shapes unless the schema says
- * otherwise.
+ * Two caveats this does not encode, both narrow enough to document rather
+ * than type:
  *
- * One caveat this does not encode: on the server the field keeps the id
- * string in both cases, because there are no collections to resolve against.
- * System code runs on both sides, and typing that union would put a string
- * check in front of every read of a document reference. The client shape is
- * the one worth typing.
+ * - On the server the field keeps the id string in both cases, because there
+ *   are no collections to resolve against. System code runs on both sides,
+ *   but typing that union would put a string check in front of every read of
+ *   a document reference.
+ * - Under `readonly: true` the data model takes the read-only branch before
+ *   the getter branch, so the property keeps the resolver function itself.
+ *   The field turns that flag off by default and no schema has reason to
+ *   turn it back on.
  */
-type ForeignDocumentValue<Doc extends DocumentClass, O> = PresenceNullableByDefault<
+type ForeignDocumentValue<Doc extends DocumentClass, O> = Presence<
   O,
-  O extends { idOnly: true } ? string : InstanceType<Doc>
+  O extends { idOnly: true } ? string : InstanceType<Doc>,
+  ReferenceDefaults
 >;
 
 /**
@@ -115,25 +150,25 @@ type ForeignDocumentValue<Doc extends DocumentClass, O> = PresenceNullableByDefa
  */
 export type InferField<F> =
   F extends NumberFieldInstance<infer O>
-    ? ApplyPresence<O, number>
+    ? Presence<O, number, NumberDefaults>
     : F extends StringFieldInstance<infer O>
-      ? ApplyPresence<O, string>
+      ? Presence<O, string, StringDefaults>
       : F extends BooleanFieldInstance<infer O>
-        ? ApplyPresence<O, boolean>
+        ? Presence<O, boolean, BooleanDefaults>
         : F extends HTMLFieldInstance<infer O>
-          ? ApplyPresence<O, string>
+          ? Presence<O, string, HTMLDefaults>
           : F extends ColorFieldInstance<infer O>
             ? ColorFieldValue<O>
             : F extends FilePathFieldInstance<infer O>
-              ? ApplyPresence<O, string>
+              ? Presence<O, string, NullStartDefaults>
               : F extends ForeignDocumentFieldInstance<infer Doc, infer O>
                 ? ForeignDocumentValue<Doc, O>
                 : F extends ArrayFieldInstance<infer Inner, infer O>
-                  ? ApplyPresence<O, InferField<Inner>[]>
+                  ? Presence<O, InferField<Inner>[], ContainerDefaults>
                   : F extends SetFieldInstance<infer Inner, infer O>
-                    ? ApplyPresence<O, Set<InferField<Inner>>>
+                    ? Presence<O, Set<InferField<Inner>>, ContainerDefaults>
                     : F extends SchemaFieldInstance<infer S, infer O>
-                      ? ApplyPresence<O, InferSchema<S>>
+                      ? Presence<O, InferSchema<S>, ContainerDefaults>
                       : never;
 
 /**


### PR DESCRIPTION
Follow-up to #84. Reviewing that PR turned up a hole in what shipped in #82.

Every field class picks its own defaults for `required`, `nullable` and `initial`, and they disagree with each other. The inference applied a single rule to all of them, so three fields were typed as shapes they cannot hold:

| field | defaults | was | is |
|---|---|---|---|
| `NumberField` | optional, nullable | `number` | `number \| null \| undefined` |
| `StringField` | optional | `string` | `string \| undefined` |
| `FilePathField` | optional, nullable, starts at `null` | `string` | `string \| null` |

`NumberField` is the one that matters — it is the field people write most, and it is nullable out of the box.

The rest were already right, but for reasons nothing recorded. They are written down now: booleans and HTML fields are required and supply their own initial; arrays, sets and schemas are required and build their own empty value; document references are required but nullable.

### What this costs

Schemas that leave the options off will start seeing errors. That is the point — the value really can be absent. The fix is to declare what you meant:

```js
level: new f.NumberField({ required: true, nullable: false, initial: 1 })
```

### Tests that were passing for the wrong reason

Most of the existing assertions encoded the old, wrong shapes. Each has been updated to either the true default shape or an explicitly declared one. Two new cases prove the `DocumentClass` bound holds for a class with a real constructor signature, not only the synthetic one-property stand-in.

### Still to do, in a separate PR

The example system and the four scaffolding templates write `{ required: true, integer: true, initial: 1 }` with no `nullable: false`, so they infer `number | null` — accurately, since that is what the field accepts. They should say what they mean. That is a `fix(cli)` change and does not belong in this one.

### Caveats documented rather than typed

Two narrow cases on `ForeignDocumentField`, both noted in the doc comment: on the server the field keeps the id string, and under `readonly: true` the property keeps the resolver function instead of the document.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build` and knip pass.