### PR TITLE
ci: publish from a github-hosted runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,12 @@ concurrency:
 jobs:
   publish:
     name: Verify + publish (OIDC)
-    runs-on: [self-hosted, linux, x64, gcp]
+    # GitHub-hosted on purpose, unlike CI. npm attaches sigstore provenance to
+    # public packages and refuses it from a self-hosted runner — only
+    # github-hosted ones are accepted. This surfaced the moment the repository
+    # went public: while it was private, pnpm could not determine visibility
+    # and skipped provenance, so the self-hosted runner worked by accident.
+    runs-on: ubuntu-latest
     environment: npm-publish
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The first publish after the repository went public failed:

    422 Unprocessable Entity - Error verifying sigstore provenance bundle:
    Unsupported GitHub Actions runner environment: "self-hosted".
    Only "github-hosted" runners are supported when publishing with provenance.

npm attaches provenance to public packages, and it will only accept it from a github-hosted runner.

The interesting part is why this worked before. While the repository was private, pnpm logged `Skipped setting provenance: the environment does not provide enough information to determine visibility` and published without it. The self-hosted runner was working by accident, and going public removed the accident.

Only the publish job moves. CI stays on the self-hosted runners.