### PR TITLE
feat(core): add registerModule for module document sub-types

### DIFF
--- a/.changeset/eighty-taxis-shave.md
+++ b/.changeset/eighty-taxis-shave.md
@@ -1,0 +1,16 @@
+---
+'@vttforge/core': minor
+---
+
+Add `registerModule()` for modules that contribute document sub-types.
+
+Foundry files a module's sub-type under `<module-id>.<type>`. Register the bare name and there is no error — the type just never appears. `registerModule()` adds the prefix, and `moduleSubType(id, type)` gives you the same string wherever else you need it (registering the sheet, checking `actor.type`, writing `documentTypes` in the manifest).
+
+```ts
+registerModule({
+  id: 'pdf-character-sheet',
+  itemDataModels: { pdf: PdfItemData }, // → CONFIG.Item.dataModels['pdf-character-sheet.pdf']
+});
+```
+
+`registerSystem()` was the only option before, and it is the wrong shape for a module: it writes bare keys and also replaces the document classes, the initiative formula, and the status-effect array — all of which belong to the system. There is no option to replace them here, and `statusEffects` appends instead of assigning.

--- a/packages/core/src/__tests__/register-module.test.ts
+++ b/packages/core/src/__tests__/register-module.test.ts
@@ -1,0 +1,136 @@
+/**
+ * A module contributing document sub-types.
+ *
+ * The prefix is the whole point. Foundry files a module's sub-type under
+ * `<module-id>.<type>`, and a module that registers the bare name gets no
+ * error — the type just never shows up. These cases pin the prefixing, and
+ * pin what a module is deliberately not allowed to do.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FoundryConfig } from '../foundry-globals.js';
+import {
+  _resetRegisteredModulesForTests,
+  moduleSubType,
+  registerModule,
+} from '../register-module.js';
+
+const MODULE_ID = 'pdf-character-sheet';
+
+class PdfItemData {}
+class PdfActorData {}
+
+let CONFIG: FoundryConfig;
+let initHooks: Array<() => void>;
+let readyHooks: Array<() => void>;
+
+beforeEach(() => {
+  _resetRegisteredModulesForTests();
+  initHooks = [];
+  readyHooks = [];
+  CONFIG = {
+    Actor: { dataModels: {}, documentClass: 'SystemActor' },
+    Item: { dataModels: {}, documentClass: 'SystemItem' },
+    Combat: { initiative: { formula: '1d20' } },
+    ActiveEffect: {},
+    statusEffects: [{ id: 'system.prone' }],
+  };
+  (globalThis as Record<string, unknown>).CONFIG = CONFIG;
+  (globalThis as Record<string, unknown>).Hooks = {
+    once: (event: string, fn: () => void) => {
+      if (event === 'init') initHooks.push(fn);
+      if (event === 'ready') readyHooks.push(fn);
+      return 0;
+    },
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).CONFIG;
+  delete (globalThis as Record<string, unknown>).Hooks;
+});
+
+const fireInit = () => {
+  for (const fn of initHooks) fn();
+};
+
+describe('moduleSubType', () => {
+  it('joins the module id and the bare type', () => {
+    expect(moduleSubType(MODULE_ID, 'pdf')).toBe('pdf-character-sheet.pdf');
+  });
+});
+
+describe('registerModule', () => {
+  it('files item sub-types under the prefixed key, not the bare one', () => {
+    registerModule({ id: MODULE_ID, itemDataModels: { pdf: PdfItemData } });
+    fireInit();
+
+    expect(CONFIG.Item.dataModels['pdf-character-sheet.pdf']).toBe(PdfItemData);
+    // The bare key is what a system would use. A module writing it gets no
+    // error from Foundry and no sub-type either.
+    expect(CONFIG.Item.dataModels.pdf).toBeUndefined();
+  });
+
+  it('does the same for actor sub-types', () => {
+    registerModule({ id: MODULE_ID, actorDataModels: { sheet: PdfActorData } });
+    fireInit();
+    expect(CONFIG.Actor.dataModels['pdf-character-sheet.sheet']).toBe(PdfActorData);
+  });
+
+  it('leaves the system document classes alone', () => {
+    registerModule({ id: MODULE_ID, itemDataModels: { pdf: PdfItemData } });
+    fireInit();
+    expect(CONFIG.Actor.documentClass).toBe('SystemActor');
+    expect(CONFIG.Item.documentClass).toBe('SystemItem');
+  });
+
+  it('leaves the initiative formula alone', () => {
+    registerModule({ id: MODULE_ID });
+    fireInit();
+    expect(CONFIG.Combat.initiative).toEqual({ formula: '1d20' });
+  });
+
+  it('appends status effects rather than replacing the array', () => {
+    // Replacing it would delete the system's own conditions.
+    registerModule({ id: MODULE_ID, statusEffects: [{ id: 'pdf-character-sheet.reading' }] });
+    fireInit();
+    expect(CONFIG.statusEffects).toEqual([
+      { id: 'system.prone' },
+      { id: 'pdf-character-sheet.reading' },
+    ]);
+  });
+
+  it('defers every mutation to the init hook', () => {
+    registerModule({ id: MODULE_ID, itemDataModels: { pdf: PdfItemData } });
+    expect(CONFIG.Item.dataModels).toEqual({});
+  });
+
+  it('runs onBeforeInit before the mutations and onAfterInit after', () => {
+    const order: string[] = [];
+    registerModule({
+      id: MODULE_ID,
+      itemDataModels: { pdf: PdfItemData },
+      onBeforeInit: () => order.push(`before:${Object.keys(CONFIG.Item.dataModels).length}`),
+      onAfterInit: () => order.push(`after:${Object.keys(CONFIG.Item.dataModels).length}`),
+    });
+    fireInit();
+    expect(order).toEqual(['before:0', 'after:1']);
+  });
+
+  it('runs onReady on the ready hook, not on init', () => {
+    const onReady = vi.fn();
+    registerModule({ id: MODULE_ID, onReady });
+    fireInit();
+    expect(onReady).not.toHaveBeenCalled();
+    for (const fn of readyHooks) fn();
+    expect(onReady).toHaveBeenCalledOnce();
+  });
+
+  it('refuses a second registration of the same id', () => {
+    registerModule({ id: MODULE_ID });
+    expect(() => registerModule({ id: MODULE_ID })).toThrow(/already registered/);
+  });
+
+  it('does not collide with a system of the same id', () => {
+    expect(() => registerModule({ id: 'shared-id' })).not.toThrow();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@
  * v0.1 surface:
  *
  *   - registerSystem()             — one-call init, replaces Hooks.once("init")
+ *   - registerModule()             — the same for modules, with namespaced sub-types
  *   - SystemConfig                 — typed wrapper around game.settings
  *   - BaseTypeDataModel()          — TypeDataModel with safe migrateData default
  *   - BaseActorSheet()             — ActorSheetV2 + HandlebarsApplicationMixin
@@ -103,5 +104,10 @@ export type {
   MigrationRunner,
   MigrationRunnerOptions,
 } from './migrations/types.js';
+export {
+  type ModuleRegistration,
+  moduleSubType,
+  registerModule,
+} from './register-module.js';
 export { registerSystem, type SystemRegistration } from './register-system.js';
 export { SystemConfig } from './system-config.js';

--- a/packages/core/src/register-module.ts
+++ b/packages/core/src/register-module.ts
@@ -1,0 +1,157 @@
+/**
+ * registerModule — the module counterpart to `registerSystem`.
+ *
+ * A module is a guest in someone else's world, and Foundry enforces that. The
+ * two differences that matter:
+ *
+ * - **Sub-type keys are namespaced.** A system registers `character`; a module
+ *   registering the same thing must register `<module-id>.character`, and the
+ *   manifest must declare it under `documentTypes`. Forget the prefix and the
+ *   type silently never appears. This function adds it for you.
+ * - **A module never owns the globals.** Document classes, the initiative
+ *   formula and the status-effect array belong to the system. So there is no
+ *   option here to replace them — `statusEffects` only appends, which is what
+ *   a module is allowed to do.
+ */
+
+import { VttfError, type VttfErrorCode } from './errors/registry.js';
+import type { FoundryConfig, HooksApi } from './foundry-globals.js';
+
+export interface ModuleRegistration {
+  /** Module id — must match the folder name and `module.json` `id`. */
+  readonly id: string;
+
+  /**
+   * Actor sub-types this module contributes, keyed by the bare type name.
+   * Registered under `<id>.<type>`, so declare them the same way in
+   * `documentTypes.Actor` in your manifest.
+   */
+  readonly actorDataModels?: Readonly<Record<string, unknown>>;
+
+  /** Item sub-types, same rule as `actorDataModels`. */
+  readonly itemDataModels?: Readonly<Record<string, unknown>>;
+
+  /**
+   * Status effects to append to `CONFIG.statusEffects`.
+   *
+   * Appended, never assigned: the array belongs to the system, and replacing
+   * it would delete conditions the world depends on.
+   */
+  readonly statusEffects?: readonly unknown[];
+
+  /** Runs before any CONFIG mutation — the usual home for the module API. */
+  readonly onBeforeInit?: () => void;
+
+  /** Runs after the mutations above, inside the same `init` hook. */
+  readonly onAfterInit?: () => void;
+
+  /**
+   * Runs once on `ready`.
+   *
+   * **Not GM-gated.** Guard inside your callback when the work is GM-only.
+   */
+  readonly onReady?: () => void | Promise<void>;
+}
+
+const registered = new Set<string>();
+
+/** For tests — clears the in-process "already registered" guard. */
+export function _resetRegisteredModulesForTests(): void {
+  registered.clear();
+}
+
+/**
+ * The key Foundry files a module's document sub-type under.
+ *
+ * Use it wherever you name the type outside `registerModule` — registering the
+ * sheet, checking `actor.type`, writing `documentTypes` in the manifest. The
+ * prefix is easy to get wrong by hand and fails silently when you do.
+ *
+ * @example
+ * ```ts
+ * moduleSubType('pdf-character-sheet', 'pdf'); // 'pdf-character-sheet.pdf'
+ * ```
+ */
+export function moduleSubType(moduleId: string, type: string): string {
+  return `${moduleId}.${type}`;
+}
+
+function vttfError(code: VttfErrorCode, message?: string): VttfError {
+  return new VttfError(code, message);
+}
+
+function readHooks(): HooksApi {
+  const hooks = (globalThis as Record<string, unknown>).Hooks as HooksApi | undefined;
+  if (hooks === undefined || typeof hooks.once !== 'function') {
+    throw vttfError(
+      'VTTF-0002',
+      'globalThis.Hooks is not available — call registerModule() inside a Foundry runtime or stub Hooks in tests',
+    );
+  }
+  return hooks;
+}
+
+function readConfig(): FoundryConfig {
+  const config = (globalThis as Record<string, unknown>).CONFIG as FoundryConfig | undefined;
+  if (config === undefined) {
+    throw vttfError(
+      'VTTF-0002',
+      'globalThis.CONFIG is not available — call registerModule() inside a Foundry runtime or stub CONFIG in tests',
+    );
+  }
+  return config;
+}
+
+function assignSubTypes(
+  target: Record<string, unknown>,
+  moduleId: string,
+  models: Readonly<Record<string, unknown>>,
+): void {
+  for (const [type, model] of Object.entries(models)) {
+    target[moduleSubType(moduleId, type)] = model;
+  }
+}
+
+/**
+ * Register a Foundry module with VTTForge.
+ *
+ * Calling twice with the same `id` throws VTTF-0001 — almost always a
+ * hot-reload artefact or a duplicate import. The CONFIG mutations are deferred
+ * until Foundry's `init` hook fires.
+ */
+export function registerModule(config: ModuleRegistration): ModuleRegistration {
+  if (registered.has(config.id)) {
+    throw vttfError('VTTF-0001', `Module "${config.id}" was already registered`);
+  }
+  registered.add(config.id);
+
+  const hooks = readHooks();
+  hooks.once('init', () => {
+    applyInit(config);
+  });
+  if (config.onReady !== undefined) {
+    hooks.once('ready', () => {
+      void config.onReady?.();
+    });
+  }
+
+  return config;
+}
+
+function applyInit(config: ModuleRegistration): void {
+  config.onBeforeInit?.();
+  const CONFIG = readConfig();
+
+  if (config.actorDataModels !== undefined) {
+    assignSubTypes(CONFIG.Actor.dataModels, config.id, config.actorDataModels);
+  }
+  if (config.itemDataModels !== undefined) {
+    assignSubTypes(CONFIG.Item.dataModels, config.id, config.itemDataModels);
+  }
+  if (config.statusEffects !== undefined && config.statusEffects.length > 0) {
+    CONFIG.statusEffects ??= [];
+    CONFIG.statusEffects.push(...config.statusEffects);
+  }
+
+  config.onAfterInit?.();
+}


### PR DESCRIPTION
The first gap the module port turned up.

Foundry files a module's document sub-type under `<module-id>.<type>`. A module that registers the bare name gets no error from Foundry — the type just never appears, which is a miserable thing to debug.

```ts
registerModule({
  id: 'pdf-character-sheet',
  itemDataModels: { pdf: PdfItemData }, // → CONFIG.Item.dataModels['pdf-character-sheet.pdf']
});
```

`moduleSubType(id, type)` returns the same string for everywhere else it is needed: registering the sheet, checking `actor.type`, writing `documentTypes` in the manifest.

### Why not just use registerSystem

It writes bare keys, so the sub-types would never register. It also assigns `CONFIG.Actor.documentClass`, `CONFIG.Item.documentClass`, `CONFIG.Combat.initiative`, and replaces `CONFIG.statusEffects` — every one of those belongs to the system, and a module overwriting them breaks the world it is a guest in.

So none of them are options here. `statusEffects` appends rather than assigns, which is what a module is allowed to do; tests pin that the system's own entries survive.

### Also verified along the way

pdf.js builds cleanly under `@vttforge/vite-plugin` with no SDK change: the worker is emitted unhashed to `dist/assets/pdf.worker.min.mjs` and the bundled URL resolves to `/modules/<id>/assets/pdf.worker.min.mjs`, the path Foundry serves. That was the one risk that could have forced a plugin change, and it did not.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build` and knip pass.