### PR TITLE
docs(vite-plugin): say that keepNames moves hand-registered sheet keys

### DIFF
--- a/.changeset/keep-class-names.md
+++ b/.changeset/keep-class-names.md
@@ -10,4 +10,21 @@ Everything else stayed minified. A stack trace named `mo`. An `instanceof` error
 
 Builds now pass `keepNames` to rolldown, so a class reports the name it was written with.
 
-This complements the explicit sheet id rather than replacing it: a rename in your own source would still move a key that was inferred from the class name.
+## Upgrading moves your sheet keys, once
+
+This matters if you register sheets by hand — `Actors.registerSheet(id, MySheet, …)` rather than the `sheets` option on `registerSystem` / `registerModule`.
+
+Foundry derives the key from the class name, so this release changes it: a sheet that registered as `my-system.e` under 0.3.x registers as `my-system.CharacterSheet` under 0.4.0. Every `flags.core.sheetClass` already saved against the old key names a sheet that no longer exists, and Foundry falls back to the default without saying anything.
+
+That is the same failure the explicit sheet id exists to prevent, so **migrate before you upgrade**:
+
+```ts
+registerSystem({
+  id: 'my-system',
+  sheets: [{ id: 'character', document: 'Actor', sheet: CharacterSheet, types: ['character'], makeDefault: true }],
+});
+```
+
+With an explicit `id`, the key is written down rather than derived, and neither this release nor any later rename moves it. Ship that first, then take the plugin bump — otherwise the key jumps from one derived value to another and your readers lose their sheet in between.
+
+This complements the explicit sheet id rather than replacing it: a rename in your own source would still move a key that was inferred from a class name.


### PR DESCRIPTION
Amends the changeset for #110 before the release PR freezes it into the CHANGELOG.

## The gap

The note said the explicit sheet id and `keepNames` "complement" each other and stopped there. It left out that the upgrade is itself a one-time key change for anyone still registering sheets by hand.

Foundry derives a sheet's key from the class name. So under 0.3.x a hand-registered sheet keyed as `my-system.e`, and under 0.4.0 the same sheet keys as `my-system.CharacterSheet`. Every `flags.core.sheetClass` saved against the old key now names a sheet that does not exist, and Foundry falls back to the default without a word — the exact failure #107 exists to prevent, arriving via its companion.

## Confirmed, not reasoned

The shipped `examples/simple-system` registers by hand. Read out of a live world:

- before the plugin change: `vttforge-example.e`
- after: `vttforge-example.CharacterSheet`

## What the note now says

Migrate to the `sheets` option with an explicit `id` **first**, then take the plugin bump. That way the key stops being derived at all, rather than jumping from one derived value to another with the reader's selection lost in between.

No code changes — release notes only. The `minor` bump was already right for 0.x.