### PR TITLE
feat(core): let BaseTypeDataModel learn its schema

### DIFF
--- a/.changeset/olive-otters-teach.md
+++ b/.changeset/olive-otters-teach.md
@@ -1,0 +1,22 @@
+---
+'@vttforge/core': minor
+---
+
+Let `BaseTypeDataModel` learn your schema.
+
+Hand it the function that returns your fields and it implements `static defineSchema()` for you. The schema is written once, and `this` inside `prepareDerivedData()` knows its own fields:
+
+```ts
+class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {
+  declare armorClass: number;
+  prepareDerivedData() {
+    this.armorClass = 10 + this.level; // this.level is number
+  }
+}
+
+type CharacterSystem = CharacterData['$inferData'];
+```
+
+Derived values are not in the schema, so declare them on the subclass.
+
+Calling `BaseTypeDataModel()` with no arguments works exactly as before.

--- a/packages/core/src/__tests__/base-type-data-model.test.ts
+++ b/packages/core/src/__tests__/base-type-data-model.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { BaseTypeDataModel } from '../base-type-data-model.js';
+import type { NumberFieldInstance, SchemaFieldInstance } from '../data/fields.js';
 import { VttfError } from '../errors/registry.js';
 
 class FakeFoundryTypeDataModel {
@@ -64,5 +65,87 @@ describe('BaseTypeDataModel', () => {
     }
     const result = CharacterData.migrateData({ name: 'hero' });
     expect(result).toEqual({ name: 'hero', level: 1, _migrated: true });
+  });
+});
+
+describe('BaseTypeDataModel(defineSchema) — runtime', () => {
+  const define = () => ({ level: 1 }) as unknown as Record<string, never>;
+
+  it('implements defineSchema for the subclass, so the schema is written once', () => {
+    class CharacterData extends BaseTypeDataModel(define) {}
+    expect(CharacterData.defineSchema()).toEqual({ level: 1 });
+  });
+
+  it('lets a subclass override defineSchema, like any other static', () => {
+    class CharacterData extends BaseTypeDataModel(define) {
+      static override defineSchema() {
+        return { level: 99 } as unknown as Record<string, never>;
+      }
+    }
+    expect(CharacterData.defineSchema()).toEqual({ level: 99 });
+  });
+
+  it('leaves defineSchema alone in the no-argument form', () => {
+    // Foundry's own TypeDataModel owns it there. Shadowing it with a stub
+    // that returns nothing would break every existing subclass.
+    const Base = BaseTypeDataModel();
+    expect(Object.hasOwn(Base, 'defineSchema')).toBe(false);
+  });
+
+  it('still applies the hook defaults', () => {
+    class CharacterData extends BaseTypeDataModel(define) {}
+    const instance = new CharacterData();
+    expect(() => instance.prepareBaseData()).not.toThrow();
+    expect(() => instance.prepareDerivedData()).not.toThrow();
+  });
+});
+
+describe('BaseTypeDataModel(defineSchema) — types', () => {
+  type Score = NumberFieldInstance<{ required: true; nullable: false; initial: 0 }>;
+  const defineCharacterSchema = (() => ({})) as unknown as () => {
+    level: Score;
+    health: SchemaFieldInstance<{ value: Score; max: Score }>;
+  };
+
+  // Wrapped in a factory so the class body is not evaluated at collection
+  // time, before the Foundry stub is installed. The type is the same either
+  // way, which is all these cases read.
+  const makeCharacterData = () =>
+    class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {
+      // Derived values are not in the schema, so the author declares them.
+      declare armorClass: number;
+
+      override prepareDerivedData(): void {
+        this.health.max = 10 + this.level;
+        this.armorClass = 10;
+      }
+    };
+  type CharacterData = InstanceType<ReturnType<typeof makeCharacterData>>;
+
+  it('types the schema fields as instance properties', () => {
+    expectTypeOf<CharacterData['level']>().toEqualTypeOf<number>();
+    expectTypeOf<CharacterData['health']>().toEqualTypeOf<{ value: number; max: number }>();
+  });
+
+  it('names the inferred shape through $inferData', () => {
+    expectTypeOf<CharacterData['$inferData']>().toEqualTypeOf<{
+      level: number;
+      health: { value: number; max: number };
+    }>();
+  });
+
+  it('keeps the hooks on the instance', () => {
+    expectTypeOf<CharacterData['prepareDerivedData']>().toEqualTypeOf<() => void>();
+  });
+
+  it('leaves the no-argument form untyped, as it was', () => {
+    // Every scaffolded template calls it this way. The typed overload must
+    // not capture the no-argument call and hand it a schema of nothing.
+    class Legacy extends BaseTypeDataModel() {
+      whatever(): void {
+        this.anythingAtAll = 1;
+      }
+    }
+    expect(typeof Legacy).toBe('function');
   });
 });

--- a/packages/core/src/base-type-data-model.ts
+++ b/packages/core/src/base-type-data-model.ts
@@ -20,6 +20,8 @@
  * exists by the time this module runs (we are loaded from system esmodules).
  */
 
+import type { FieldInstance } from './data/fields.js';
+import type { InferSchema } from './data/infer-schema.js';
 import { VttfError } from './errors/registry.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: we mix into Foundry's TypeDataModel whose shape lives in fvtt-types (deferred to @vttforge/types v1.0)
@@ -46,7 +48,86 @@ function resolveTypeDataModelClass(): AnyConstructor {
  * globals may not exist yet (test boot, ESM hoist). Calling `BaseTypeDataModel()`
  * lazy-resolves the global at the moment of subclassing.
  */
-export function BaseTypeDataModel(): AnyConstructor {
+/** The two hooks this base fills in, so a subclass can omit either. */
+export interface TypeDataModelHooks {
+  prepareBaseData(): void;
+  prepareDerivedData(): void;
+}
+
+/**
+ * What an instance looks like when the schema is known.
+ *
+ * The schema's fields ARE the instance properties — inside
+ * `prepareDerivedData()` you read `this.level`, not `this.system.level`, and
+ * `actor.system` is this instance.
+ *
+ * Derived values are not in the schema, so they are not here either. Declare
+ * them on the subclass:
+ *
+ * ```ts
+ * declare armorClass: number;
+ * ```
+ */
+export type TypedTypeDataModel<S extends Record<string, FieldInstance>> = InferSchema<S> &
+  TypeDataModelHooks & {
+    /**
+     * Phantom property carrying the schema's inferred shape. Never assigned,
+     * never present at runtime — it exists so the type has a name:
+     *
+     * ```ts
+     * type CharacterSystem = CharacterData['$inferData'];
+     * ```
+     */
+    readonly $inferData: InferSchema<S>;
+  };
+
+export interface TypedTypeDataModelCtor<S extends Record<string, FieldInstance>> {
+  // biome-ignore lint/suspicious/noExplicitAny: a subclass declaring its own
+  // constructor has to pass Foundry's (data, context) pair through to super.
+  new (...args: any[]): TypedTypeDataModel<S>;
+  defineSchema(): S;
+  migrateData(data: Record<string, unknown>): Record<string, unknown>;
+}
+
+/**
+ * Build a base class with no knowledge of the schema.
+ *
+ * `this` inside the hooks is untyped. Pass your schema function instead to
+ * get the fields typed.
+ */
+export function BaseTypeDataModel(): AnyConstructor;
+/**
+ * Build a base class that knows its schema.
+ *
+ * Hand it the function that returns your fields and it implements
+ * `static defineSchema()` for you, so the schema is written once:
+ *
+ * ```ts
+ * const defineCharacterSchema = () => {
+ *   const f = fields();
+ *   return { level: new f.NumberField({ required: true, nullable: false, initial: 1 }) };
+ * };
+ *
+ * class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {
+ *   declare armorClass: number;
+ *   prepareDerivedData() {
+ *     this.armorClass = 10 + this.level; // this.level is number
+ *   }
+ * }
+ * ```
+ *
+ * It has to be a function, not an object: `fields()` reads a Foundry global
+ * that does not exist when the module is first evaluated.
+ *
+ * A subclass may still declare its own `static defineSchema()`; that one wins,
+ * the same as any other static.
+ */
+export function BaseTypeDataModel<S extends Record<string, FieldInstance>>(
+  defineSchema: () => S,
+): TypedTypeDataModelCtor<S>;
+export function BaseTypeDataModel(
+  defineSchema?: () => Record<string, FieldInstance>,
+): AnyConstructor {
   const Base = resolveTypeDataModelClass();
 
   class VttforgeBaseTypeDataModel extends Base {
@@ -89,6 +170,17 @@ export function BaseTypeDataModel(): AnyConstructor {
     prepareDerivedData(): void {
       // override me
     }
+  }
+
+  if (defineSchema !== undefined) {
+    // Assigned rather than declared in the class body so the no-argument form
+    // keeps inheriting Foundry's own defineSchema instead of shadowing it
+    // with one that returns nothing.
+    Object.defineProperty(VttforgeBaseTypeDataModel, 'defineSchema', {
+      value: defineSchema,
+      writable: true,
+      configurable: true,
+    });
   }
 
   return VttforgeBaseTypeDataModel as unknown as AnyConstructor;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,7 +26,12 @@ export {
   VTTFORGE_SHEET_CLASS,
 } from './base-actor-sheet.js';
 export { BaseItemSheet } from './base-item-sheet.js';
-export { BaseTypeDataModel } from './base-type-data-model.js';
+export {
+  BaseTypeDataModel,
+  type TypeDataModelHooks,
+  type TypedTypeDataModel,
+  type TypedTypeDataModelCtor,
+} from './base-type-data-model.js';
 export type {
   ArrayFieldOptions,
   BooleanFieldOptions,


### PR DESCRIPTION
Closes the class-level inference item on the types track.

```ts
class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {
  declare armorClass: number;
  prepareDerivedData() {
    this.armorClass = 10 + this.level; // this.level is number
  }
}

type CharacterSystem = CharacterData['$inferData'];
```

The factory takes the schema function, implements `static defineSchema()` from it, and types the instance so the schema's fields are the instance's properties. It has to be a function, not an object — `fields()` reads a Foundry global that does not exist at module evaluation.

Derived values are not in the schema, so a subclass declares them (`declare armorClass: number`). That reads as documentation of the derived surface rather than a workaround.

### Three things checked rather than assumed

- **`never[]` breaks subclass constructors.** The first draft used it; a subclass declaring `constructor(data, context)` failed to compile. Widened to `any[]`, matching the existing `AnyConstructor`.
- **The no-argument overload still resolves to the untyped branch.** Worth stating how this was measured: `ReturnType<typeof BaseTypeDataModel>` is *not* the test — for an overloaded function TypeScript takes the last signature, which made the no-arg form look broken when it was not. Verified at a real call site instead.
- **A subclass's own `static defineSchema()` still wins**, so existing code is unaffected. The no-argument form deliberately does not define one at all — shadowing Foundry's with a stub returning nothing would break every current subclass.

### Verification

Each type assertion was broken on purpose and confirmed to fail: wrong field type, undeclared derived field, wrong assignment, incomplete `$inferData`. Runtime cases cover inherited vs overridden `defineSchema` and the untouched no-argument form.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build` and knip pass.