### PR TITLE
feat(core): type the embedded fields and turn checkJs back on

### DIFF
--- a/.changeset/tall-donkeys-smile.md
+++ b/.changeset/tall-donkeys-smile.md
@@ -1,0 +1,11 @@
+---
+'@vttforge/core': minor
+---
+
+Type the three embedded fields, and turn `checkJs` back on for the example.
+
+- `EmbeddedDataField` is the model instance, not a plain object — the field builds a schema from the model's own `defineSchema()`, but initializing constructs the model, so derived data and methods come with it.
+- `EmbeddedDocumentField` is the same for a Document class, and nullable out of the box.
+- `TypedSchemaField` is a discriminated union. The field supplies a `type` string validated to equal each entry's key when the entry does not declare one, which is what makes narrowing on `type` work.
+
+The example system now compiles with `checkJs: true`, which is what proves any of this against real JavaScript rather than only against type tests.

--- a/examples/simple-system/scripts/foundry-globals.d.ts
+++ b/examples/simple-system/scripts/foundry-globals.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Minimal Foundry runtime globals for the example.
+ *
+ * `checkJs` is on here, which is the point: it compiles the example the way a
+ * consumer's own JavaScript gets compiled, so the SDK's inferred types are
+ * exercised against real code rather than only against type tests.
+ *
+ * These stubs are deliberately `any`. Typing the Foundry runtime is
+ * `@vttforge/types`' job; what this file exists to do is stop "Cannot find
+ * name 'game'" from drowning out the errors that actually matter.
+ */
+declare global {
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const game: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const CONFIG: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const Hooks: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const ui: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const ChatMessage: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const Roll: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const foundry: any;
+}
+
+export {};

--- a/examples/simple-system/scripts/migrations.mjs
+++ b/examples/simple-system/scripts/migrations.mjs
@@ -17,7 +17,7 @@ const SYSTEM_ID = 'vttforge-example';
  * survive the rename.
  */
 async function migrateToV0_1_0() {
-  const actors = game.actors?.filter((a) => a.type === 'character') ?? [];
+  const actors = game.actors?.filter(/** @param {any} a */ (a) => a.type === 'character') ?? [];
   for (const actor of actors) {
     const legacy = actor.system?.bio;
     if (typeof legacy !== 'string') continue;

--- a/examples/simple-system/scripts/sheets/character-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/character-sheet.mjs
@@ -21,6 +21,7 @@ import { BaseActorSheet } from '@vttforge/core';
 const SYSTEM_ID = 'vttforge-example';
 
 export class CharacterSheet extends BaseActorSheet() {
+  /** @override */
   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
     super.DEFAULT_OPTIONS,
     {
@@ -78,6 +79,7 @@ export class CharacterSheet extends BaseActorSheet() {
     },
   };
 
+  /** @override */
   static DRAG_DROP = [
     {
       dragSelector: '.sh-item[draggable=true]',
@@ -85,7 +87,10 @@ export class CharacterSheet extends BaseActorSheet() {
     },
   ];
 
-  /** @override */
+  /**
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<Record<string, unknown>>}
+   */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const actor = this.document;
@@ -103,21 +108,23 @@ export class CharacterSheet extends BaseActorSheet() {
     context.isEditable = this.isEditable;
     context.abilities = Object.entries(system.abilities ?? {}).map(([key, data]) => ({
       key,
-      label: game.i18n.localize(abilityLabels[key] ?? key),
+      label: game.i18n.localize(/** @type {Record<string, string>} */ (abilityLabels)[key] ?? key),
       value: data?.value ?? data,
       mod: data?.mod ?? 0,
     }));
     context.gear = actor.items
-      .filter((item) => item.type === 'gear')
-      .map((item) => ({
-        id: item.id,
-        name: item.name,
-        img: item.img,
-        kind: item.system?.kind ?? 'stowed',
-        quantity: item.system?.quantity ?? 1,
-        weight: item.system?.weight ?? 0,
-        description: item.system?.description ?? '',
-      }));
+      .filter(/** @param {any} item */ (item) => item.type === 'gear')
+      .map(
+        /** @param {any} item */ (item) => ({
+          id: item.id,
+          name: item.name,
+          img: item.img,
+          kind: item.system?.kind ?? 'stowed',
+          quantity: item.system?.quantity ?? 1,
+          weight: item.system?.weight ?? 0,
+          description: item.system?.description ?? '',
+        }),
+      );
     context.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
       system.biography ?? '',
       { relativeTo: actor, secrets: actor.isOwner },
@@ -126,6 +133,10 @@ export class CharacterSheet extends BaseActorSheet() {
   }
 
   /** Reject non-gear drops with a notification; let gear fall through to Foundry. */
+  /**
+   * @param {any} item
+   * @param {any} _event
+   */
   async onDropItem(item, _event) {
     if (item?.type !== 'gear') {
       ui.notifications?.warn(
@@ -136,6 +147,12 @@ export class CharacterSheet extends BaseActorSheet() {
     return undefined;
   }
 
+  /**
+   * @this {CharacterSheet} ApplicationV2 declares action handlers static but
+   *   calls them with `this` bound to the sheet instance.
+   * @param {any} _event
+   * @param {any} target
+   */
   static async _onRollAbility(_event, target) {
     const key = target?.dataset?.ability;
     if (!key) return;
@@ -152,6 +169,11 @@ export class CharacterSheet extends BaseActorSheet() {
     });
   }
 
+  /**
+   * @this {CharacterSheet} Bound to the sheet instance, not the class.
+   * @param {any} _event
+   * @param {any} _target
+   */
   static async _onCreateGear(_event, _target) {
     const cls = CONFIG.Item.documentClass;
     // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
@@ -162,6 +184,11 @@ export class CharacterSheet extends BaseActorSheet() {
     );
   }
 
+  /**
+   * @this {CharacterSheet} Bound to the sheet instance, not the class.
+   * @param {any} _event
+   * @param {any} target
+   */
   static async _onDeleteItem(_event, target) {
     const row = target?.closest('[data-item-id]');
     const id = row?.dataset?.itemId;

--- a/examples/simple-system/scripts/sheets/gear-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/gear-sheet.mjs
@@ -11,6 +11,7 @@ import { BaseItemSheet } from '@vttforge/core';
 const SYSTEM_ID = 'vttforge-example';
 
 export class GearSheet extends BaseItemSheet() {
+  /** @override */
   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
     super.DEFAULT_OPTIONS,
     {
@@ -51,7 +52,10 @@ export class GearSheet extends BaseItemSheet() {
     },
   };
 
-  /** @override */
+  /**
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<Record<string, unknown>>}
+   */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const item = this.document;

--- a/examples/simple-system/tsconfig.json
+++ b/examples/simple-system/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
-    "checkJs": false,
+    "checkJs": true,
     "noEmit": true
   },
   "include": ["scripts/**/*"],

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.6.0"
+    "@vttforge/core": "^0.7.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.6.0"
+    "@vttforge/core": "^0.7.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.6.0",
+    "@vttforge/core": "^0.7.0",
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.6.0",
+    "@vttforge/core": "^0.7.0",
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/infer-schema.test.ts
+++ b/packages/core/src/__tests__/infer-schema.test.ts
@@ -4,6 +4,8 @@ import {
   type ArrayFieldInstance,
   type BooleanFieldInstance,
   type ColorFieldInstance,
+  type EmbeddedDataFieldInstance,
+  type EmbeddedDocumentFieldInstance,
   type FilePathFieldInstance,
   type ForeignDocumentFieldInstance,
   fields,
@@ -12,6 +14,7 @@ import {
   type SchemaFieldInstance,
   type SetFieldInstance,
   type StringFieldInstance,
+  type TypedSchemaFieldInstance,
 } from '../data/fields.js';
 import type { InferField, InferSchema } from '../data/infer-schema.js';
 import { VttfError } from '../errors/registry.js';
@@ -26,6 +29,9 @@ class FakeArrayField {}
 class FakeSetField {}
 class FakeForeignDocumentField {}
 class FakeSchemaField {}
+class FakeEmbeddedDataField {}
+class FakeEmbeddedDocumentField {}
+class FakeTypedSchemaField {}
 
 /** Stands in for a document class in the reference-field cases. */
 declare class FakeActor {
@@ -37,6 +43,13 @@ declare class FakeActor {
  * arguments, and an overload. The `DocumentClass` bound has to accept these
  * or it only works against the synthetic case above.
  */
+/** A nested data model: schema value plus something derived from it. */
+declare class Wounds {
+  readonly value: number;
+  /** Derived, so it exists on the instance but not in the schema. */
+  readonly isBleeding: boolean;
+}
+
 declare class FakeItem {
   constructor(data: { name: string }, context?: { parent?: FakeActor });
   readonly name: string;
@@ -57,6 +70,9 @@ beforeEach(() => {
         SetField: FakeSetField,
         ForeignDocumentField: FakeForeignDocumentField,
         SchemaField: FakeSchemaField,
+        EmbeddedDataField: FakeEmbeddedDataField,
+        EmbeddedDocumentField: FakeEmbeddedDocumentField,
+        TypedSchemaField: FakeTypedSchemaField,
       },
     },
   };
@@ -89,6 +105,9 @@ describe('fields()', () => {
     expect(f.SetField).toBe(FakeSetField);
     expect(f.ForeignDocumentField).toBe(FakeForeignDocumentField);
     expect(f.SchemaField).toBe(FakeSchemaField);
+    expect(f.EmbeddedDataField).toBe(FakeEmbeddedDataField);
+    expect(f.EmbeddedDocumentField).toBe(FakeEmbeddedDocumentField);
+    expect(f.TypedSchemaField).toBe(FakeTypedSchemaField);
   });
 });
 
@@ -358,5 +377,64 @@ describe('DocumentClass — the bound accepts real document shapes', () => {
     type T = InferField<ForeignDocumentFieldInstance<typeof FakeItem, { nullable: false }>>;
     expectTypeOf<T>().toHaveProperty('parent');
     expectTypeOf<T>().not.toEqualTypeOf<typeof FakeItem>();
+  });
+});
+
+describe('InferField<F> — embedded models', () => {
+  it('EmbeddedDataField is the model instance, not a plain object', () => {
+    // The field builds a SchemaField from the model's own defineSchema, but
+    // initialize constructs the model — so derived data and methods are there.
+    type T = InferField<EmbeddedDataFieldInstance<typeof Wounds>>;
+    expectTypeOf<T>().toEqualTypeOf<Wounds>();
+    expectTypeOf<T>().toHaveProperty('isBleeding');
+  });
+
+  it('EmbeddedDataField is required, so it is never absent', () => {
+    expectTypeOf<InferField<EmbeddedDataFieldInstance<typeof Wounds>>>().not.toEqualTypeOf<
+      Wounds | undefined
+    >();
+  });
+
+  it('EmbeddedDocumentField is nullable out of the box', () => {
+    type T = InferField<EmbeddedDocumentFieldInstance<typeof Wounds>>;
+    expectTypeOf<T>().toEqualTypeOf<Wounds | null>();
+  });
+
+  it('EmbeddedDocumentField drops the null when the schema says so', () => {
+    type T = InferField<EmbeddedDocumentFieldInstance<typeof Wounds, { nullable: false }>>;
+    expectTypeOf<T>().toEqualTypeOf<Wounds>();
+  });
+});
+
+describe('InferField<F> — TypedSchemaField', () => {
+  type Str = StringFieldInstance<{ required: true }>;
+  type Num = NumberFieldInstance<{ required: true; nullable: false; initial: 0 }>;
+
+  type Attack = TypedSchemaFieldInstance<{
+    melee: { reach: Num };
+    ranged: { range: Num; ammo: Str };
+  }>;
+
+  it('is a union of one shape per entry', () => {
+    expectTypeOf<InferField<Attack>>().toEqualTypeOf<
+      { reach: number; type: 'melee' } | { range: number; ammo: string; type: 'ranged' }
+    >();
+  });
+
+  it('carries the key as the discriminant, so narrowing works', () => {
+    // The field adds a `type` string validated to equal the key when the
+    // entry does not declare one. That is what makes this narrowable.
+    const attack = {} as InferField<Attack>;
+    if (attack.type === 'ranged') {
+      expectTypeOf(attack.ammo).toEqualTypeOf<string>();
+    } else {
+      expectTypeOf(attack.reach).toEqualTypeOf<number>();
+    }
+  });
+
+  it('is required, so it is never absent', () => {
+    expectTypeOf<InferField<Attack>>().not.toEqualTypeOf<
+      { reach: number; type: 'melee' } | undefined
+    >();
   });
 });

--- a/packages/core/src/data/field-options.ts
+++ b/packages/core/src/data/field-options.ts
@@ -78,3 +78,12 @@ export interface ForeignDocumentFieldOptions extends DataFieldOptions {
    */
   readonly idOnly?: boolean;
 }
+
+/** `EmbeddedDataField` builds a SchemaField from the model's own schema. */
+export type EmbeddedDataFieldOptions = SchemaFieldOptions;
+
+/** `EmbeddedDocumentField` is the same, but nullable out of the box. */
+export type EmbeddedDocumentFieldOptions = SchemaFieldOptions;
+
+/** `TypedSchemaField` is required by default and takes no options of its own. */
+export type TypedSchemaFieldOptions = DataFieldOptions;

--- a/packages/core/src/data/fields.ts
+++ b/packages/core/src/data/fields.ts
@@ -23,6 +23,8 @@ import type {
   ArrayFieldOptions,
   BooleanFieldOptions,
   ColorFieldOptions,
+  EmbeddedDataFieldOptions,
+  EmbeddedDocumentFieldOptions,
   FilePathFieldOptions,
   ForeignDocumentFieldOptions,
   HTMLFieldOptions,
@@ -30,6 +32,7 @@ import type {
   SchemaFieldOptions,
   SetFieldOptions,
   StringFieldOptions,
+  TypedSchemaFieldOptions,
 } from './field-options.js';
 
 declare const BRAND: unique symbol;
@@ -125,6 +128,57 @@ export interface ForeignDocumentFieldInstance<
   readonly options: O;
 }
 
+/**
+ * A nested data model.
+ *
+ * It is a `SchemaField` built from the model class's own `defineSchema()`, so
+ * the value is an instance of that model — not a plain object. Reading it
+ * gives you the model's derived data and methods too.
+ */
+export interface EmbeddedDataFieldInstance<
+  Model extends DataModelClass = DataModelClass,
+  O extends EmbeddedDataFieldOptions = EmbeddedDataFieldOptions,
+> extends FieldInstance {
+  readonly [BRAND]: 'embeddedData';
+  readonly model: Model;
+  readonly options: O;
+}
+
+/**
+ * A single embedded document, stored inline.
+ *
+ * Like `EmbeddedDataField` but for a Document class, and nullable by default:
+ * the field's own defaults turn `nullable` on, so an absent one reads `null`.
+ */
+export interface EmbeddedDocumentFieldInstance<
+  Doc extends DataModelClass = DataModelClass,
+  O extends EmbeddedDocumentFieldOptions = EmbeddedDocumentFieldOptions,
+> extends FieldInstance {
+  readonly [BRAND]: 'embeddedDocument';
+  readonly model: Doc;
+  readonly options: O;
+}
+
+/**
+ * One of several shapes, told apart by a `type` property.
+ *
+ * Each entry becomes its own SchemaField. When an entry does not declare a
+ * `type` field, the field adds one — a required string whose value must equal
+ * that entry's key — which is what makes the result a discriminated union you
+ * can narrow on.
+ */
+export interface TypedSchemaFieldInstance<
+  T extends Record<string, Record<string, FieldInstance>> = Record<
+    string,
+    Record<string, FieldInstance>
+  >,
+  O extends TypedSchemaFieldOptions = TypedSchemaFieldOptions,
+> extends FieldInstance {
+  readonly [BRAND]: 'typedSchema';
+  readonly types: T;
+  readonly options: O;
+}
+
 export interface SchemaFieldInstance<
   S extends Record<string, FieldInstance> = Record<string, FieldInstance>,
   O extends SchemaFieldOptions = SchemaFieldOptions,
@@ -191,6 +245,38 @@ export interface ForeignDocumentFieldCtor {
   ): ForeignDocumentFieldInstance<Doc, O>;
 }
 
+/** Any DataModel subclass — what the embedded fields take as their type. */
+// biome-ignore lint/suspicious/noExplicitAny: a constructor bound must accept
+// the argument list of whatever model class the caller passes.
+export type DataModelClass = abstract new (...args: any[]) => object;
+
+export interface EmbeddedDataFieldCtor {
+  new <Model extends DataModelClass, O extends EmbeddedDataFieldOptions = EmbeddedDataFieldOptions>(
+    model: Model,
+    options?: O,
+  ): EmbeddedDataFieldInstance<Model, O>;
+}
+
+export interface EmbeddedDocumentFieldCtor {
+  new <
+    Doc extends DataModelClass,
+    O extends EmbeddedDocumentFieldOptions = EmbeddedDocumentFieldOptions,
+  >(
+    model: Doc,
+    options?: O,
+  ): EmbeddedDocumentFieldInstance<Doc, O>;
+}
+
+export interface TypedSchemaFieldCtor {
+  new <
+    T extends Record<string, Record<string, FieldInstance>>,
+    O extends TypedSchemaFieldOptions = TypedSchemaFieldOptions,
+  >(
+    types: T,
+    options?: O,
+  ): TypedSchemaFieldInstance<T, O>;
+}
+
 export interface SchemaFieldCtor {
   new <S extends Record<string, FieldInstance>, O extends SchemaFieldOptions = SchemaFieldOptions>(
     fields: S,
@@ -214,6 +300,9 @@ export interface FieldsApi {
   readonly SetField: SetFieldCtor;
   readonly ForeignDocumentField: ForeignDocumentFieldCtor;
   readonly SchemaField: SchemaFieldCtor;
+  readonly EmbeddedDataField: EmbeddedDataFieldCtor;
+  readonly EmbeddedDocumentField: EmbeddedDocumentFieldCtor;
+  readonly TypedSchemaField: TypedSchemaFieldCtor;
 }
 
 interface FoundryDataNamespace {

--- a/packages/core/src/data/fields.ts
+++ b/packages/core/src/data/fields.ts
@@ -246,9 +246,7 @@ export interface ForeignDocumentFieldCtor {
 }
 
 /** Any DataModel subclass — what the embedded fields take as their type. */
-// biome-ignore lint/suspicious/noExplicitAny: a constructor bound must accept
-// the argument list of whatever model class the caller passes.
-export type DataModelClass = abstract new (...args: any[]) => object;
+export type DataModelClass = abstract new (...args: never[]) => object;
 
 export interface EmbeddedDataFieldCtor {
   new <Model extends DataModelClass, O extends EmbeddedDataFieldOptions = EmbeddedDataFieldOptions>(

--- a/packages/core/src/data/infer-schema.ts
+++ b/packages/core/src/data/infer-schema.ts
@@ -22,7 +22,6 @@ import type {
   ArrayFieldInstance,
   BooleanFieldInstance,
   ColorFieldInstance,
-  DataModelClass,
   DocumentClass,
   EmbeddedDataFieldInstance,
   EmbeddedDocumentFieldInstance,

--- a/packages/core/src/data/infer-schema.ts
+++ b/packages/core/src/data/infer-schema.ts
@@ -22,7 +22,10 @@ import type {
   ArrayFieldInstance,
   BooleanFieldInstance,
   ColorFieldInstance,
+  DataModelClass,
   DocumentClass,
+  EmbeddedDataFieldInstance,
+  EmbeddedDocumentFieldInstance,
   FieldInstance,
   FilePathFieldInstance,
   ForeignDocumentFieldInstance,
@@ -31,6 +34,7 @@ import type {
   SchemaFieldInstance,
   SetFieldInstance,
   StringFieldInstance,
+  TypedSchemaFieldInstance,
 } from './fields.js';
 
 /**
@@ -150,6 +154,18 @@ type ForeignDocumentValue<Doc extends DocumentClass, O> = Presence<
 >;
 
 /**
+ * What a `TypedSchemaField` holds: one shape per entry, each carrying the
+ * key it was filed under as its `type`.
+ *
+ * The field supplies that `type` when an entry does not declare one — a
+ * required string validated to equal the key — so narrowing on `type` picks
+ * exactly one branch.
+ */
+type TypedSchemaValue<T extends Record<string, Record<string, FieldInstance>>> = {
+  [K in keyof T]: Prettify<InferSchema<T[K]> & { type: K }>;
+}[keyof T];
+
+/**
  * Map a single field instance to its runtime TypeScript type. `never` for
  * shapes we don't recognise — the v1.0 `@vttforge/types` package will widen
  * this matrix to the remaining Foundry fields.
@@ -175,7 +191,13 @@ export type InferField<F> =
                     ? Presence<O, Set<InferField<Inner>>, ContainerDefaults>
                     : F extends SchemaFieldInstance<infer S, infer O>
                       ? Presence<O, InferSchema<S>, ContainerDefaults>
-                      : never;
+                      : F extends EmbeddedDocumentFieldInstance<infer Doc, infer O>
+                        ? Presence<O, InstanceType<Doc>, ReferenceDefaults>
+                        : F extends EmbeddedDataFieldInstance<infer Model, infer O>
+                          ? Presence<O, InstanceType<Model>, ContainerDefaults>
+                          : F extends TypedSchemaFieldInstance<infer T, infer O>
+                            ? Presence<O, TypedSchemaValue<T>, ContainerDefaults>
+                            : never;
 
 /**
  * Map a `defineSchema()` return value to the corresponding `system` shape.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,8 @@ export type {
   BooleanFieldOptions,
   ColorFieldOptions,
   DataFieldOptions,
+  EmbeddedDataFieldOptions,
+  EmbeddedDocumentFieldOptions,
   FilePathFieldOptions,
   ForeignDocumentFieldOptions,
   HTMLFieldOptions,
@@ -47,6 +49,7 @@ export type {
   SchemaFieldOptions,
   SetFieldOptions,
   StringFieldOptions,
+  TypedSchemaFieldOptions,
 } from './data/field-options.js';
 export {
   type ArrayFieldCtor,
@@ -55,7 +58,12 @@ export {
   type BooleanFieldInstance,
   type ColorFieldCtor,
   type ColorFieldInstance,
+  type DataModelClass,
   type DocumentClass,
+  type EmbeddedDataFieldCtor,
+  type EmbeddedDataFieldInstance,
+  type EmbeddedDocumentFieldCtor,
+  type EmbeddedDocumentFieldInstance,
   type FieldInstance,
   type FieldsApi,
   type FilePathFieldCtor,
@@ -73,6 +81,8 @@ export {
   type SetFieldInstance,
   type StringFieldCtor,
   type StringFieldInstance,
+  type TypedSchemaFieldCtor,
+  type TypedSchemaFieldInstance,
 } from './data/fields.js';
 export type { InferField, InferSchema, Prettify } from './data/infer-schema.js';
 export {


### PR DESCRIPTION
Closes the field work on the types track, and re-enables the check that proves it.

### The three fields

- **EmbeddedDataField** is the model instance, not a plain object. The field builds a schema from the model's own `defineSchema()`, but initializing constructs the model — so derived data and methods come with it.
- **EmbeddedDocumentField** is the same for a Document class, and nullable out of the box.
- **TypedSchemaField** is a discriminated union. When an entry does not declare a `type`, the field adds one: a required string validated to equal that entry's key. That is what makes narrowing on `type` pick exactly one branch, and there is a test that narrows.

Each new assertion was broken on purpose and confirmed to fail — embedded data collapsing to a plain object, the document field losing its `null`, the union losing its discriminant.

### checkJs: 41 errors to 0

This is the item the whole track was for. The example now compiles the way a consumer's JavaScript does, so the inferred types meet real code instead of only type tests. The errors were worth reading:

- The example never declared the Foundry globals, so most of the noise was "Cannot find name 'game'". It now has the same stub the templates ship.
- **ApplicationV2 declares action handlers `static` but calls them with `this` bound to the sheet instance.** Three handlers read `this.document` and nothing had ever said that was legal. They carry `@this` now — this is the trap a consumer hits first.
- Several callbacks took untyped parameters, and the ability-label lookup indexed a six-key object with a plain string.

### The pin guard, sixth time

A minor bump on `@vttforge/core` put `^0.6.0` out of range. Caught before merge; pins are at `^0.7.0`.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build` and knip pass.
