### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every PR gets a default reviewer. Solo today, so this mostly documents
+# ownership for when someone else shows up.
+* @fcsouza


### PR DESCRIPTION
Now that the repo is public, incoming PRs get a default reviewer.

The main ruleset does not require code-owner review, so this changes nothing about how merging works today — it documents ownership for when contributors arrive.