### PR TITLE
fix(cli): build each ability score from a factory, not a shared options object

### DIFF
--- a/.changeset/lucky-pumas-tap.md
+++ b/.changeset/lucky-pumas-tap.md
@@ -1,0 +1,7 @@
+---
+'@vttforge/cli': patch
+---
+
+Build each ability score from a factory rather than one shared options object.
+
+A field keeps a reference to the options it was handed, and some field classes write back into that object. Six fields sharing one object is safe for the field this template uses, but it is not a habit to teach in code people copy and adapt.

--- a/examples/simple-system/scripts/data/character-data.mjs
+++ b/examples/simple-system/scripts/data/character-data.mjs
@@ -13,17 +13,18 @@ import { BaseTypeDataModel, fields } from '@vttforge/core';
 export class CharacterData extends BaseTypeDataModel() {
   static defineSchema() {
     const f = fields();
-    // The six ability scores share one spec, so it is written once. The
-    // `const` matters: without it `nullable: false` widens to `boolean` and
-    // the inferred type falls back to the field's own nullable default.
-    const score = /** @type {const} */ ({
-      required: true,
-      nullable: false,
-      integer: true,
-      min: 1,
-      max: 30,
-      initial: 10,
-    });
+    // The six ability scores are written once, as a factory rather than a
+    // shared options object: a field keeps the options it was handed, and
+    // some field classes write back into them.
+    const score = () =>
+      new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 1,
+        max: 30,
+        initial: 10,
+      });
     return {
       level: new f.NumberField({
         required: true,
@@ -41,12 +42,12 @@ export class CharacterData extends BaseTypeDataModel() {
         initial: 30,
       }),
       abilities: new f.SchemaField({
-        str: new f.NumberField(score),
-        dex: new f.NumberField(score),
-        con: new f.NumberField(score),
-        int: new f.NumberField(score),
-        wis: new f.NumberField(score),
-        cha: new f.NumberField(score),
+        str: score(),
+        dex: score(),
+        con: score(),
+        int: score(),
+        wis: score(),
+        cha: score(),
       }),
       health: new f.SchemaField({
         value: new f.NumberField({

--- a/packages/cli/templates/system-js/scripts/data/character-data.mjs
+++ b/packages/cli/templates/system-js/scripts/data/character-data.mjs
@@ -15,17 +15,18 @@ import { BaseTypeDataModel, fields } from '@vttforge/core';
 export class CharacterData extends BaseTypeDataModel() {
   static defineSchema() {
     const f = fields();
-    // The six ability scores share one spec, so it is written once. The
-    // `const` matters: without it `nullable: false` widens to `boolean` and
-    // the inferred type falls back to the field's own nullable default.
-    const score = /** @type {const} */ ({
-      required: true,
-      nullable: false,
-      integer: true,
-      min: 1,
-      max: 30,
-      initial: 10,
-    });
+    // The six ability scores are written once, as a factory rather than a
+    // shared options object: a field keeps the options it was handed, and
+    // some field classes write back into them.
+    const score = () =>
+      new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 1,
+        max: 30,
+        initial: 10,
+      });
     return {
       level: new f.NumberField({
         required: true,
@@ -43,12 +44,12 @@ export class CharacterData extends BaseTypeDataModel() {
         initial: 30,
       }),
       abilities: new f.SchemaField({
-        str: new f.NumberField(score),
-        dex: new f.NumberField(score),
-        con: new f.NumberField(score),
-        int: new f.NumberField(score),
-        wis: new f.NumberField(score),
-        cha: new f.NumberField(score),
+        str: score(),
+        dex: score(),
+        con: score(),
+        int: score(),
+        wis: score(),
+        cha: score(),
       }),
       health: new f.SchemaField({
         value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),

--- a/packages/cli/templates/system-ts/scripts/data/character-data.ts
+++ b/packages/cli/templates/system-ts/scripts/data/character-data.ts
@@ -15,17 +15,18 @@ import { BaseTypeDataModel, fields } from '@vttforge/core';
 export class CharacterData extends BaseTypeDataModel() {
   static defineSchema() {
     const f = fields();
-    // The six ability scores share one spec, so it is written once. The
-    // `as const` matters: without it `nullable: false` widens to `boolean`
-    // and the inferred type falls back to the field's own nullable default.
-    const score = {
-      required: true,
-      nullable: false,
-      integer: true,
-      min: 1,
-      max: 30,
-      initial: 10,
-    } as const;
+    // The six ability scores are written once, as a factory rather than a
+    // shared options object: a field keeps the options it was handed, and
+    // some field classes write back into them.
+    const score = () =>
+      new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 1,
+        max: 30,
+        initial: 10,
+      });
     return {
       level: new f.NumberField({
         required: true,
@@ -43,12 +44,12 @@ export class CharacterData extends BaseTypeDataModel() {
         initial: 30,
       }),
       abilities: new f.SchemaField({
-        str: new f.NumberField(score),
-        dex: new f.NumberField(score),
-        con: new f.NumberField(score),
-        int: new f.NumberField(score),
-        wis: new f.NumberField(score),
-        cha: new f.NumberField(score),
+        str: score(),
+        dex: score(),
+        con: score(),
+        int: score(),
+        wis: score(),
+        cha: score(),
       }),
       health: new f.SchemaField({
         value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),


### PR DESCRIPTION
Follow-up to #86, which pulled the six repeated ability-score specs into one shared options object.

A field keeps a reference to the options object it was handed, and some field classes write back into it. `NumberField` does not, so what #86 shipped is safe — but this is reference code that authors copy and adapt, and the same shape applied to a field type that does write would give six fields one mutable object and a bug that is very hard to trace.

A factory sidesteps it and reads no worse:

```js
const score = () =>
  new f.NumberField({ required: true, nullable: false, integer: true, min: 1, max: 30, initial: 10 });
```

It also keeps the options inline, so the literal types survive on their own and the `as const` from #86 is no longer needed.

Verified the same way as #86: the `system-ts` template compiled against the local core with a probe asserting `system.abilities.str` is `number`, not `number | null`.

### Separately

`packages/cli/src/__tests__/dev-watcher.test.ts` is flaky — roughly one run in five under a full parallel suite. It waits for filesystem-watch events with fixed `setTimeout` calls, which run out under load. Pre-existing on `main`, unrelated to this change, fix coming in its own PR.