### PR TITLE
feat(core): make the base factories report what they add

### DIFF
--- a/.changeset/witty-donkeys-shave.md
+++ b/.changeset/witty-donkeys-shave.md
@@ -1,0 +1,13 @@
+---
+'@vttforge/core': minor
+---
+
+The base factories now report what they add.
+
+Every `Base*` factory returned `any`, which gave up on two things at once: a subclass could not write `override` on a member it really was overriding, and a call to a method that does not exist passed silently. Both happened while porting a real module onto the SDK — the second one shipped a broken call into a release.
+
+They now return the members they contribute, with the rest of the Foundry surface reachable through an index signature. A property the SDK knows about carries its real type; anything else behaves as before.
+
+This will surface `override` errors in subclasses that were previously allowed to omit the keyword. That is the point: TypeScript can see the member now.
+
+The index signature is what `@vttforge/types` replaces when it lands.

--- a/examples/simple-system/scripts/data/character-data.mjs
+++ b/examples/simple-system/scripts/data/character-data.mjs
@@ -85,6 +85,7 @@ export class CharacterData extends BaseTypeDataModel() {
     };
   }
 
+  /** @override */
   prepareDerivedData() {
     for (const [key, value] of Object.entries(this.abilities)) {
       const score = typeof value === 'number' ? value : (value?.value ?? 10);

--- a/examples/simple-system/scripts/sheets/character-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/character-sheet.mjs
@@ -88,6 +88,7 @@ export class CharacterSheet extends BaseActorSheet() {
   ];
 
   /**
+   * @override
    * @param {Record<string, unknown>} options
    * @returns {Promise<Record<string, unknown>>}
    */
@@ -134,6 +135,7 @@ export class CharacterSheet extends BaseActorSheet() {
 
   /** Reject non-gear drops with a notification; let gear fall through to Foundry. */
   /**
+   * @override
    * @param {any} item
    * @param {any} _event
    */

--- a/examples/simple-system/scripts/sheets/gear-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/gear-sheet.mjs
@@ -53,6 +53,7 @@ export class GearSheet extends BaseItemSheet() {
   };
 
   /**
+   * @override
    * @param {Record<string, unknown>} options
    * @returns {Promise<Record<string, unknown>>}
    */

--- a/packages/core/src/__tests__/base-actor-sheet.test.ts
+++ b/packages/core/src/__tests__/base-actor-sheet.test.ts
@@ -189,7 +189,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
   it('does nothing when DRAG_DROP is empty', () => {
     const Sub = BaseActorSheet();
     const instance = new Sub();
-    (instance as { element: HTMLElement }).element = document.createElement('div');
+    instance.element = document.createElement('div');
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(0);
   });
@@ -204,8 +204,8 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     }
     const instance = new Sheet();
     const element = document.createElement('div');
-    (instance as { element: HTMLElement }).element = element;
-    (instance as { isEditable: boolean }).isEditable = true;
+    instance.element = element;
+    instance.isEditable = true;
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(2);
     const first = dragDropBinds[0];
@@ -233,8 +233,8 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
       ];
     }
     const instance = new Sheet();
-    (instance as { element: HTMLElement }).element = document.createElement('div');
-    (instance as { isEditable: boolean }).isEditable = true;
+    instance.element = document.createElement('div');
+    instance.isEditable = true;
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(1);
     const entry = dragDropBinds[0];
@@ -252,8 +252,8 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
       static override DRAG_DROP: ReadonlyArray<DragDropConfig> = [{ dragSelector: '.item' }];
     }
     const instance = new Sheet();
-    (instance as { element: HTMLElement }).element = document.createElement('div');
-    (instance as { isEditable: boolean }).isEditable = false;
+    instance.element = document.createElement('div');
+    instance.isEditable = false;
     instance._onRender({}, {});
     const lockedEntry = dragDropBinds[0];
     if (!lockedEntry) throw new Error('expected dragDropBinds[0]');
@@ -270,8 +270,8 @@ describe('BaseActorSheet — default _onDragStart', () => {
   it('serializes the item identified by data-item-id', () => {
     const Sub = BaseActorSheet();
     const instance = new Sub();
-    (instance as { document: { items: { get(id: string): { uuid: string } } } }).document = {
-      items: { get: (id) => ({ uuid: `Item.${id}` }) },
+    instance.document = {
+      items: { get: (id: string) => ({ uuid: `Item.${id}` }) },
     };
     const setData = vi.fn();
     const target = document.createElement('li');
@@ -312,7 +312,7 @@ describe('BaseActorSheet — typed drop dispatch', () => {
     const Base = BaseActorSheet();
     const onDropItem = vi.fn().mockResolvedValue('subclass-handled');
     class Sheet extends Base {
-      onDropItem = onDropItem;
+      override onDropItem = onDropItem;
     }
     const instance = new Sheet();
     const event = {} as DragEvent;
@@ -325,7 +325,7 @@ describe('BaseActorSheet — typed drop dispatch', () => {
     setupFromUuid('Item.y', { id: 'y' });
     const Base = BaseActorSheet();
     class Sheet extends Base {
-      onDropItem = vi.fn().mockResolvedValue(undefined);
+      override onDropItem = vi.fn().mockResolvedValue(undefined);
     }
     const instance = new Sheet();
     const result = await instance._onDropItem({} as DragEvent, { uuid: 'Item.y' });
@@ -336,7 +336,7 @@ describe('BaseActorSheet — typed drop dispatch', () => {
     setupFromUuid('Item.missing', null);
     const Base = BaseActorSheet();
     class Sheet extends Base {
-      onDropItem = vi.fn();
+      override onDropItem = vi.fn();
     }
     const instance = new Sheet();
     const result = await instance._onDropItem({} as DragEvent, { uuid: 'Other.id' });
@@ -350,9 +350,9 @@ describe('BaseActorSheet — typed drop dispatch', () => {
     const onFolder = vi.fn().mockResolvedValue('folder-ok');
     const onEffect = vi.fn().mockResolvedValue('effect-ok');
     class Sheet extends Base {
-      onDropActor = onActor;
-      onDropFolder = onFolder;
-      onDropActiveEffect = onEffect;
+      override onDropActor = onActor;
+      override onDropFolder = onFolder;
+      override onDropActiveEffect = onEffect;
     }
     const instance = new Sheet();
     const evt = {} as DragEvent;

--- a/packages/core/src/__tests__/base-application.test.ts
+++ b/packages/core/src/__tests__/base-application.test.ts
@@ -12,10 +12,7 @@ import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from 'vites
 import { BaseApplication } from '../base-application.js';
 import { VttfError } from '../errors/registry.js';
 
-class FakeApplicationV2 {
-  // biome-ignore lint/suspicious/noExplicitAny: stands in for Foundry's own constructor
-  constructor(..._args: any[]) {}
-}
+class FakeApplicationV2 {}
 
 beforeEach(() => {
   (globalThis as Record<string, unknown>).foundry = {

--- a/packages/core/src/__tests__/base-application.test.ts
+++ b/packages/core/src/__tests__/base-application.test.ts
@@ -8,7 +8,7 @@
  * "the class is not renderable", pointing at Foundry rather than at the line
  * that was wrong.
  */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 import { BaseApplication } from '../base-application.js';
 import { VttfError } from '../errors/registry.js';
 
@@ -54,10 +54,9 @@ describe('BaseApplication', () => {
       _renderHTML() {
         return document.createElement('div');
       }
-      // No `override` keyword: the factory returns an untyped constructor,
-      // so TypeScript cannot see the member being replaced. That is the next
-      // thing a typed base would fix.
-      _replaceHTML(result: HTMLElement, content: HTMLElement): void {
+      // `override` is required, not merely allowed: the factory reports what
+      // it adds, so TypeScript can see the member being replaced.
+      override _replaceHTML(result: HTMLElement, content: HTMLElement): void {
         content.append(result);
       }
     }
@@ -84,5 +83,33 @@ describe('BaseApplication', () => {
   it('names the offending class in the message', () => {
     class PdfConfig extends BaseApplication() {}
     expect(() => new PdfConfig()).toThrow(/PdfConfig/);
+  });
+});
+
+describe('what the factory reports', () => {
+  it('types the members it adds', () => {
+    class Window extends BaseApplication() {
+      _renderHTML() {
+        return document.createElement('div');
+      }
+    }
+    expectTypeOf<Window['_replaceHTML']>().toEqualTypeOf<
+      (result: HTMLElement, content: HTMLElement) => void
+    >();
+  });
+
+  it('still reaches the Foundry members it does not describe', () => {
+    // The Foundry half is typed by @vttforge/types, not here. Until then it
+    // has to stay reachable, or every real subclass fails to compile.
+    class Window extends BaseApplication() {
+      _renderHTML() {
+        return document.createElement('div');
+      }
+      probe(): void {
+        void this.element;
+        void this.options;
+      }
+    }
+    expect(typeof Window).toBe('function');
   });
 });

--- a/packages/core/src/__tests__/base-item-sheet.test.ts
+++ b/packages/core/src/__tests__/base-item-sheet.test.ts
@@ -128,8 +128,8 @@ describe('BaseItemSheet', () => {
       static override DRAG_DROP = [{ dragSelector: '.item' }];
     }
     const instance = new Sheet();
-    (instance as { element: HTMLElement }).element = document.createElement('div');
-    (instance as { isEditable: boolean }).isEditable = true;
+    instance.element = document.createElement('div');
+    instance.isEditable = true;
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(1);
     const entry = dragDropBinds[0];

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -30,6 +30,7 @@
  */
 
 import { VttfError } from './errors/registry.js';
+import type { UntypedFoundryMembers } from './foundry-base.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: Foundry's ActorSheetV2 shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
@@ -73,10 +74,34 @@ export interface SheetBaseStatics {
  * What the factory hands back: something you can `extend`, whose statics the
  * compiler can see.
  */
+/**
+ * What the sheet factories add on top of Foundry's own sheet.
+ *
+ * Only the members a subclass actually reaches for. The rest of the Foundry
+ * surface stays reachable and untyped until `@vttforge/types` describes it —
+ * see `UntypedFoundryMembers`.
+ */
+export interface SheetBaseMembers {
+  /** Fills in `context.tabs` for every group in `static TABS`. */
+  _prepareContext(options: unknown): Promise<Record<string, unknown>>;
+  /** Binds the `static DRAG_DROP` entries. */
+  _onRender(context: unknown, options: unknown): void;
+  _onDragStart(event: DragEvent): void;
+
+  /**
+   * The typed drop hooks. Override the one you want; returning `undefined`
+   * hands the drop back to Foundry's own handling.
+   */
+  onDropItem(item: unknown, event: DragEvent): Promise<unknown>;
+  onDropActor(actor: unknown, event: DragEvent): Promise<unknown>;
+  onDropFolder(folder: unknown, event: DragEvent): Promise<unknown>;
+  onDropActiveEffect(effect: unknown, event: DragEvent): Promise<unknown>;
+}
+
 export interface SheetBaseCtor extends SheetBaseStatics {
   // biome-ignore lint/suspicious/noExplicitAny: mirrors ApplicationV2's own
   // constructor arity, which subclasses pass straight through.
-  new (...args: any[]): any;
+  new (...args: any[]): SheetBaseMembers & UntypedFoundryMembers;
 }
 
 interface DragDropInstance {

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -64,8 +64,7 @@ export interface DragDropConfig {
  * into it, and pinning ours would reject the merge.
  */
 export interface SheetBaseStatics {
-  // biome-ignore lint/suspicious/noExplicitAny: a subclass merges arbitrary
-  // ApplicationV2 options into this; a narrower type would reject the merge.
+  // biome-ignore lint/suspicious/noExplicitAny: a subclass merges arbitrary ApplicationV2 options in; a narrower type would reject the merge
   readonly DEFAULT_OPTIONS: Record<string, any>;
   readonly DRAG_DROP: ReadonlyArray<DragDropConfig>;
 }
@@ -99,8 +98,7 @@ export interface SheetBaseMembers {
 }
 
 export interface SheetBaseCtor extends SheetBaseStatics {
-  // biome-ignore lint/suspicious/noExplicitAny: mirrors ApplicationV2's own
-  // constructor arity, which subclasses pass straight through.
+  // biome-ignore lint/suspicious/noExplicitAny: mirrors ApplicationV2's constructor arity, which subclasses pass straight through
   new (...args: any[]): SheetBaseMembers & UntypedFoundryMembers;
 }
 

--- a/packages/core/src/base-application.ts
+++ b/packages/core/src/base-application.ts
@@ -20,6 +20,7 @@
  */
 
 import { VttfError } from './errors/registry.js';
+import type { VttforgeClass } from './foundry-base.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: Foundry's ApplicationV2 shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
@@ -60,7 +61,18 @@ function resolveApplicationV2(): AnyConstructor {
  * `_replaceHTML` is provided. `_renderHTML` is yours, and omitting it throws
  * when the class is constructed rather than when someone opens the window.
  */
-export function BaseApplication(): AnyConstructor {
+/** What `BaseApplication` adds on top of Foundry's `ApplicationV2`. */
+export interface BaseApplicationMembers {
+  /**
+   * Put the rendered content in the window.
+   *
+   * Provided because it is the half people forget. Override it for a window
+   * that updates in place rather than swapping its whole content.
+   */
+  _replaceHTML(result: HTMLElement, content: HTMLElement): void;
+}
+
+export function BaseApplication(): VttforgeClass<BaseApplicationMembers> {
   const Base = resolveApplicationV2();
 
   class VttforgeBaseApplication extends Base {
@@ -87,5 +99,5 @@ export function BaseApplication(): AnyConstructor {
     }
   }
 
-  return VttforgeBaseApplication as unknown as AnyConstructor;
+  return VttforgeBaseApplication as unknown as VttforgeClass<BaseApplicationMembers>;
 }

--- a/packages/core/src/base-type-data-model.ts
+++ b/packages/core/src/base-type-data-model.ts
@@ -83,8 +83,7 @@ export type TypedTypeDataModel<S extends Record<string, FieldInstance>> = InferS
   };
 
 export interface TypedTypeDataModelCtor<S extends Record<string, FieldInstance>> {
-  // biome-ignore lint/suspicious/noExplicitAny: a subclass declaring its own
-  // constructor has to pass Foundry's (data, context) pair through to super.
+  // biome-ignore lint/suspicious/noExplicitAny: a subclass with its own constructor passes Foundry's (data, context) through to super
   new (...args: any[]): TypedTypeDataModel<S>;
   defineSchema(): S;
   migrateData(data: Record<string, unknown>): Record<string, unknown>;

--- a/packages/core/src/base-type-data-model.ts
+++ b/packages/core/src/base-type-data-model.ts
@@ -23,6 +23,7 @@
 import type { FieldInstance } from './data/fields.js';
 import type { InferSchema } from './data/infer-schema.js';
 import { VttfError } from './errors/registry.js';
+import type { VttforgeClass } from './foundry-base.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: we mix into Foundry's TypeDataModel whose shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
@@ -92,10 +93,10 @@ export interface TypedTypeDataModelCtor<S extends Record<string, FieldInstance>>
 /**
  * Build a base class with no knowledge of the schema.
  *
- * `this` inside the hooks is untyped. Pass your schema function instead to
- * get the fields typed.
+ * The hooks are typed; the schema's own fields are not, since nothing said
+ * what they are. Pass your schema function instead to get those too.
  */
-export function BaseTypeDataModel(): AnyConstructor;
+export function BaseTypeDataModel(): VttforgeClass<TypeDataModelHooks>;
 /**
  * Build a base class that knows its schema.
  *

--- a/packages/core/src/foundry-base.ts
+++ b/packages/core/src/foundry-base.ts
@@ -1,0 +1,40 @@
+/**
+ * How a base factory reports what it returns.
+ *
+ * These factories mix VTTForge behaviour into a Foundry class resolved at
+ * runtime. Two halves, and they are not equally knowable: what we add is
+ * ours and can be typed exactly; what Foundry brings lives in a type package
+ * that is not wired up yet.
+ *
+ * Returning `any` for the whole thing — which is what every factory did —
+ * gives up on both. It costs more than it looks: a subclass cannot write
+ * `override` on a member it really is overriding, and a call to a method
+ * that does not exist passes silently. Both happened while porting a real
+ * module onto the SDK, the second one shipping a broken call into a release.
+ *
+ * So: type our half, and let Foundry's half through an index signature. A
+ * property we know about carries its real type; anything else is reachable
+ * and `any`, the same as before. When `@vttforge/types` lands, the index
+ * signature is what it replaces.
+ */
+
+/**
+ * The part of an instance this SDK does not describe yet.
+ *
+ * Deliberately permissive. Narrowing it before the Foundry types exist would
+ * only mean rejecting code that works.
+ */
+export interface UntypedFoundryMembers {
+  // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed by fvtt-types / @vttforge/types, not here
+  [member: string]: any;
+}
+
+/**
+ * A class this SDK built on top of a Foundry one.
+ *
+ * `Added` is what the factory contributes. Everything else stays reachable.
+ */
+export type VttforgeClass<Added, Statics = unknown> = Statics & {
+  // biome-ignore lint/suspicious/noExplicitAny: forwards Foundry's own constructor arity
+  new (...args: any[]): Added & UntypedFoundryMembers;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,10 +25,14 @@ export {
   BaseActorSheet,
   type DragDropConfig,
   type SheetBaseCtor,
+  type SheetBaseMembers,
   type SheetBaseStatics,
   VTTFORGE_SHEET_CLASS,
 } from './base-actor-sheet.js';
-export { BaseApplication } from './base-application.js';
+export {
+  BaseApplication,
+  type BaseApplicationMembers,
+} from './base-application.js';
 export { BaseItemSheet } from './base-item-sheet.js';
 export {
   BaseTypeDataModel,
@@ -99,6 +103,7 @@ export {
   type VttfErrorCode,
   type VttfErrorEntry,
 } from './errors/registry.js';
+export type { UntypedFoundryMembers, VttforgeClass } from './foundry-base.js';
 export type {
   ActiveEffectConfig,
   CombatConfig,


### PR DESCRIPTION
Every `Base*` factory returned `any`. That gave up on two things at once:

- A subclass could not write `override` on a member it really was overriding — TypeScript rejected the keyword.
- A call to a method that does not exist passed silently.

Both happened while porting a real module onto the SDK. The second shipped: `socket.ts` called `url` and `goToPage` on a viewer that had neither, and nothing complained until the code ran.

### What changed

The factories now return the members they contribute. The rest of the Foundry surface stays reachable through an index signature, so a property the SDK knows about carries its real type and anything else behaves as before. That index signature is exactly what `@vttforge/types` replaces when it lands — this is the shape that makes the eventual swap a narrowing rather than a rewrite.

### It paid off inside this PR

The example system compiles with `checkJs`, and turning this on made it demand `@override` on `prepareDerivedData`, `_prepareContext` and the drop hooks — members it had been overriding all along with nothing to check against. The core tests shed a dozen `as { element: HTMLElement }` casts that existed only because the instance type was `any`.

### What it will do to consumers

Subclasses that omit `override` on a now-visible member will start failing. That is the point.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build` and knip pass.
