### PR TITLE
feat(core): add BaseApplication for plain ApplicationV2 windows

### DIFF
--- a/.changeset/lazy-hounds-wave.md
+++ b/.changeset/lazy-hounds-wave.md
@@ -1,0 +1,12 @@
+---
+'@vttforge/core': minor
+---
+
+`BaseApplication` — a plain `ApplicationV2` window without the two traps.
+
+The document sheets already had a baseline. Everything else a package puts on screen — a config dialog, a picker, a reader — is a bare `ApplicationV2`, and writing one by hand means meeting both of these:
+
+- **`_replaceHTML` is easy to forget.** ApplicationV2 splits rendering in two, and implementing only `_renderHTML` leaves the class silently unrenderable. Foundry reports it at the moment something tries to open the window, as an error about abstract methods. Nearly every implementation of the second half is the same line, so this ships it.
+- **A missing `_renderHTML` fails late.** This checks at construction and names the class, so it fails where the class is used rather than deep inside a render.
+
+Both were met while porting a real module onto the SDK.

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.7.0"
+    "@vttforge/core": "^0.8.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.7.0"
+    "@vttforge/core": "^0.8.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.7.0",
+    "@vttforge/core": "^0.8.0",
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.7.0",
+    "@vttforge/core": "^0.8.0",
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/base-application.test.ts
+++ b/packages/core/src/__tests__/base-application.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+/**
+ * BaseApplication exists because of two traps in raw ApplicationV2, and the
+ * cases that matter are the ones that prove each trap is gone.
+ *
+ * Both were met for real while porting a module onto the SDK: a viewer class
+ * that declared only `_renderHTML` rendered nothing and reported it as
+ * "the class is not renderable", pointing at Foundry rather than at the line
+ * that was wrong.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BaseApplication } from '../base-application.js';
+import { VttfError } from '../errors/registry.js';
+
+class FakeApplicationV2 {
+  // biome-ignore lint/suspicious/noExplicitAny: stands in for Foundry's own constructor
+  constructor(..._args: any[]) {}
+}
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).foundry = {
+    applications: { api: { ApplicationV2: FakeApplicationV2 } },
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).foundry;
+});
+
+describe('BaseApplication', () => {
+  it('throws VTTF-0002 when ApplicationV2 is missing', () => {
+    delete (globalThis as Record<string, unknown>).foundry;
+    expect(() => BaseApplication()).toThrow(VttfError);
+  });
+
+  it('ships _replaceHTML, the half that is easy to forget', () => {
+    class Window extends BaseApplication() {
+      _renderHTML() {
+        return document.createElement('div');
+      }
+    }
+    const app = new Window();
+    const content = document.createElement('section');
+    content.appendChild(document.createElement('span'));
+
+    const rendered = document.createElement('p');
+    app._replaceHTML(rendered, content);
+
+    expect([...content.children]).toEqual([rendered]);
+  });
+
+  it('lets a subclass replace _replaceHTML for in-place updates', () => {
+    class Window extends BaseApplication() {
+      _renderHTML() {
+        return document.createElement('div');
+      }
+      // No `override` keyword: the factory returns an untyped constructor,
+      // so TypeScript cannot see the member being replaced. That is the next
+      // thing a typed base would fix.
+      _replaceHTML(result: HTMLElement, content: HTMLElement): void {
+        content.append(result);
+      }
+    }
+    const app = new Window();
+    const content = document.createElement('section');
+    const first = document.createElement('p');
+    content.appendChild(first);
+
+    app._replaceHTML(document.createElement('p'), content);
+    // Appended, not swapped: the original child survives.
+    expect(content.children.length).toBe(2);
+    expect(content.firstElementChild).toBe(first);
+  });
+
+  it('fails at construction when _renderHTML is missing', () => {
+    // Foundry reports this on first render, which means a user clicks
+    // something and gets an error about abstract methods. Failing here points
+    // at the class instead.
+    class Broken extends BaseApplication() {}
+    expect(() => new Broken()).toThrow(VttfError);
+    expect(() => new Broken()).toThrow(/_renderHTML/);
+  });
+
+  it('names the offending class in the message', () => {
+    class PdfConfig extends BaseApplication() {}
+    expect(() => new PdfConfig()).toThrow(/PdfConfig/);
+  });
+});

--- a/packages/core/src/base-application.ts
+++ b/packages/core/src/base-application.ts
@@ -1,0 +1,91 @@
+/**
+ * BaseApplication — a plain `ApplicationV2` window, minus the two traps.
+ *
+ * The document sheets are covered by `BaseActorSheet` and `BaseItemSheet`.
+ * Everything else a package puts on screen — a config dialog, a picker, a
+ * reader window — is a bare `ApplicationV2`, and writing one by hand means
+ * meeting both of these:
+ *
+ * **`_replaceHTML` is easy to forget.** ApplicationV2 splits rendering in two:
+ * `_renderHTML` builds the content and `_replaceHTML` puts it in the window.
+ * Implement only the first and the class is silently unrenderable — Foundry
+ * says so at the moment something tries to open it, not when it is defined.
+ * Nearly every implementation of the second is the same line, so this ships
+ * it. Override it when the window updates in place instead of wholesale.
+ *
+ * **A missing `_renderHTML` fails late.** Foundry's own check fires on first
+ * render, which in practice means a user clicks something and gets an error
+ * about abstract methods. This checks at construction, so it fails where the
+ * class is used rather than deep inside a render.
+ */
+
+import { VttfError } from './errors/registry.js';
+
+// biome-ignore lint/suspicious/noExplicitAny: Foundry's ApplicationV2 shape lives in fvtt-types (deferred to @vttforge/types v1.0)
+type AnyConstructor = new (...args: any[]) => any;
+
+interface FoundryApplicationsApi {
+  ApplicationV2?: AnyConstructor;
+}
+
+interface FoundryRoot {
+  readonly applications?: { readonly api?: FoundryApplicationsApi };
+}
+
+function resolveApplicationV2(): AnyConstructor {
+  const foundry = (globalThis as Record<string, unknown>).foundry as FoundryRoot | undefined;
+  const cls = foundry?.applications?.api?.ApplicationV2;
+  if (typeof cls !== 'function') {
+    throw new VttfError(
+      'VTTF-0002',
+      'foundry.applications.api.ApplicationV2 is not available. Define your BaseApplication subclasses inside the Foundry runtime (or stub the global in tests).',
+    );
+  }
+  return cls;
+}
+
+/**
+ * Build an `ApplicationV2` base with the rendering contract filled in.
+ *
+ * ```ts
+ * class PdfConfig extends BaseApplication() {
+ *   async _renderHTML() {
+ *     const form = document.createElement('form');
+ *     // …
+ *     return form;
+ *   }
+ * }
+ * ```
+ *
+ * `_replaceHTML` is provided. `_renderHTML` is yours, and omitting it throws
+ * when the class is constructed rather than when someone opens the window.
+ */
+export function BaseApplication(): AnyConstructor {
+  const Base = resolveApplicationV2();
+
+  class VttforgeBaseApplication extends Base {
+    // biome-ignore lint/suspicious/noExplicitAny: forwards Foundry's own constructor arity
+    constructor(...args: any[]) {
+      super(...args);
+      if (typeof (this as { _renderHTML?: unknown })._renderHTML !== 'function') {
+        throw new VttfError(
+          'VTTF-0002',
+          `${this.constructor.name} extends BaseApplication but does not implement _renderHTML. ApplicationV2 cannot render without it.`,
+        );
+      }
+    }
+
+    /**
+     * Put the rendered content in the window.
+     *
+     * The whole-content swap, which is what almost every window wants.
+     * Override to update in place — a viewer that keeps scroll position
+     * across a page turn, say.
+     */
+    _replaceHTML(result: HTMLElement, content: HTMLElement): void {
+      content.replaceChildren(result);
+    }
+  }
+
+  return VttforgeBaseApplication as unknown as AnyConstructor;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export {
   type SheetBaseStatics,
   VTTFORGE_SHEET_CLASS,
 } from './base-actor-sheet.js';
+export { BaseApplication } from './base-application.js';
 export { BaseItemSheet } from './base-item-sheet.js';
 export {
   BaseTypeDataModel,


### PR DESCRIPTION
Found by using the SDK rather than by reading it.

The document sheets have `BaseActorSheet` and `BaseItemSheet`. Everything else a package puts on screen — a config dialog, a picker, a reader window — is a bare `ApplicationV2`, and there was no baseline for it. Porting a module onto the SDK meant writing four of them by hand, and hitting the same two traps each time.

**`_replaceHTML` is easy to forget.** ApplicationV2 splits rendering in two: `_renderHTML` builds the content, `_replaceHTML` puts it in the window. Implement only the first and the class is silently unrenderable. Foundry reports it at the moment something tries to open the window, and the message is about abstract methods — it points at Foundry, not at the line that is wrong. Nearly every implementation of the second half is `content.replaceChildren(result)`, so this ships it, overridable for windows that update in place.

**A missing `_renderHTML` fails late** for the same reason. This checks at construction and names the offending class.

### A gap this surfaced but does not close

Every base factory in `core` returns `AnyConstructor`, which is `any`. A subclass cannot use `override`, and in the ported module `socket.ts` called `url` and `goToPage` on a viewer that had neither with the compiler silent. Typing these return values is `@vttforge/types`' job; recorded rather than fixed here.

### The pin guard, seventh time

Second time it caught the drift before merge rather than after.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build` and knip pass.
