### PR TITLE
docs: stability policy, and stop requiring Node 26 for browser packages

### DIFF
--- a/.changeset/tidy-poems-write.md
+++ b/.changeset/tidy-poems-write.md
@@ -1,0 +1,13 @@
+---
+'@vttforge/core': patch
+'@vttforge/styles': patch
+'@vttforge/types': patch
+'@vttforge/dev-module': patch
+'@vttforge/testing': patch
+---
+
+Stop requiring Node 26 to install a browser package.
+
+Every package declared `engines.node: ">=26.0.0"`. Four of them — `core`, `styles`, `types` and `dev-module` — compile to ES2022 and run in the browser inside Foundry. They never touch Node, and the floor did nothing except stop anyone on Node 22 LTS from installing the SDK at all.
+
+Those four declare no engine now. `@vttforge/testing` drops to `>=22` — its Quench half runs in the browser too. `@vttforge/cli` and `@vttforge/vite-plugin` keep `>=26`, which is what they actually build against.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ VTTForge ships its own design language — the **Forge theme**: warm-dark surfac
 - **Themes** — Forge is the default. Four documented recipe themes (Codex / Parchment / Grimdark / Neon) live in `examples/themes/` and re-theme everything by overriding `--vttf-*` tokens on a parent class.
 - **Reference Foundry sheet** — `examples/simple-system` renders the canonical reference sheet (HP / AC / SPD / INIT quick stats, four tabs, ability scores grid with roll buttons, items list with kind pills, drop affordance) using the Forge theme. Boot it via the Docker compose below to see the SDK + design system together.
 
+Stability, versioning and Node support: [STABILITY.md](STABILITY.md).
+
 ## Try it today
 
 The repo ships a working Foundry v13 system you can boot in one command. Requires Docker + a [foundryvtt.com](https://foundryvtt.com) license:

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,74 @@
+# Stability and versioning
+
+What you can build on, and what may move.
+
+## Before 1.0
+
+Every package is below `1.0.0`. Under semver that means a **minor may break
+you** — and in this project it regularly does, because the API is still meeting
+real systems and modules for the first time.
+
+Pin exactly, or accept that `pnpm update` can require code changes:
+
+```jsonc
+{ "dependencies": { "@vttforge/core": "0.8.0" } }
+```
+
+A caret on a `0.x` version pins the minor (`^0.8.0` means `>=0.8.0 <0.9.0`),
+so it is narrower than people expect. That is a feature here.
+
+## After 1.0
+
+- No breaking change in a minor. Ever.
+- A breaking change means a major, and a major comes with a migration note
+  saying what to change, not only what changed.
+- Anything marked `@experimental` is exempt. It says so in its own doc comment,
+  and the changelog says so when it moves.
+
+## Deprecation
+
+A stable export that is going away:
+
+1. Gains an `@deprecated` tag naming its replacement, in a minor.
+2. Keeps working for **two more minors**, at least 90 days.
+3. Goes in the next major.
+
+If there is no replacement, the tag says that too. "Deprecated, use X instead"
+is a promise; "deprecated, and here is why nothing replaces it" is honest.
+
+## What each package promises
+
+| Package | Runs in | Stability |
+|---|---|---|
+| `@vttforge/core` | Browser, inside Foundry | Shaping. The base factories and `InferSchema` have moved several times. |
+| `@vttforge/cli` | Node | The command surface is settling; the scaffolded output still changes. |
+| `@vttforge/vite-plugin` | Node | The build contract is the most settled thing here. |
+| `@vttforge/styles` | Browser | Token names are stable; component CSS is not. |
+| `@vttforge/testing` | Node and browser | New. Expect it to move. |
+| `@vttforge/dev-module` | Browser, inside Foundry | Internal to the dev loop; not an API. |
+| `@vttforge/types` | Types only | A stub. It will replace the index signature the base factories use today. |
+
+## Node
+
+Only the packages that run in Node declare an engine floor. `@vttforge/core`,
+`@vttforge/styles`, `@vttforge/types` and `@vttforge/dev-module` run in the
+browser inside Foundry and never touch Node, so they declare none — requiring a
+Node version to install a browser package only blocks people for no reason.
+
+| Package | Node |
+|---|---|
+| `@vttforge/cli` | >= 26 |
+| `@vttforge/vite-plugin` | >= 26 |
+| `@vttforge/testing` | >= 22 — its Quench half runs in the browser |
+| everything else | not applicable |
+
+## Foundry
+
+Every package targets **Foundry v13+**. v12 is an explicit non-goal: the v13
+application and data-model APIs are what the SDK is built on, and supporting
+both would mean shipping the older shape forever.
+
+## Peer dependencies
+
+`@vttforge/vite-plugin` peers on `vite`. Nothing else declares a peer, and
+nothing else should — a package that needs something should depend on it.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,9 +52,6 @@
     "vitest": "catalog:",
     "@vttforge/testing": "workspace:*"
   },
-  "engines": {
-    "node": ">=26.0.0"
-  },
   "publishConfig": {
     "access": "public",
     "provenance": false

--- a/packages/dev-module/package.json
+++ b/packages/dev-module/package.json
@@ -55,9 +55,6 @@
     "unrun": "catalog:",
     "vitest": "catalog:"
   },
-  "engines": {
-    "node": ">=26.0.0"
-  },
   "publishConfig": {
     "access": "public",
     "provenance": false

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -38,17 +38,14 @@
   ],
   "scripts": {
     "build": "node build-tokens.mjs",
-    "typecheck": "echo 'styles is CSS-only — no typecheck'",
+    "typecheck": "echo 'styles is CSS-only \u2014 no typecheck'",
     "test": "echo 'styles has no tests yet'",
     "publint": "publint",
-    "attw": "echo 'styles is CSS-only — no types'"
+    "attw": "echo 'styles is CSS-only \u2014 no types'"
   },
   "devDependencies": {
     "publint": "catalog:",
     "style-dictionary": "catalog:"
-  },
-  "engines": {
-    "node": ">=26.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -57,7 +57,7 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=26.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -48,9 +48,6 @@
     "unrun": "catalog:",
     "vitest": "catalog:"
   },
-  "engines": {
-    "node": ">=26.0.0"
-  },
   "publishConfig": {
     "access": "public",
     "provenance": false


### PR DESCRIPTION
Track 8 asked for four things: a deprecation policy, an audit of the public surface, the `peerDependencies` ranges written down, and the semver discipline locked. `STABILITY.md` is all four.

### The audit found a real problem

Every package declared `engines.node: ">=26.0.0"`.

Four of them — `core`, `styles`, `types`, `dev-module` — compile to ES2022 and **run in the browser, inside Foundry**. They never touch Node. The floor did nothing except stop anyone on Node 22 LTS from installing the SDK at all, for a package that would have run fine.

Now: those four declare no engine. `@vttforge/testing` drops to `>=22`, since its Quench half runs in the browser too. `@vttforge/cli` and `@vttforge/vite-plugin` keep `>=26`, which is what they actually build against.

### What the policy says

- **Before 1.0**, a minor may break you, and in this project it regularly does. Pin exactly, and know that `^0.8.0` on a `0.x` version pins the minor — narrower than people expect, which is a feature here.
- **After 1.0**, no breaking change in a minor, ever. A major carries a migration note saying what to change, not only what changed.
- **Deprecation** is two minors and at least 90 days, with the tag naming a replacement — or saying plainly that nothing replaces it.
- A per-package table of what is settled and what is still moving, which is more useful than a blanket "beta".

### On the surface audit

Comparing `index.ts` exports against the emitted `.d.mts` turned up the inference internals — `Presence`, `Resolve`, the `*Defaults` set. They are reachable in the declaration file because public types reference them, but they are not exported and cannot be imported. That is correct, not a leak, so nothing changed there.
