### PR TITLE
ci: create the version tags and GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,11 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
+  # write, not read: this workflow pushes the version tags and opens the
+  # GitHub releases. Nothing else did — changesets/action creates those as
+  # part of its publish step, and publishing moved here for OIDC without the
+  # tagging coming along.
+  contents: write
   id-token: write # required for npm OIDC trusted publishing
 
 concurrency:
@@ -68,3 +72,21 @@ jobs:
       # Corepack-managed pnpm 10.33+ ships a compatible npm bundle.
       - name: Publish
         run: pnpm publish -r --access public --no-git-checks
+
+      # `changeset git-tag` reads the versions already in package.json and creates
+      # one git tag per package that does not have one yet. Safe to re-run: it
+      # skips tags that already exist.
+      - name: Tag the published versions
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          pnpm exec changeset git-tag
+          git push --tags
+
+      # One GitHub release per new tag, with the notes taken from that
+      # package's CHANGELOG section for that version — the same text the
+      # changeset author wrote, rather than a generated diff summary.
+      - name: Open a GitHub release per tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/create-releases.mjs

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,0 +1,31 @@
+# @vttforge/docs
+
+The documentation site. VitePress + Pagefind.
+
+```bash
+pnpm --filter @vttforge/docs dev     # local, with hot reload
+pnpm --filter @vttforge/docs build   # static HTML + search index
+```
+
+## Known Dependabot alerts
+
+Four open alerts trace to this package. All four are transitive through
+VitePress 1.6.4, which pins Vite 5.x and esbuild 0.21:
+
+| Severity | Package | What it needs |
+|---|---|---|
+| High | vite | `server.fs.deny` bypass — **Windows only** |
+| Medium | vite | path traversal in `.map` handling — dev server |
+| Medium | launch-editor | NTLM disclosure via UNC paths — **Windows only** |
+| Medium | esbuild | permissive CORS on the dev server |
+
+Every one is a **dev-server** issue. CI runs `vitepress build`, which emits
+static HTML and never starts a server, so the published site is not exposed.
+The reachable case is someone running `dev` locally — on Windows, for three of
+them — with a hostile page open in the same browser.
+
+They cannot be resolved by upgrading: VitePress `latest` is 1.6.4 and it pins
+Vite 5. VitePress 2 is alpha, and moving a new docs site onto an alpha to clear
+dev-only advisories is the worse trade.
+
+Revisit when VitePress 2 is stable.

--- a/scripts/create-releases.mjs
+++ b/scripts/create-releases.mjs
@@ -1,0 +1,98 @@
+/**
+ * Open a GitHub release for every version tag that does not have one.
+ *
+ * `changeset tag` creates the tags; nothing opened the releases. That job
+ * belongs to `changesets/action`'s publish step, and publishing moved to a
+ * separate workflow for OIDC without the release-making coming along — which
+ * is why the releases page sat empty while eight versions shipped to npm.
+ *
+ * Notes come from the package's own CHANGELOG section for that version: the
+ * text a changeset author wrote, which says why the change happened. A
+ * generated file list would not.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function sh(cmd, args) {
+  return execFileSync(cmd, args, { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+}
+
+/** Every workspace package directory that publishes. */
+function publishablePackages() {
+  const dirs = [];
+  for (const group of ['packages', 'apps']) {
+    const root = join(REPO_ROOT, group);
+    if (!existsSync(root)) continue;
+    for (const name of readdirSync(root)) {
+      const manifest = join(root, name, 'package.json');
+      if (!existsSync(manifest)) continue;
+      const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+      if (pkg.private === true || !pkg.name || !pkg.version) continue;
+      dirs.push({ dir: join(root, name), name: pkg.name, version: pkg.version });
+    }
+  }
+  return dirs;
+}
+
+/**
+ * The CHANGELOG section for one version.
+ *
+ * Changesets writes `## 1.2.3` headings, so the section runs to the next `## `.
+ */
+function changelogSection(dir, version) {
+  const path = join(dir, 'CHANGELOG.md');
+  if (!existsSync(path)) return '';
+  const lines = readFileSync(path, 'utf8').split('\n');
+  const start = lines.findIndex((l) => l.trim() === `## ${version}`);
+  if (start === -1) return '';
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => l.startsWith('## '));
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n').trim();
+}
+
+function releaseExists(tag) {
+  try {
+    sh('gh', ['release', 'view', tag, '--json', 'tagName']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tagExists(tag) {
+  try {
+    sh('git', ['rev-parse', '--verify', `refs/tags/${tag}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let created = 0;
+let skipped = 0;
+
+for (const { dir, name, version } of publishablePackages()) {
+  const tag = `${name}@${version}`;
+
+  if (!tagExists(tag)) {
+    // The tag is what `changeset tag` produces. No tag means this version was
+    // not part of this release — not an error, just nothing to announce.
+    skipped += 1;
+    continue;
+  }
+  if (releaseExists(tag)) {
+    skipped += 1;
+    continue;
+  }
+
+  const notes = changelogSection(dir, version) || `\`${name}\` ${version}.`;
+  sh('gh', ['release', 'create', tag, '--title', tag, '--notes', notes, '--verify-tag']);
+  console.log(`[create-releases] opened ${tag}`);
+  created += 1;
+}
+
+console.log(`[create-releases] ${created} created, ${skipped} already present or untagged`);


### PR DESCRIPTION
The releases page was empty while eight versions shipped to npm, and the repository had no tags at all.

### The seam

`changesets/action` creates git tags **and** GitHub releases as part of its publish step. This repo passes it only `version-script` — publishing was deliberately moved to `publish.yml` so it could use npm's OIDC trusted publishing. The tagging and release-making went with the publish step, and nothing on the other side picked them up.

Triggering `publish.yml` by `workflow_dispatch` rather than a tag push meant nothing produced a tag either, so there was not even a `v*` to hang a release on.

### The fix

`publish.yml` now runs `changeset git-tag` after a successful publish, pushes the tags, and opens one GitHub release per new tag.

Release notes come from that package's own CHANGELOG section for that version — the text a changeset author wrote, which says *why* the change happened. A generated file list would not.

`permissions` goes from `contents: read` to `write`. Without it none of this could work, which is worth stating because it is the kind of thing that fails at 2am on a release.

`scripts/create-releases.mjs` skips tags that already have a release and versions with no tag, so re-running it is safe.

### The eight missing releases exist now

Created by running the script against the current tags, so the history is not left with a hole:

`@vttforge/cli@0.5.0`, `@vttforge/core@0.8.0`, `@vttforge/dev-module@0.2.1`, `@vttforge/styles@0.3.1`, `@vttforge/testing@0.2.0`, `@vttforge/types@0.1.1`, `@vttforge/vite-plugin@0.3.1`, `create-vttforge@0.3.3`.
