### PR TITLE
feat(core): type the statics on the sheet factories

### DIFF
--- a/.changeset/warm-schools-count.md
+++ b/.changeset/warm-schools-count.md
@@ -1,0 +1,9 @@
+---
+'@vttforge/core': minor
+---
+
+Type the statics on `BaseActorSheet()` and `BaseItemSheet()`.
+
+Both returned a bare constructor, so a subclass writing `super.DEFAULT_OPTIONS` — the pattern the docs show and every sheet needs — failed to compile. TypeScript cannot see a static through an untyped constructor. The example system is JavaScript, so nothing caught it.
+
+They now return `SheetBaseCtor`, which carries `DEFAULT_OPTIONS` and `DRAG_DROP`. A subclass declaring either needs the `override` modifier, which is TypeScript correctly seeing the inherited static.

--- a/packages/core/src/__tests__/base-actor-sheet.test.ts
+++ b/packages/core/src/__tests__/base-actor-sheet.test.ts
@@ -197,7 +197,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
   it('binds one DragDrop per static DRAG_DROP entry with default permissions and callbacks', () => {
     const Base = BaseActorSheet();
     class Sheet extends Base {
-      static DRAG_DROP: ReadonlyArray<DragDropConfig> = [
+      static override DRAG_DROP: ReadonlyArray<DragDropConfig> = [
         { dragSelector: '.item[draggable]' },
         { dropSelector: '.inventory' },
       ];
@@ -224,7 +224,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     const Base = BaseActorSheet();
     const customDrag = vi.fn();
     class Sheet extends Base {
-      static DRAG_DROP: ReadonlyArray<DragDropConfig> = [
+      static override DRAG_DROP: ReadonlyArray<DragDropConfig> = [
         {
           dragSelector: '.x',
           permissions: { dragstart: () => false, drop: () => false },
@@ -249,7 +249,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
   it('isEditable false locks dragstart and drop', () => {
     const Base = BaseActorSheet();
     class Sheet extends Base {
-      static DRAG_DROP: ReadonlyArray<DragDropConfig> = [{ dragSelector: '.item' }];
+      static override DRAG_DROP: ReadonlyArray<DragDropConfig> = [{ dragSelector: '.item' }];
     }
     const instance = new Sheet();
     (instance as { element: HTMLElement }).element = document.createElement('div');

--- a/packages/core/src/__tests__/base-item-sheet.test.ts
+++ b/packages/core/src/__tests__/base-item-sheet.test.ts
@@ -125,7 +125,7 @@ describe('BaseItemSheet', () => {
   it('binds DragDrop entries declared via static DRAG_DROP', () => {
     const Base = BaseItemSheet();
     class Sheet extends Base {
-      static DRAG_DROP = [{ dragSelector: '.item' }];
+      static override DRAG_DROP = [{ dragSelector: '.item' }];
     }
     const instance = new Sheet();
     (instance as { element: HTMLElement }).element = document.createElement('div');

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -51,6 +51,34 @@ export interface DragDropConfig {
   readonly callbacks?: Record<string, (...args: any[]) => unknown>;
 }
 
+/**
+ * The statics a VTTForge sheet base carries.
+ *
+ * The factory used to return a bare constructor, so a subclass writing
+ * `super.DEFAULT_OPTIONS` — the pattern the docs show and every sheet needs —
+ * failed to compile. TypeScript cannot see a static through an untyped
+ * constructor. The example system never caught it because it is JavaScript.
+ *
+ * `DEFAULT_OPTIONS` is deliberately loose: a subclass merges its own shape
+ * into it, and pinning ours would reject the merge.
+ */
+export interface SheetBaseStatics {
+  // biome-ignore lint/suspicious/noExplicitAny: a subclass merges arbitrary
+  // ApplicationV2 options into this; a narrower type would reject the merge.
+  readonly DEFAULT_OPTIONS: Record<string, any>;
+  readonly DRAG_DROP: ReadonlyArray<DragDropConfig>;
+}
+
+/**
+ * What the factory hands back: something you can `extend`, whose statics the
+ * compiler can see.
+ */
+export interface SheetBaseCtor extends SheetBaseStatics {
+  // biome-ignore lint/suspicious/noExplicitAny: mirrors ApplicationV2's own
+  // constructor arity, which subclasses pass straight through.
+  new (...args: any[]): any;
+}
+
 interface DragDropInstance {
   bind(element: HTMLElement): void;
 }
@@ -148,7 +176,7 @@ export const VTTFORGE_SHEET_CLASS = 'vttforge';
  * }
  * ```
  */
-export function BaseActorSheet(): AnyConstructor {
+export function BaseActorSheet(): SheetBaseCtor {
   const { Base, mixin } = resolveBases();
   const Mixed = mixin(Base);
 
@@ -357,5 +385,5 @@ export function BaseActorSheet(): AnyConstructor {
     }
   }
 
-  return VttforgeBaseActorSheet as unknown as AnyConstructor;
+  return VttforgeBaseActorSheet as unknown as SheetBaseCtor;
 }

--- a/packages/core/src/base-item-sheet.ts
+++ b/packages/core/src/base-item-sheet.ts
@@ -14,7 +14,7 @@
  * built-in on `DocumentSheetV2` (parent of `ItemSheetV2`).
  */
 
-import type { DragDropConfig } from './base-actor-sheet.js';
+import type { DragDropConfig, SheetBaseCtor } from './base-actor-sheet.js';
 import { VTTFORGE_SHEET_CLASS } from './base-actor-sheet.js';
 import { VttfError } from './errors/registry.js';
 
@@ -93,7 +93,7 @@ function resolveDragDrop(): DragDropCtor | undefined {
  * }
  * ```
  */
-export function BaseItemSheet(): AnyConstructor {
+export function BaseItemSheet(): SheetBaseCtor {
   const { Base, mixin } = resolveBases();
   const Mixed = mixin(Base);
 
@@ -198,5 +198,5 @@ export function BaseItemSheet(): AnyConstructor {
     }
   }
 
-  return VttforgeBaseItemSheet as unknown as AnyConstructor;
+  return VttforgeBaseItemSheet as unknown as SheetBaseCtor;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,8 @@ export const VTTFORGE_CORE_VERSION = '0.2.0';
 export {
   BaseActorSheet,
   type DragDropConfig,
+  type SheetBaseCtor,
+  type SheetBaseStatics,
   VTTFORGE_SHEET_CLASS,
 } from './base-actor-sheet.js';
 export { BaseItemSheet } from './base-item-sheet.js';


### PR DESCRIPTION
The second gap the module port turned up, on its very first sheet.

`BaseActorSheet()` and `BaseItemSheet()` both returned a bare constructor. So a subclass writing this — the pattern our own docs show, and what every real sheet needs — did not compile:

```ts
class PdfSheet extends BaseItemSheet() {
  static DEFAULT_OPTIONS = foundry.utils.mergeObject(super.DEFAULT_OPTIONS, { ... });
  //                                                 ^ Property 'DEFAULT_OPTIONS' does not exist
}
```

TypeScript cannot see a static through an untyped constructor. The example system is JavaScript and never typechecks, which is exactly why this survived.

Both now return `SheetBaseCtor`, carrying `DEFAULT_OPTIONS` and `DRAG_DROP`.

`DEFAULT_OPTIONS` is deliberately loose (`Record<string, any>`): a subclass merges its own ApplicationV2 options into it, and pinning our shape would reject the merge.

### Evidence the typing is real

Adding it immediately broke four subclasses in the existing sheet tests with `TS4114: This member must have an 'override' modifier` — the compiler seeing an inherited static it previously could not. Those got `override`, which is the correct declaration.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build` and knip pass.