### PR TITLE
feat(cli): let init run without a terminal

### DIFF
--- a/.changeset/smooth-moons-invite.md
+++ b/.changeset/smooth-moons-invite.md
@@ -1,0 +1,16 @@
+---
+'@vttforge/cli': minor
+---
+
+`vttforge init` can now run without a terminal.
+
+Five values — id, title, description, author, license — were always asked for, with no flag to supply them. Clack prompts read from stdin, so with none attached the scaffolder hung: no error, no output, nothing to debug. That ruled out CI and scripts, and meant nothing could test the scaffolder through its own entry point.
+
+Each now has a flag, and `--yes` (`-y`) takes the default for anything not passed. A run with no terminal assumes `--yes`, so CI needs no extra flag.
+
+```bash
+vttforge init pdf-character-sheet --type module --lang ts \
+  --title "PDF Character Sheet" --license Apache-2.0 --yes
+```
+
+The directory name is the one thing with no sensible default. Without a terminal to ask, the run stops and says so.

--- a/packages/cli/src/__tests__/cli-args.test.ts
+++ b/packages/cli/src/__tests__/cli-args.test.ts
@@ -44,6 +44,37 @@ describe('init args', () => {
     expect(parse(init, []).name).toBeUndefined();
   });
 
+  it('defaults yes to false, so a bare run still prompts', () => {
+    expect(parse(init, ['my-sys']).yes).toBe(false);
+  });
+
+  it.each([['--yes'], ['-y']])('%s turns off prompting', (flag) => {
+    expect(parse(init, ['my-sys', flag]).yes).toBe(true);
+  });
+
+  it('reads every metadata flag', () => {
+    const args = parse(init, [
+      'my-sys',
+      '--id',
+      'pdf-character-sheet',
+      '--title',
+      'PDF Character Sheet',
+      '--description',
+      'Form-fillable PDFs as sheets',
+      '--author',
+      'Fabricio Cavalcante',
+      '--license',
+      'Apache-2.0',
+    ]);
+    expect(args).toMatchObject({
+      id: 'pdf-character-sheet',
+      title: 'PDF Character Sheet',
+      description: 'Form-fillable PDFs as sheets',
+      author: 'Fabricio Cavalcante',
+      license: 'Apache-2.0',
+    });
+  });
+
   it.each([
     [['my-sys', '--type', 'module', '--lang', 'js']],
     [['my-sys', '--type=module', '--lang=js']],

--- a/packages/cli/src/__tests__/init-non-interactive.test.ts
+++ b/packages/cli/src/__tests__/init-non-interactive.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `vttforge init` without a terminal.
+ *
+ * Clack prompts read from stdin. With none attached they never resolve, so
+ * before this the scaffolder simply hung — no error, no output, nothing to
+ * debug. That ruled out CI, scripts, and testing the scaffolder through its
+ * own entry point.
+ *
+ * These cases drive `runInit` with `stdin.isTTY` off, which is what any
+ * non-interactive caller looks like.
+ */
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runInit, ScaffoldError } from '../commands/init.js';
+
+let cwd: string;
+let originalIsTTY: boolean | undefined;
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'vttforge-init-'));
+  originalIsTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+  vi.restoreAllMocks();
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+const readJson = (...parts: string[]) => JSON.parse(readFileSync(join(...parts), 'utf8'));
+
+describe('runInit without a terminal', () => {
+  it('scaffolds from the defaults alone', async () => {
+    await runInit({ cwd, name: 'smoke-module', type: 'module', noInstall: true, noGit: true });
+
+    const manifest = readJson(cwd, 'smoke-module', 'module.json');
+    expect(manifest.id).toBe('smoke-module');
+    expect(manifest.title).toBe('Smoke Module');
+    expect(manifest.compatibility.minimum).toBe('13');
+  });
+
+  it('takes every metadata value from its option', async () => {
+    await runInit({
+      cwd,
+      name: 'sheet-module',
+      type: 'module',
+      lang: 'ts',
+      id: 'pdf-character-sheet',
+      title: 'PDF Character Sheet',
+      description: 'Form-fillable PDFs as character sheets',
+      author: 'Fabricio Cavalcante',
+      license: 'Apache-2.0',
+      noInstall: true,
+      noGit: true,
+    });
+
+    const manifest = readJson(cwd, 'sheet-module', 'module.json');
+    expect(manifest).toMatchObject({
+      id: 'pdf-character-sheet',
+      title: 'PDF Character Sheet',
+      description: 'Form-fillable PDFs as character sheets',
+      authors: [{ name: 'Fabricio Cavalcante' }],
+    });
+    expect(readJson(cwd, 'sheet-module', 'package.json').license).toBe('Apache-2.0');
+  });
+
+  it('defaults type to system and lang to TypeScript', async () => {
+    await runInit({ cwd, name: 'bare', noInstall: true, noGit: true });
+    expect(readJson(cwd, 'bare', 'system.json').id).toBe('bare');
+  });
+
+  it('refuses a bad id from the flag instead of scaffolding one', async () => {
+    // The prompt validates; a flag has to be held to the same rule, or an
+    // invalid id lands in the manifest and Foundry rejects the package.
+    await expect(
+      runInit({ cwd, name: 'ok-name', id: 'Not A Valid Id', noInstall: true, noGit: true }),
+    ).rejects.toThrow(ScaffoldError);
+  });
+
+  it('says what is missing when it cannot ask for the name', async () => {
+    await expect(runInit({ cwd, noInstall: true, noGit: true })).rejects.toThrow(ScaffoldError);
+  });
+
+  it('honours --yes even with a terminal attached', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    await runInit({ cwd, name: 'forced', type: 'module', yes: true, noInstall: true, noGit: true });
+    expect(readJson(cwd, 'forced', 'module.json').id).toBe('forced');
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -33,6 +33,35 @@ export const init = defineCommand({
       type: 'string',
       description: 'Language: ts | js',
     },
+    id: {
+      type: 'string',
+      description: 'Manifest id (defaults to a slug of the directory name)',
+    },
+    title: {
+      type: 'string',
+      description: 'Human-readable title shown in Foundry setup screens',
+    },
+    description: {
+      type: 'string',
+      description: 'One-line description for the manifest',
+    },
+    author: {
+      type: 'string',
+      description: 'Author name for the manifest (defaults to the git author)',
+    },
+    license: {
+      type: 'string',
+      description: 'SPDX license id (default MIT)',
+    },
+    // Without a terminal there is nothing for a prompt to read, so it waits
+    // forever. This flag takes the defaults instead — and the scaffolder
+    // also assumes it when stdin is not a TTY, so CI need not pass it.
+    yes: {
+      type: 'boolean',
+      alias: 'y',
+      default: false,
+      description: 'Accept defaults for anything not passed, without prompting',
+    },
     // Citty parses `--no-X` as `args.X === false`, so define affirmative
     // flags with a true default. `--no-install` then yields `install: false`
     // which we forward as `noInstall: true`.
@@ -53,6 +82,12 @@ export const init = defineCommand({
         name: typeof args.name === 'string' ? args.name : undefined,
         type: typeof args.type === 'string' ? (args.type as 'system' | 'module') : undefined,
         lang: typeof args.lang === 'string' ? (args.lang as 'ts' | 'js') : undefined,
+        id: typeof args.id === 'string' ? args.id : undefined,
+        title: typeof args.title === 'string' ? args.title : undefined,
+        description: typeof args.description === 'string' ? args.description : undefined,
+        author: typeof args.author === 'string' ? args.author : undefined,
+        license: typeof args.license === 'string' ? args.license : undefined,
+        yes: args.yes === true,
         noInstall: args.install === false,
         noGit: args.git === false,
       });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,13 +18,33 @@ export interface InitOptions {
   name?: string;
   type?: 'system' | 'module';
   lang?: 'ts' | 'js';
+  /** Manifest id. Defaults to a slug of the directory name. */
+  id?: string;
+  /** Human-readable title shown in Foundry's setup screens. */
+  title?: string;
+  /** One-line description for the manifest. */
+  description?: string;
+  /** Author name for the manifest. Defaults to the local git author. */
+  author?: string;
+  /** SPDX license id written to package.json. */
+  license?: string;
+  /**
+   * Take the default for anything not supplied instead of asking.
+   *
+   * Required to scaffold without a terminal — a prompt with nothing to read
+   * from waits forever, which is no way to fail.
+   */
+  yes?: boolean;
   noInstall?: boolean;
   noGit?: boolean;
   /** Override the working directory (test hook). Defaults to `process.cwd()`. */
   cwd?: string;
 }
 
-export interface ResolvedInitOptions extends Required<Omit<InitOptions, 'cwd'>> {
+export interface ResolvedInitOptions
+  extends Required<
+    Omit<InitOptions, 'cwd' | 'id' | 'title' | 'description' | 'author' | 'license' | 'yes'>
+  > {
   cwd: string;
   dest: string;
   id: string;
@@ -125,16 +145,33 @@ function titleCase(input: string): string {
     .join(' ');
 }
 
+/**
+ * Whether we may ask the user anything at all.
+ *
+ * Clack reads from stdin. With no terminal attached there is nothing to read,
+ * and the prompt simply hangs — so a run that cannot ask has to be told every
+ * answer up front, or be given `--yes` and take the defaults.
+ */
+function canPrompt(yes: boolean | undefined): boolean {
+  return yes !== true && Boolean(process.stdin.isTTY);
+}
+
 function templateVariantFor(type: 'system' | 'module', lang: 'ts' | 'js'): TemplateVariant {
   return `${type}-${lang}` as TemplateVariant;
 }
 
 export async function runInit(options: InitOptions = {}): Promise<void> {
   const cwd = options.cwd ?? process.cwd();
+  const interactive = canPrompt(options.yes);
   p.intro('🜲 vttforge init — scaffold a Foundry v13+ system or module');
 
   // --- name ------------------------------------------------------------------
   let name = options.name?.trim();
+  if (!name && !interactive) {
+    bail(
+      'A directory name is required when running without prompts. Pass it as the first argument: `vttforge init my-module --yes`.',
+    );
+  }
   if (!name) {
     const answer = await p.text({
       message: 'Directory name (also the default manifest id)',
@@ -162,6 +199,9 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
 
   // --- type ------------------------------------------------------------------
   let type = options.type;
+  if (type !== 'system' && type !== 'module' && !interactive) {
+    type = 'system';
+  }
   if (type !== 'system' && type !== 'module') {
     const answer = await p.select({
       message: 'What are you building?',
@@ -180,6 +220,9 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
 
   // --- lang ------------------------------------------------------------------
   let lang = options.lang;
+  if (lang !== 'ts' && lang !== 'js' && !interactive) {
+    lang = 'ts';
+  }
   if (lang !== 'ts' && lang !== 'js') {
     const answer = await p.select({
       message: 'Language',
@@ -194,31 +237,67 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
   }
 
   // --- id / title / description / author ------------------------------------
+  /**
+   * Resolve one metadata field: an explicit flag wins, otherwise ask, and
+   * when asking is impossible take the default.
+   */
+  const resolveField = async (
+    provided: string | undefined,
+    fallback: string,
+    ask: () => Promise<unknown>,
+    validate: (value: string) => string | undefined,
+  ): Promise<string> => {
+    if (provided !== undefined) {
+      const trimmed = provided.trim();
+      const failure = validate(trimmed);
+      if (failure !== undefined) bail(`${failure} (got ${JSON.stringify(provided)})`);
+      return trimmed;
+    }
+    if (!interactive) return fallback;
+    const answer = await ask();
+    if (isCancelled(answer)) bail('Scaffold cancelled.');
+    const value = String(answer).trim();
+    return value.length > 0 ? value : fallback;
+  };
+
   const defaultId = slugify(name);
-  const idAnswer = await p.text({
-    message: 'Package id (used as the folder Foundry serves under /<systems|modules>/<id>/)',
-    initialValue: defaultId,
-    validate: validatePackageId,
-  });
-  if (isCancelled(idAnswer)) bail('Scaffold cancelled.');
-  const id = String(idAnswer);
+  const id = await resolveField(
+    options.id,
+    defaultId,
+    () =>
+      p.text({
+        message: 'Package id (used as the folder Foundry serves under /<systems|modules>/<id>/)',
+        initialValue: defaultId,
+        validate: validatePackageId,
+      }),
+    validatePackageId,
+  );
 
-  const titleAnswer = await p.text({
-    message: 'Title (human-readable, shown in Foundry setup screens)',
-    initialValue: titleCase(id),
-    validate: validateRequiredMetadata,
-  });
-  if (isCancelled(titleAnswer)) bail('Scaffold cancelled.');
-  const title = String(titleAnswer).trim();
+  const title = await resolveField(
+    options.title,
+    titleCase(id),
+    () =>
+      p.text({
+        message: 'Title (human-readable, shown in Foundry setup screens)',
+        initialValue: titleCase(id),
+        validate: validateRequiredMetadata,
+      }),
+    validateRequiredMetadata,
+  );
 
-  const descriptionAnswer = await p.text({
-    message: 'One-line description',
-    placeholder: 'A Foundry v13+ system built with VTTForge',
-    initialValue: `A Foundry v13+ ${type} built with VTTForge`,
-    validate: validateMetadata,
-  });
-  if (isCancelled(descriptionAnswer)) bail('Scaffold cancelled.');
-  const description = String(descriptionAnswer);
+  const defaultDescription = `A Foundry v13+ ${type} built with VTTForge`;
+  const description = await resolveField(
+    options.description,
+    defaultDescription,
+    () =>
+      p.text({
+        message: 'One-line description',
+        placeholder: defaultDescription,
+        initialValue: defaultDescription,
+        validate: validateMetadata,
+      }),
+    validateMetadata,
+  );
 
   const rawDetectedAuthor = await readGitAuthorName();
   // The git fallback bypasses Clack validation, so apply the same metadata
@@ -229,27 +308,35 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
     rawDetectedAuthor && validateMetadata(rawDetectedAuthor) === undefined
       ? rawDetectedAuthor
       : undefined;
-  const authorAnswer = await p.text({
-    message: 'Author name (used in the manifest)',
-    placeholder: detectedAuthor ?? 'Your Name',
-    initialValue: detectedAuthor ?? '',
-    validate: validateMetadata,
-  });
-  if (isCancelled(authorAnswer)) bail('Scaffold cancelled.');
-  const author = String(authorAnswer).trim() || (detectedAuthor ?? 'Anonymous');
+  const author = await resolveField(
+    options.author,
+    detectedAuthor ?? 'Anonymous',
+    () =>
+      p.text({
+        message: 'Author name (used in the manifest)',
+        placeholder: detectedAuthor ?? 'Your Name',
+        initialValue: detectedAuthor ?? '',
+        validate: validateMetadata,
+      }),
+    validateMetadata,
+  );
 
-  const licenseAnswer = await p.select({
-    message: 'License',
-    options: [
-      { value: 'MIT', label: 'MIT (recommended for Foundry community packages)' },
-      { value: 'Apache-2.0', label: 'Apache-2.0' },
-      { value: 'GPL-3.0-or-later', label: 'GPL-3.0-or-later' },
-      { value: 'UNLICENSED', label: 'UNLICENSED (private use only)' },
-    ],
-    initialValue: 'MIT',
-  });
-  if (isCancelled(licenseAnswer)) bail('Scaffold cancelled.');
-  const license = String(licenseAnswer);
+  const license = await resolveField(
+    options.license,
+    'MIT',
+    () =>
+      p.select({
+        message: 'License',
+        options: [
+          { value: 'MIT', label: 'MIT (recommended for Foundry community packages)' },
+          { value: 'Apache-2.0', label: 'Apache-2.0' },
+          { value: 'GPL-3.0-or-later', label: 'GPL-3.0-or-later' },
+          { value: 'UNLICENSED', label: 'UNLICENSED (private use only)' },
+        ],
+        initialValue: 'MIT',
+      }),
+    validateRequiredMetadata,
+  );
 
   const foundryMinVersion = '13';
   const foundryVerifiedVersion = '13.341';
@@ -289,7 +376,7 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
   // the working tree stays clean after scaffold.
   const pm = detectPackageManager();
   let shouldInstall = !options.noInstall;
-  if (shouldInstall) {
+  if (shouldInstall && interactive) {
     const confirm = await p.confirm({
       message: `Install dependencies now with ${pm}?`,
       initialValue: true,

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -14,7 +14,7 @@
     "@vttforge/core": "^0.6.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.4.0",
+    "@vttforge/cli": "^0.5.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -15,7 +15,7 @@
     "@vttforge/core": "^0.6.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.4.0",
+    "@vttforge/cli": "^0.5.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -15,7 +15,7 @@
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.4.0",
+    "@vttforge/cli": "^0.5.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -16,7 +16,7 @@
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.4.0",
+    "@vttforge/cli": "^0.5.0",
     "@vttforge/vite-plugin": "^0.3.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"


### PR DESCRIPTION
Found while starting the module port: `vttforge init` cannot run non-interactively at all.

Five values — id, title, description, author, license — were always prompted, with no flag to supply them. Clack prompts read from stdin, so with none attached the scaffolder hangs. No error, no timeout, no output. That rules out CI and scripts, and it meant nothing could test the scaffolder through its own entry point — the integration tests call `scaffold()` directly and skip `runInit` entirely, which is why this went unnoticed.

### What changed

Each value gets a flag, plus `--yes` / `-y` to take the default for anything not passed:

```bash
vttforge init pdf-character-sheet --type module --lang ts \
  --title "PDF Character Sheet" --license Apache-2.0 --yes
```

A run with no terminal assumes `--yes`, so CI needs no extra flag. `--type` defaults to `system` and `--lang` to `ts` — the same values their prompts already offered.

A flag-supplied value is held to the same validation the prompt applied, so `--id "Not A Valid Id"` fails rather than writing an id Foundry will reject.

The directory name is the one thing with no sensible default. Without a terminal to ask, the run stops and says which argument to pass.

### Coverage

`runInit` had no test at all — a new `init-non-interactive.test.ts` drives it with `stdin.isTTY` off, covering defaults, every flag, the id validation, the missing-name failure, and `--yes` overriding an attached terminal.

### The pin guard earned its keep

This changeset bumps `@vttforge/cli` to 0.5.0, and on a 0.x version a caret pins the minor — so the four templates' `^0.4.0` would have excluded it. That is the fifth time this drift has happened and the first time it was caught before merge rather than after. Pins updated to `^0.5.0`.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build` and knip pass.