### PR TITLE
fix(vite-plugin): keep class names through minification

### DIFF
--- a/.changeset/keep-class-names.md
+++ b/.changeset/keep-class-names.md
@@ -1,0 +1,13 @@
+---
+'@vttforge/vite-plugin': minor
+---
+
+Keep class names through minification.
+
+Foundry reads class names at runtime, and a minifier does not promise the same one twice. The clearest case is a registered sheet: Foundry keys it by `${package id}.${class name}` and saves that key on every document using it, so a rename between builds orphans the reader's choice. `registerSheets` fixes the name for that case.
+
+Everything else stayed minified. A stack trace named `mo`. An `instanceof` error message named `t`. Someone debugging a sheet that renders nothing read a prototype chain of `go → r → HandlebarsApplication` and had to work out which of those was theirs.
+
+Builds now pass `keepNames` to rolldown, so a class reports the name it was written with.
+
+This complements the explicit sheet id rather than replacing it: a rename in your own source would still move a key that was inferred from the class name.

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",
-    "@vttforge/vite-plugin": "^0.3.0",
+    "@vttforge/vite-plugin": "^0.4.0",
     "vite": "^8.2.2"
   },
   "engines": {

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",
-    "@vttforge/vite-plugin": "^0.3.0",
+    "@vttforge/vite-plugin": "^0.4.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",
-    "@vttforge/vite-plugin": "^0.3.0",
+    "@vttforge/vite-plugin": "^0.4.0",
     "vite": "^8.2.2"
   },
   "engines": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",
-    "@vttforge/vite-plugin": "^0.3.0",
+    "@vttforge/vite-plugin": "^0.4.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -303,6 +303,14 @@ export default function vttforge(options: VttforgeOptions): Plugin {
           rollupOptions: {
             input: rollupInput,
             output: {
+              // Foundry reads class names at runtime, and the minifier does
+              // not promise the same one twice. A registered sheet is keyed by
+              // `${package id}.${class name}` and that key is saved on every
+              // document using it, so a rename orphans the reader's choice.
+              // `registerSheets` fixes the name for that case; this keeps every
+              // other one honest — a stack trace, an instanceof error message,
+              // a prototype chain someone reads while debugging.
+              keepNames: true,
               entryFileNames: (chunkInfo) => {
                 if (chunkInfo.name === JS_ENTRY_FILENAME) return JS_ENTRY_FILENAME;
                 return '[name]';


### PR DESCRIPTION
## What

Builds pass `keepNames` to rolldown, so a class reports the name it was written with.

## Why

Foundry reads class names at runtime, and a minifier does not promise the same one twice.

The sharpest case already has its own fix: a registered sheet is keyed by `${package id}.${class name}`, that key is saved on every document using it, and a rename between builds orphans the reader's choice. `registerSheets` pins the name for that one.

Everything else stayed minified, and it costs real debugging time. Diagnosing the blank-sheet bug earlier in this series meant reading a prototype chain that came back as:

```
go → r → HandlebarsApplication → ActorSheetV2 → DocumentSheetV2 → ApplicationV2
```

Three of those six names are meaningless, and one of them was the class doing the damage.

## Verified

Built a real module with the change and read the chain back out of a live Foundry world:

```
fillable → VttforgeBaseDocumentSheet → ActorSheetV2 → DocumentSheetV2 → ApplicationV2
```

`fillable` is the sheet id `registerSheets` assigns, which is correct. `VttforgeBaseDocumentSheet` read `n` before this change.

The option name was read out of rolldown's own type definitions, not written from memory.

## Not a replacement for the explicit sheet id

A rename in your own source would still move a key that was inferred from a class name. These two work together.