### PR TITLE
fix(cli): declare nullable: false on the scaffolded number fields

### DIFF
--- a/.changeset/great-pianos-shake.md
+++ b/.changeset/great-pianos-shake.md
@@ -1,0 +1,9 @@
+---
+'@vttforge/cli': patch
+---
+
+Say what the scaffolded schemas mean.
+
+The generated number fields declared `required: true` but left `nullable` alone, so they still accepted `null` — and now that the types say so, that shows up as an error the author has to think about. They set `nullable: false`.
+
+The six ability scores share one spec instead of repeating it six times.

--- a/examples/simple-system/scripts/data/character-data.mjs
+++ b/examples/simple-system/scripts/data/character-data.mjs
@@ -13,9 +13,21 @@ import { BaseTypeDataModel, fields } from '@vttforge/core';
 export class CharacterData extends BaseTypeDataModel() {
   static defineSchema() {
     const f = fields();
+    // The six ability scores share one spec, so it is written once. The
+    // `const` matters: without it `nullable: false` widens to `boolean` and
+    // the inferred type falls back to the field's own nullable default.
+    const score = /** @type {const} */ ({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 1,
+      max: 30,
+      initial: 10,
+    });
     return {
       level: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 1,
         max: 20,
@@ -23,25 +35,50 @@ export class CharacterData extends BaseTypeDataModel() {
       }),
       speed: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 0,
         initial: 30,
       }),
       abilities: new f.SchemaField({
-        str: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        dex: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        con: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        int: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        wis: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        cha: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        str: new f.NumberField(score),
+        dex: new f.NumberField(score),
+        con: new f.NumberField(score),
+        int: new f.NumberField(score),
+        wis: new f.NumberField(score),
+        cha: new f.NumberField(score),
       }),
       health: new f.SchemaField({
-        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
-        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
+        value: new f.NumberField({
+          required: true,
+          nullable: false,
+          integer: true,
+          min: 0,
+          initial: 10,
+        }),
+        max: new f.NumberField({
+          required: true,
+          nullable: false,
+          integer: true,
+          min: 0,
+          initial: 10,
+        }),
       }),
       power: new f.SchemaField({
-        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
-        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
+        value: new f.NumberField({
+          required: true,
+          nullable: false,
+          integer: true,
+          min: 0,
+          initial: 5,
+        }),
+        max: new f.NumberField({
+          required: true,
+          nullable: false,
+          integer: true,
+          min: 0,
+          initial: 5,
+        }),
       }),
       biography: new f.HTMLField(),
     };

--- a/examples/simple-system/scripts/data/gear-data.mjs
+++ b/examples/simple-system/scripts/data/gear-data.mjs
@@ -16,12 +16,14 @@ export class GearData extends BaseTypeDataModel() {
     return {
       quantity: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 0,
         initial: 1,
       }),
       weight: new f.NumberField({
         required: true,
+        nullable: false,
         min: 0,
         initial: 0,
       }),

--- a/packages/cli/templates/system-js/scripts/data/character-data.mjs
+++ b/packages/cli/templates/system-js/scripts/data/character-data.mjs
@@ -15,9 +15,21 @@ import { BaseTypeDataModel, fields } from '@vttforge/core';
 export class CharacterData extends BaseTypeDataModel() {
   static defineSchema() {
     const f = fields();
+    // The six ability scores share one spec, so it is written once. The
+    // `const` matters: without it `nullable: false` widens to `boolean` and
+    // the inferred type falls back to the field's own nullable default.
+    const score = /** @type {const} */ ({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 1,
+      max: 30,
+      initial: 10,
+    });
     return {
       level: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 1,
         max: 20,
@@ -25,25 +37,26 @@ export class CharacterData extends BaseTypeDataModel() {
       }),
       speed: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 0,
         initial: 30,
       }),
       abilities: new f.SchemaField({
-        str: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        dex: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        con: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        int: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        wis: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        cha: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        str: new f.NumberField(score),
+        dex: new f.NumberField(score),
+        con: new f.NumberField(score),
+        int: new f.NumberField(score),
+        wis: new f.NumberField(score),
+        cha: new f.NumberField(score),
       }),
       health: new f.SchemaField({
-        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
-        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
+        value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
+        max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
       }),
       power: new f.SchemaField({
-        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
-        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
+        value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
+        max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
       }),
       biography: new f.HTMLField(),
     };

--- a/packages/cli/templates/system-js/scripts/data/gear-data.mjs
+++ b/packages/cli/templates/system-js/scripts/data/gear-data.mjs
@@ -15,12 +15,14 @@ export class GearData extends BaseTypeDataModel() {
     return {
       quantity: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 0,
         initial: 1,
       }),
       weight: new f.NumberField({
         required: true,
+        nullable: false,
         min: 0,
         initial: 0,
       }),

--- a/packages/cli/templates/system-ts/scripts/data/character-data.ts
+++ b/packages/cli/templates/system-ts/scripts/data/character-data.ts
@@ -15,9 +15,21 @@ import { BaseTypeDataModel, fields } from '@vttforge/core';
 export class CharacterData extends BaseTypeDataModel() {
   static defineSchema() {
     const f = fields();
+    // The six ability scores share one spec, so it is written once. The
+    // `as const` matters: without it `nullable: false` widens to `boolean`
+    // and the inferred type falls back to the field's own nullable default.
+    const score = {
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 1,
+      max: 30,
+      initial: 10,
+    } as const;
     return {
       level: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 1,
         max: 20,
@@ -25,25 +37,26 @@ export class CharacterData extends BaseTypeDataModel() {
       }),
       speed: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 0,
         initial: 30,
       }),
       abilities: new f.SchemaField({
-        str: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        dex: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        con: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        int: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        wis: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
-        cha: new f.NumberField({ required: true, integer: true, min: 1, max: 30, initial: 10 }),
+        str: new f.NumberField(score),
+        dex: new f.NumberField(score),
+        con: new f.NumberField(score),
+        int: new f.NumberField(score),
+        wis: new f.NumberField(score),
+        cha: new f.NumberField(score),
       }),
       health: new f.SchemaField({
-        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
-        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 10 }),
+        value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
+        max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
       }),
       power: new f.SchemaField({
-        value: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
-        max: new f.NumberField({ required: true, integer: true, min: 0, initial: 5 }),
+        value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
+        max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
       }),
       biography: new f.HTMLField(),
     };

--- a/packages/cli/templates/system-ts/scripts/data/gear-data.ts
+++ b/packages/cli/templates/system-ts/scripts/data/gear-data.ts
@@ -15,12 +15,14 @@ export class GearData extends BaseTypeDataModel() {
     return {
       quantity: new f.NumberField({
         required: true,
+        nullable: false,
         integer: true,
         min: 0,
         initial: 1,
       }),
       weight: new f.NumberField({
         required: true,
+        nullable: false,
         min: 0,
         initial: 0,
       }),

--- a/packages/core/src/data/infer-schema.ts
+++ b/packages/core/src/data/infer-schema.ts
@@ -10,6 +10,12 @@
  * Document-level fields — ownership, the `_stats` block — are deliberately
  * absent. They live on the document, never inside the schema a type data
  * model defines, so they cannot appear in what this maps.
+ *
+ * One thing to know when writing schemas: this reads the literal types of
+ * the options you pass. Hand a field an options object held in a variable
+ * and `nullable: false` widens to `boolean`, which says nothing, so the
+ * field's own default applies instead. Pin such an object with `as const`
+ * (or `/** @type {const} *\/` in JavaScript) and the declared values count.
  */
 import type { Color } from './color.js';
 import type {


### PR DESCRIPTION
Completes #85. The types now say a bare `NumberField` accepts `null`; the templates should stop writing fields that do when they don't mean it.

Every generated number field set `required: true` and left `nullable` alone, so a level, a speed, an ability score and a quantity all still accepted `null`. They set `nullable: false`. Same for the example system, which is the reference these templates follow.

### A trap this turned up

The six ability scores repeated the same six-line spec, so I pulled it into one shared object — and that silently undid the fix. An options object held in a variable widens `nullable: false` to `boolean`, which tells the inference nothing, so the field's own default applies again and the type goes back to `number | null`.

The spec is pinned with `as const` (`/** @type {const} */` in the JavaScript templates). The constraint applies to any options object an author holds in a variable, so it is written into the `InferSchema` doc comment as well. That doc change is comment-only and carries no changeset.

### Verification

CI does not typecheck the templates, so this was checked by hand: the `system-ts` template compiled against the local core, with a probe asserting `system.level` and `system.abilities.str` are `number`.

- with `nullable: false` declared → compiles
- with it removed → both fail with "Type 'null' is not assignable to type 'number'"
- with the shared spec but no `as const` → `abilities.str` fails, `level` passes

That third case is how the trap surfaced.

`pnpm typecheck`, `pnpm test`, `pnpm lint` and `pnpm build` pass.