### PR TITLE
feat(testing): first real release

### DIFF
--- a/.changeset/great-donkeys-brake.md
+++ b/.changeset/great-donkeys-brake.md
@@ -1,0 +1,13 @@
+---
+'@vttforge/testing': minor
+---
+
+First real release. It was a three-line placeholder.
+
+Two entry points, because the two kinds of test run in different places.
+
+`@vttforge/testing/vitest` installs the Foundry globals a package reaches for and hands back a handle that records what your code registered — hooks, settings, notifications — so a test can assert on what happened rather than only on what did not throw. Every `@vttforge/core` test built this by hand, differently each time; that is the problem it solves.
+
+`@vttforge/testing/quench` registers a batch inside a live world, for what a mock cannot answer: a sheet that really draws, a socket with two clients, a document that round-trips through the database.
+
+Also ships ambient declarations for the globals, since a test that mocks Foundry then reads `game.settings` otherwise gets "Cannot find name 'game'".

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,11 +1,75 @@
 # @vttforge/testing
 
-Test helpers and Foundry mocks for VTTForge consumers. Wraps Vitest (unit tests) and Quench (in-Foundry browser tests).
+Helpers for testing Foundry VTT packages.
 
-> **Status:** v0.0.1 placeholder. Implementation lands in v1.0.0.
+Two entry points, because the two kinds of test run in different places.
 
-## Planned scope (v1.0.0)
+## `@vttforge/testing/vitest`
 
-- Pre-built Foundry global mocks (`game`, `Hooks`, `CONFIG`, `Roll`, `ui.notifications`).
-- Quench test harness with VTTForge sheet helpers.
-- Snapshot helpers for `system.json` / `template.json` regression tests.
+Runs in CI against mocked globals. Covers everything up to the moment a window
+renders: data models, settings, hook registration, migrations, document
+updates.
+
+```ts
+import { createMockActor, withMockFoundry } from '@vttforge/testing/vitest';
+
+const foundry = withMockFoundry();
+registerMyModule();
+
+foundry.callHook('init');
+expect(foundry.settings[0].key).toBe('cacheSize');
+
+foundry.restore();
+```
+
+`withMockFoundry` installs `foundry`, `game`, `CONFIG`, `Hooks`, `ui` and
+`CONST`, and hands back a handle that records what your code registered — hooks,
+settings, notifications — so a test can assert on what happened rather than only
+on what did not throw. `restore()` puts every global back, including deleting the
+ones that never existed.
+
+The mock documents behave like real ones where it counts: `update` merges rather
+than replacing, and dotted paths expand. Both matter — a mock that replaces lets
+a test pass while the real thing drops every sibling key.
+
+### Naming the globals
+
+A test that reads `game.settings` gets "Cannot find name 'game'". Add the
+ambient declarations:
+
+```jsonc
+// tsconfig.json
+{ "compilerOptions": { "types": ["@vttforge/testing/globals"] } }
+```
+
+## `@vttforge/testing/quench`
+
+Runs inside a live world, for what a mock cannot answer: a sheet that really
+draws, a socket with two clients, a document that round-trips through the
+database.
+
+```ts
+import { registerBatch } from '@vttforge/testing/quench';
+
+registerBatch('my-module.sheets', ({ describe, it, assert }) => {
+  describe('character sheet', () => {
+    it('renders', async () => {
+      const actor = await Actor.create({ name: 'T', type: 'character' });
+      await actor.sheet.render(true);
+      assert.ok(actor.sheet.rendered);
+      await actor.delete();
+    });
+  });
+});
+```
+
+Safe to call at module scope: it waits for `quenchReady` rather than assuming
+Quench has loaded, which is the mistake that makes a batch silently never
+appear. Outside Foundry it is a no-op, so a file holding both kinds of test can
+still be imported by the vitest run.
+
+## Where the line sits
+
+Anything before `_renderHTML` is testable in Vitest. Real rendering is Quench's
+half. Reaching for a mock past that line produces tests that pass and tell you
+nothing.

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -22,7 +22,18 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs"
     },
-    "./package.json": "./package.json"
+    "./vitest": {
+      "types": "./dist/vitest/index.d.mts",
+      "import": "./dist/vitest/index.mjs"
+    },
+    "./quench": {
+      "types": "./dist/quench/index.d.mts",
+      "import": "./dist/quench/index.mjs"
+    },
+    "./package.json": "./package.json",
+    "./globals": {
+      "types": "./dist/globals.d.mts"
+    }
   },
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
@@ -34,7 +45,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && node -e \"require('node:fs').copyFileSync('src/globals.d.ts','dist/globals.d.mts')\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "publint": "publint",

--- a/packages/testing/src/__tests__/dogfood.test.ts
+++ b/packages/testing/src/__tests__/dogfood.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The package used the way a consumer would use it.
+ *
+ * Every `@vttforge/core` test builds these globals by hand, differently each
+ * time. This is the same job done through the package, and it is the case
+ * that would have caught a mock too thin to be useful.
+ */
+import { describe, expect, it } from 'vitest';
+import { createMockActor } from '../vitest/mock-foundry.js';
+import { withMockFoundry } from '../vitest/with-mock-foundry.js';
+
+/** Stands in for a module's entry point. */
+function registerExampleModule(): void {
+  Hooks.once('init', () => {
+    game.settings.register('example', 'cacheSize', {
+      name: 'Cache size',
+      scope: 'client',
+      config: true,
+      type: Number,
+      default: 256,
+    });
+    CONFIG.Item.dataModels['example.pdf'] = class {};
+  });
+
+  Hooks.once('ready', () => {
+    if (game.user.isGM) ui.notifications.info('example ready');
+  });
+}
+
+describe('a module registered against the mock', () => {
+  it('runs its whole lifecycle without a Foundry', () => {
+    const mock = withMockFoundry();
+    registerExampleModule();
+
+    // Nothing has happened yet: the module only registered listeners.
+    expect(mock.settings).toHaveLength(0);
+
+    mock.callHook('init');
+    expect(mock.settings[0]?.key).toBe('cacheSize');
+    expect(game.settings.get('example', 'cacheSize')).toBe(256);
+    expect(CONFIG.Item.dataModels['example.pdf']).toBeDefined();
+
+    mock.callHook('ready');
+    expect(mock.notifications).toEqual([{ level: 'info', message: 'example ready' }]);
+
+    mock.restore();
+  });
+
+  it('lets the same lifecycle be driven as a player', () => {
+    const mock = withMockFoundry({ user: { isGM: false } });
+    registerExampleModule();
+    mock.callHook('ready');
+    // The GM-only branch did not run.
+    expect(mock.notifications).toEqual([]);
+    mock.restore();
+  });
+
+  it('checks what a sheet wrote to an actor', async () => {
+    const mock = withMockFoundry();
+    const actor = createMockActor({ system: { hp: { value: 10, max: 10 } } });
+
+    // What a sheet's change handler does.
+    await actor.update(foundry.utils.expandObject({ 'system.hp.value': 4 }));
+
+    expect(actor.system.hp.value).toBe(4);
+    expect(actor.system.hp.max).toBe(10);
+    expect(actor.updates).toHaveLength(1);
+    mock.restore();
+  });
+});

--- a/packages/testing/src/__tests__/with-mock-foundry.test.ts
+++ b/packages/testing/src/__tests__/with-mock-foundry.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createMockActor, createMockItem } from '../vitest/mock-foundry.js';
+import { type MockFoundry, withMockFoundry } from '../vitest/with-mock-foundry.js';
+
+let mock: MockFoundry | undefined;
+
+afterEach(() => {
+  mock?.restore();
+  mock = undefined;
+});
+
+describe('withMockFoundry', () => {
+  it('installs the globals a package reaches for', () => {
+    mock = withMockFoundry();
+    for (const name of ['foundry', 'game', 'CONFIG', 'Hooks', 'ui', 'CONST']) {
+      expect((globalThis as Record<string, unknown>)[name]).toBeDefined();
+    }
+  });
+
+  it('puts every global back, including ones that never existed', () => {
+    const scope = globalThis as Record<string, unknown>;
+    scope.game = { sentinel: true };
+    expect(scope.foundry).toBeUndefined();
+
+    const active = withMockFoundry();
+    expect(scope.foundry).toBeDefined();
+    active.restore();
+
+    // The pre-existing one is restored, and the invented one is gone rather
+    // than left behind as an empty object.
+    expect(scope.game).toEqual({ sentinel: true });
+    expect(scope.foundry).toBeUndefined();
+    delete scope.game;
+  });
+
+  it('records hook registrations instead of swallowing them', () => {
+    mock = withMockFoundry();
+    Hooks.once('init', () => 'from init');
+    Hooks.on('ready', () => 'from ready');
+
+    expect(mock.hooks.map((h) => [h.event, h.once])).toEqual([
+      ['init', true],
+      ['ready', false],
+    ]);
+  });
+
+  it('fires hooks so a test can drive a lifecycle', () => {
+    mock = withMockFoundry();
+    let ran = false;
+    Hooks.once('init', () => {
+      ran = true;
+    });
+    mock.callHook('init');
+    expect(ran).toBe(true);
+  });
+
+  it('records settings and serves their defaults back', () => {
+    mock = withMockFoundry();
+    game.settings.register('my-module', 'showWelcome', { type: Boolean, default: true });
+
+    expect(mock.settings[0]).toMatchObject({ namespace: 'my-module', key: 'showWelcome' });
+    expect(game.settings.get('my-module', 'showWelcome')).toBe(true);
+  });
+
+  it('collects notifications with their severity', () => {
+    mock = withMockFoundry();
+    ui.notifications.warn('careful');
+    ui.notifications.error('broken');
+    expect(mock.notifications).toEqual([
+      { level: 'warn', message: 'careful' },
+      { level: 'error', message: 'broken' },
+    ]);
+  });
+
+  it('defaults the user to a GM, which is what module code checks', () => {
+    mock = withMockFoundry();
+    expect(game.user.isGM).toBe(true);
+  });
+
+  it('lets a test be a player instead', () => {
+    mock = withMockFoundry({ user: { isGM: false } });
+    expect(game.user.isGM).toBe(false);
+  });
+
+  it('expands dotted paths the way foundry.utils does', () => {
+    mock = withMockFoundry();
+    expect(foundry.utils.expandObject({ 'system.hp.value': 3 })).toEqual({
+      system: { hp: { value: 3 } },
+    });
+    expect(foundry.utils.flattenObject({ system: { hp: { value: 3 } } })).toEqual({
+      'system.hp.value': 3,
+    });
+  });
+});
+
+describe('mock documents', () => {
+  it('records every update the code under test made', async () => {
+    const actor = createMockActor({ name: 'Vitória' });
+    await actor.update({ name: 'Renamed' });
+    expect(actor.updates).toEqual([{ name: 'Renamed' }]);
+    expect(actor.name).toBe('Renamed');
+  });
+
+  it('applies a dotted update to the nested path, not to a dotted key', async () => {
+    // This is how Foundry updates arrive, and code under test relies on it.
+    const actor = createMockActor({ system: { hp: { value: 10 } } });
+    await actor.update({ 'system.hp.value': 3 });
+    expect(actor.system.hp.value).toBe(3);
+    expect(Object.keys(actor.system)).toEqual(['hp']);
+  });
+
+  it('round-trips flags', async () => {
+    const item = createMockItem();
+    await item.setFlag('my-module', 'code', 'OP');
+    expect(item.getFlag('my-module', 'code')).toBe('OP');
+    await item.unsetFlag('my-module', 'code');
+    expect(item.getFlag('my-module', 'code')).toBeUndefined();
+  });
+
+  it('merges an update rather than replacing the branch', async () => {
+    // Foundry merges. A mock that replaces lets a test pass while the real
+    // thing drops every sibling key — which is how this was found.
+    const actor = createMockActor({ system: { hp: { value: 10, max: 10 } } });
+    await actor.update({ system: { hp: { value: 4 } } });
+    expect(actor.system.hp).toEqual({ value: 4, max: 10 });
+  });
+
+  it('replaces arrays wholesale, also like Foundry', async () => {
+    const actor = createMockActor({ system: { tags: ['a', 'b'] } });
+    await actor.update({ system: { tags: ['c'] } });
+    expect(actor.system.tags).toEqual(['c']);
+  });
+
+  it('gives each document a distinct id', () => {
+    expect(createMockActor().id).not.toBe(createMockActor().id);
+  });
+});

--- a/packages/testing/src/globals.d.ts
+++ b/packages/testing/src/globals.d.ts
@@ -1,0 +1,27 @@
+/**
+ * The globals `withMockFoundry` installs, declared so a test can name them.
+ *
+ * A test that mocks Foundry then reads `game.settings` gets "Cannot find name
+ * 'game'" — the values exist at runtime and nothing told TypeScript. Shipped
+ * rather than kept internal because every consumer writing tests hits this on
+ * the first one.
+ *
+ * Deliberately loose. Typing the Foundry runtime is `@vttforge/types`' job;
+ * this only exists so the names resolve.
+ */
+declare global {
+  // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
+  const foundry: any;
+  // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
+  const game: any;
+  // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
+  const CONFIG: any;
+  // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
+  const Hooks: any;
+  // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
+  const ui: any;
+  // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
+  const CONST: any;
+}
+
+export {};

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,4 +1,15 @@
 /**
- * @vttforge/testing — placeholder. Implementation lands in v1.0.0.
+ * @vttforge/testing — helpers for testing Foundry packages.
+ *
+ * Two entry points, because the two kinds of test run in different places:
+ *
+ * - `@vttforge/testing/vitest` runs in CI against mocked globals, and covers
+ *   everything up to the moment a window renders.
+ * - `@vttforge/testing/quench` runs inside a live world, for what a mock
+ *   cannot answer.
+ *
+ * The root re-exports both so a single import works while you are finding
+ * your way around.
  */
-export const VTTFORGE_TESTING_VERSION = '0.0.1';
+export * from './quench/index.js';
+export * from './vitest/index.js';

--- a/packages/testing/src/quench/index.ts
+++ b/packages/testing/src/quench/index.ts
@@ -1,0 +1,7 @@
+/**
+ * `@vttforge/testing/quench` — the half that runs inside Foundry.
+ *
+ * For what a mock cannot answer: a sheet that really draws, a socket with two
+ * clients, a document that round-trips through the database.
+ */
+export { type BatchOptions, type QuenchContext, registerBatch } from './register-batch.js';

--- a/packages/testing/src/quench/register-batch.ts
+++ b/packages/testing/src/quench/register-batch.ts
@@ -1,0 +1,85 @@
+/**
+ * Registering a Quench batch, for the tests that need a real Foundry.
+ *
+ * The vitest half covers everything up to the moment a window renders. Past
+ * that — a sheet that actually draws, a socket with two clients, a document
+ * that really round-trips through the database — needs the real thing, and
+ * Quench is how the community runs those from inside a running world.
+ *
+ * The whole ceremony is one `quenchReady` hook and a registration call, which
+ * everyone writes again and gets subtly wrong: register too early and Quench
+ * is not there, too late and the batch is missed.
+ */
+
+/** What Quench hands a batch to describe its cases. */
+export interface QuenchContext {
+  describe(title: string, fn: () => void): void;
+  it(title: string, fn: () => unknown): void;
+  before(fn: () => unknown): void;
+  after(fn: () => unknown): void;
+  beforeEach(fn: () => unknown): void;
+  afterEach(fn: () => unknown): void;
+  // biome-ignore lint/suspicious/noExplicitAny: Quench bundles chai, whose assert surface is its own
+  assert: any;
+  // biome-ignore lint/suspicious/noExplicitAny: chai's expect, likewise
+  expect: any;
+}
+
+export interface BatchOptions {
+  /** Shown in the Quench window. Defaults to the batch id. */
+  displayName?: string;
+  /**
+   * Groups the batch in the Quench UI. Use your package id so a user running
+   * everything can tell whose failures are whose.
+   */
+  snapBaseline?: boolean;
+}
+
+interface QuenchApi {
+  registerBatch(
+    id: string,
+    fn: (context: QuenchContext) => void,
+    options?: Record<string, unknown>,
+  ): void;
+}
+
+/**
+ * Register a batch once Quench is ready.
+ *
+ * Safe to call at module scope — it waits for the hook rather than assuming
+ * Quench has loaded, which is the mistake that makes a batch silently never
+ * appear.
+ *
+ * ```ts
+ * registerBatch('my-module.sheets', ({ describe, it, assert }) => {
+ *   describe('character sheet', () => {
+ *     it('renders', async () => {
+ *       const actor = await Actor.create({ name: 'T', type: 'character' });
+ *       await actor.sheet.render(true);
+ *       assert.ok(actor.sheet.rendered);
+ *       await actor.delete();
+ *     });
+ *   });
+ * });
+ * ```
+ */
+export function registerBatch(
+  id: string,
+  fn: (context: QuenchContext) => void,
+  options: BatchOptions = {},
+): void {
+  const hooks = (globalThis as Record<string, unknown>).Hooks as
+    | { once(event: string, cb: (quench: QuenchApi) => void): void }
+    | undefined;
+
+  if (!hooks?.once) {
+    // No Foundry here at all. Quench batches only mean anything inside a
+    // running world, so this is a no-op rather than an error — it lets a file
+    // holding both kinds of test be imported by the vitest run.
+    return;
+  }
+
+  hooks.once('quenchReady', (quench) => {
+    quench.registerBatch(id, fn, { displayName: options.displayName ?? id, ...options });
+  });
+}

--- a/packages/testing/src/vitest/index.ts
+++ b/packages/testing/src/vitest/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `@vttforge/testing/vitest` — the half that runs in CI.
+ *
+ * Covers everything up to the moment a window renders: data models, settings,
+ * hook registration, migrations, document updates. Past that, use the Quench
+ * half inside a real world.
+ */
+export {
+  createMockActor,
+  createMockItem,
+  type MockDocument,
+} from './mock-foundry.js';
+export {
+  type MockFoundry,
+  type RecordedHook,
+  type RecordedSetting,
+  withMockFoundry,
+} from './with-mock-foundry.js';

--- a/packages/testing/src/vitest/mock-foundry.ts
+++ b/packages/testing/src/vitest/mock-foundry.ts
@@ -1,0 +1,129 @@
+/**
+ * A Foundry runtime, faked well enough to import a package and construct
+ * its classes.
+ *
+ * Every `@vttforge/core` test built this by hand before this existed, and no
+ * two built it quite the same way. That is the problem: the globals a package
+ * needs are not obvious, they are not documented anywhere, and you discover
+ * them one `ReferenceError` at a time.
+ *
+ * What this covers is the boundary the SDK actually sits on — everything up
+ * to the moment a window renders. `_renderHTML` and beyond needs a real
+ * browser and a real Foundry; that is what the Quench half is for.
+ */
+
+/** A Foundry document, as much of one as a unit test needs. */
+export interface MockDocument {
+  id: string;
+  name: string;
+  type: string;
+  // biome-ignore lint/suspicious/noExplicitAny: a document's system data is whatever its schema says
+  system: Record<string, any>;
+  flags: Record<string, Record<string, unknown>>;
+  getFlag(scope: string, key: string): unknown;
+  setFlag(scope: string, key: string, value: unknown): Promise<MockDocument>;
+  unsetFlag(scope: string, key: string): Promise<MockDocument>;
+  update(delta: Record<string, unknown>): Promise<MockDocument>;
+  /** Every update this document received, in order. */
+  readonly updates: ReadonlyArray<Record<string, unknown>>;
+}
+
+interface MockDocumentOptions {
+  id?: string;
+  name?: string;
+  type?: string;
+  // biome-ignore lint/suspicious/noExplicitAny: mirrors MockDocument.system
+  system?: Record<string, any>;
+  flags?: Record<string, Record<string, unknown>>;
+}
+
+let nextId = 0;
+
+/** `{'system.hp.value': 3}` → `{system: {hp: {value: 3}}}`. */
+function expand(flat: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [path, value] of Object.entries(flat)) {
+    const parts = path.split('.');
+    const last = parts.pop();
+    if (!last) continue;
+    let target = out;
+    for (const part of parts) {
+      target[part] ??= {};
+      target = target[part] as Record<string, unknown>;
+    }
+    target[last] = value;
+  }
+  return out;
+}
+
+/** Deep-merge, the way a document update behaves. Arrays replace wholesale. */
+function merge(target: Record<string, unknown>, source: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(source)) {
+    const isPlain =
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      Object.getPrototypeOf(value) === Object.prototype;
+    if (isPlain) {
+      if (typeof target[key] !== 'object' || target[key] === null) target[key] = {};
+      merge(target[key] as Record<string, unknown>, value as Record<string, unknown>);
+    } else {
+      target[key] = value;
+    }
+  }
+}
+
+function createMockDocument(kind: string, options: MockDocumentOptions = {}): MockDocument {
+  nextId += 1;
+  const updates: Record<string, unknown>[] = [];
+
+  const doc: MockDocument = {
+    id: options.id ?? `${kind}${String(nextId).padStart(12, '0')}`,
+    name: options.name ?? `Test ${kind}`,
+    type: options.type ?? 'base',
+    system: options.system ?? {},
+    flags: options.flags ?? {},
+    updates,
+
+    getFlag: (scope, key) => doc.flags[scope]?.[key],
+
+    setFlag: async (scope, key, value) => {
+      doc.flags[scope] ??= {};
+      doc.flags[scope][key] = value;
+      return doc;
+    },
+
+    unsetFlag: async (scope, key) => {
+      delete doc.flags[scope]?.[key];
+      return doc;
+    },
+
+    /**
+     * Records the delta and merges it in.
+     *
+     * Merges, not replaces — which is what Foundry does and what a mock has
+     * to match. Assigning `{system: {hp: {value: 4}}}` wholesale drops
+     * `hp.max`, and a test written against that passes while the real thing
+     * loses data.
+     *
+     * Dotted keys are expanded first, because that is how updates arrive.
+     */
+    update: async (delta) => {
+      updates.push(delta);
+      merge(doc as unknown as Record<string, unknown>, expand(delta));
+      return doc;
+    },
+  };
+
+  return doc;
+}
+
+/** An Actor for a test. Its `updates` record what the code under test wrote. */
+export function createMockActor(options: MockDocumentOptions = {}): MockDocument {
+  return createMockDocument('Actor', { type: 'character', ...options });
+}
+
+/** An Item for a test. */
+export function createMockItem(options: MockDocumentOptions = {}): MockDocument {
+  return createMockDocument('Item', { type: 'base', ...options });
+}

--- a/packages/testing/src/vitest/with-mock-foundry.ts
+++ b/packages/testing/src/vitest/with-mock-foundry.ts
@@ -1,0 +1,214 @@
+/**
+ * Install the Foundry globals a package needs, and take them away again.
+ *
+ * The globals are the awkward part of testing anything built on Foundry:
+ * `foundry`, `game`, `CONFIG`, `Hooks`, `ui`, `CONST`. A package touches some
+ * subset, the subset is not written down, and you find it one
+ * `ReferenceError` at a time.
+ *
+ * Everything here is a plain object or a recording stub, so a test can assert
+ * on what was registered rather than only on what did not throw.
+ */
+
+/** A hook registration the code under test made. */
+export interface RecordedHook {
+  event: string;
+  once: boolean;
+  fn: (...args: unknown[]) => unknown;
+}
+
+/** A setting the code under test registered. */
+export interface RecordedSetting {
+  namespace: string;
+  key: string;
+  config: Record<string, unknown>;
+}
+
+export interface MockFoundry {
+  /** Every `Hooks.on` and `Hooks.once`, in order. */
+  readonly hooks: ReadonlyArray<RecordedHook>;
+  /** Every `game.settings.register`, in order. */
+  readonly settings: ReadonlyArray<RecordedSetting>;
+  /** Every notification raised, by severity. */
+  readonly notifications: ReadonlyArray<{ level: 'info' | 'warn' | 'error'; message: string }>;
+  /** Fire a hook the way Foundry would, for the listeners registered so far. */
+  callHook(event: string, ...args: unknown[]): unknown[];
+  /** Read back a registered setting's current value. */
+  getSetting(namespace: string, key: string): unknown;
+  /** Put every global back the way it was. */
+  restore(): void;
+}
+
+interface MockFoundryOptions {
+  /** The current user. Defaults to a GM, since most module code checks. */
+  user?: { id?: string; isGM?: boolean; name?: string };
+  /** Extra `foundry.*` members, merged over the defaults. */
+  foundry?: Record<string, unknown>;
+  /** Extra `game.*` members, merged over the defaults. */
+  game?: Record<string, unknown>;
+}
+
+const GLOBALS = ['foundry', 'game', 'CONFIG', 'Hooks', 'ui', 'CONST'] as const;
+
+/**
+ * Flatten and expand, the way `foundry.utils` does.
+ *
+ * Provided because SDK code calls them on the global, not because a test
+ * needs them: leaving them out means every consumer stubs them again.
+ */
+function flattenObject(obj: Record<string, unknown>, prefix = ''): Record<string, unknown> {
+  const flat: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const isPlain =
+      value !== null &&
+      typeof value === 'object' &&
+      Object.getPrototypeOf(value) === Object.prototype;
+    if (isPlain && Object.keys(value as object).length > 0) {
+      Object.assign(flat, flattenObject(value as Record<string, unknown>, path));
+    } else {
+      flat[path] = value;
+    }
+  }
+  return flat;
+}
+
+function expandObject(flat: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [path, value] of Object.entries(flat)) {
+    const parts = path.split('.');
+    const last = parts.pop();
+    if (!last) continue;
+    let target = out;
+    for (const part of parts) {
+      target[part] ??= {};
+      target = target[part] as Record<string, unknown>;
+    }
+    target[last] = value;
+  }
+  return out;
+}
+
+/**
+ * Stand up the globals, run the callback, tear them down.
+ *
+ * ```ts
+ * const foundry = withMockFoundry();
+ * registerMyModule();
+ * expect(foundry.hooks.map((h) => h.event)).toContain('init');
+ * foundry.restore();
+ * ```
+ */
+export function withMockFoundry(options: MockFoundryOptions = {}): MockFoundry {
+  const saved = new Map<string, unknown>();
+  const scope = globalThis as Record<string, unknown>;
+  for (const name of GLOBALS) saved.set(name, scope[name]);
+
+  const hooks: RecordedHook[] = [];
+  const settings: RecordedSetting[] = [];
+  const values = new Map<string, unknown>();
+  const notifications: { level: 'info' | 'warn' | 'error'; message: string }[] = [];
+
+  const Hooks = {
+    on: (event: string, fn: (...a: unknown[]) => unknown) => {
+      hooks.push({ event, once: false, fn });
+      return hooks.length;
+    },
+    once: (event: string, fn: (...a: unknown[]) => unknown) => {
+      hooks.push({ event, once: true, fn });
+      return hooks.length;
+    },
+    off: () => {},
+    call: (event: string, ...args: unknown[]) => callHook(event, ...args).every((r) => r !== false),
+    callAll: (event: string, ...args: unknown[]) => {
+      callHook(event, ...args);
+      return true;
+    },
+  };
+
+  function callHook(event: string, ...args: unknown[]): unknown[] {
+    return hooks.filter((h) => h.event === event).map((h) => h.fn(...args));
+  }
+
+  const user = { id: 'user000000000001', isGM: true, name: 'Gamemaster', ...options.user };
+
+  scope.Hooks = Hooks;
+  scope.CONST = { DOCUMENT_OWNERSHIP_LEVELS: { NONE: 0, LIMITED: 1, OBSERVER: 2, OWNER: 3 } };
+  scope.CONFIG = {
+    Actor: { dataModels: {}, sheetClasses: {} },
+    Item: { dataModels: {}, sheetClasses: {} },
+    TextEditor: { enrichers: [] },
+    Combat: {},
+    ActiveEffect: {},
+    statusEffects: [],
+    debug: { hooks: false },
+  };
+  scope.ui = {
+    notifications: {
+      info: (m: string) => notifications.push({ level: 'info', message: m }),
+      warn: (m: string) => notifications.push({ level: 'warn', message: m }),
+      error: (m: string) => notifications.push({ level: 'error', message: m }),
+    },
+  };
+  scope.foundry = {
+    utils: {
+      flattenObject,
+      expandObject,
+      mergeObject: (a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b }),
+      deepClone: <T>(v: T): T => structuredClone(v),
+      randomID: () => Math.random().toString(36).slice(2, 18),
+      isNewerVersion: (a: string, b: string) =>
+        a.localeCompare(b, undefined, { numeric: true }) > 0,
+    },
+    abstract: { TypeDataModel: class {}, DataModel: class {}, Document: class {} },
+    data: { fields: {} },
+    applications: {
+      api: { ApplicationV2: class {}, HandlebarsApplicationMixin: (b: unknown) => b },
+      sheets: { ActorSheetV2: class {}, ItemSheetV2: class {} },
+      ux: {},
+      instances: new Map(),
+    },
+    documents: {
+      collections: { Actors: { registerSheet: () => {} }, Items: { registerSheet: () => {} } },
+    },
+    ...options.foundry,
+  };
+  scope.game = {
+    user,
+    userId: user.id,
+    ready: true,
+    modules: new Map(),
+    actors: [],
+    items: [],
+    i18n: {
+      localize: (key: string) => key,
+      format: (key: string, data: Record<string, unknown>) => `${key} ${JSON.stringify(data)}`,
+    },
+    settings: {
+      register: (namespace: string, key: string, config: Record<string, unknown>) => {
+        settings.push({ namespace, key, config });
+        values.set(`${namespace}.${key}`, config.default);
+      },
+      get: (namespace: string, key: string) => values.get(`${namespace}.${key}`),
+      set: async (namespace: string, key: string, value: unknown) => {
+        values.set(`${namespace}.${key}`, value);
+        return value;
+      },
+    },
+    ...options.game,
+  };
+
+  return {
+    hooks,
+    settings,
+    notifications,
+    callHook,
+    getSetting: (namespace, key) => values.get(`${namespace}.${key}`),
+    restore() {
+      for (const [name, value] of saved) {
+        if (value === undefined) delete scope[name];
+        else scope[name] = value;
+      }
+    },
+  };
+}

--- a/packages/testing/tsdown.config.mjs
+++ b/packages/testing/tsdown.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/vitest/index.ts', 'src/quench/index.ts'],
   format: 'esm',
   platform: 'neutral',
   target: 'es2022',


### PR DESCRIPTION
`@vttforge/testing` was three lines and a placeholder version. This is the package.

Two entry points, because the two kinds of test run in different places.

### `@vttforge/testing/vitest`

Installs the globals a package reaches for — `foundry`, `game`, `CONFIG`, `Hooks`, `ui`, `CONST` — and hands back a handle that **records** what the code registered: hooks, settings, notifications. A test asserts on what happened rather than only on what did not throw, and `restore()` puts every global back including deleting the ones that never existed.

Every `@vttforge/core` test built this by hand, and no two built it the same way. That is the problem: the globals a package needs are not obvious, not written down, and you discover them one `ReferenceError` at a time.

### `@vttforge/testing/quench`

Registers a batch inside a live world, for what a mock cannot answer. It waits for `quenchReady` rather than assuming Quench has loaded — the mistake that makes a batch silently never appear — and is a no-op outside Foundry, so a file holding both kinds of test still imports under vitest.

### Writing it as a consumer found a bug in it

The dogfood test set `system.hp.value` and asserted `system.hp.max` survived. It did not: the mock's `update` replaced nested objects where Foundry merges them. A mock that replaces lets a test pass while the real thing drops every sibling key — precisely the failure a test suite is supposed to prevent. Fixed, with the behaviour pinned in both directions (objects merge, arrays replace).

### Ambient globals

A test that mocks Foundry then reads `game.settings` gets "Cannot find name 'game'". Shipped as `@vttforge/testing/globals` rather than kept internal, because every consumer hits it on the first test.

`publint` needed the declaration copied into `dist` — it is not a tsdown entry — which is why the build script grew a line.

All 17 package-quality checks pass, plus typecheck, test, lint, build and knip.
