### PR TITLE
refactor(examples): give the example system's sheets stable ids

### DIFF
--- a/examples/simple-system/scripts/main.mjs
+++ b/examples/simple-system/scripts/main.mjs
@@ -37,6 +37,36 @@ try {
     combat: {
       initiative: { formula: '1d20 + @abilities.dex.mod', decimals: 2 },
     },
+    onBeforeInit: () => {
+      // The core sheets go first, so ours can take the default. This runs
+      // before the `sheets` below are registered.
+      const { Actors, Items } = foundry.documents.collections;
+      Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
+      Items.unregisterSheet('core', foundry.applications.sheets.ItemSheetV2);
+    },
+
+    // Declared here rather than with Actors.registerSheet, so the key Foundry
+    // saves on each document is `vttforge-example.character` — written down,
+    // not derived from a class name a bundler is free to rename.
+    sheets: [
+      {
+        id: 'character',
+        document: 'Actor',
+        sheet: CharacterSheet,
+        types: ['character'],
+        makeDefault: true,
+        label: 'VTTFORGE_EXAMPLE.Sheet.Character.title',
+      },
+      {
+        id: 'gear',
+        document: 'Item',
+        sheet: GearSheet,
+        types: ['gear'],
+        makeDefault: true,
+        label: 'VTTFORGE_EXAMPLE.Sheet.Gear.title',
+      },
+    ],
+
     onAfterInit: () => {
       // Surface a single user-facing setting so the SystemConfig wrapper is
       // exercised end-to-end alongside the migration setting.
@@ -52,22 +82,6 @@ try {
       // Register the schemaVersion setting so migrations.run() has somewhere
       // to read/write the version.
       migrations.register();
-
-      // Sheet registration is per-document-type and happens inside init,
-      // after CONFIG.Actor.dataModels has been populated by registerSystem.
-      const { Actors, Items } = foundry.documents.collections;
-      Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
-      Actors.registerSheet(SYSTEM_ID, CharacterSheet, {
-        types: ['character'],
-        makeDefault: true,
-        label: 'VTTFORGE_EXAMPLE.Sheet.Character.title',
-      });
-      Items.unregisterSheet('core', foundry.applications.sheets.ItemSheetV2);
-      Items.registerSheet(SYSTEM_ID, GearSheet, {
-        types: ['gear'],
-        makeDefault: true,
-        label: 'VTTFORGE_EXAMPLE.Sheet.Gear.title',
-      });
     },
     onReady: async () => {
       if (!game.user?.isGM) return;

--- a/examples/simple-system/tests/boot.test.mjs
+++ b/examples/simple-system/tests/boot.test.mjs
@@ -16,8 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 function installFoundryGlobals() {
   const settings = new Map();
   const hooks = new Map();
-  const actorRegistry = vi.fn();
-  const itemRegistry = vi.fn();
+  const registerSheet = vi.fn();
   const actorUnregister = vi.fn();
   const itemUnregister = vi.fn();
 
@@ -80,6 +79,12 @@ function installFoundryGlobals() {
   globalThis.foundry = {
     abstract: { TypeDataModel: class {} },
     applications: {
+      apps: {
+        // What `registerSystem({ sheets })` registers through. Foundry keys a
+        // sheet by `${scope}.${sheetClass.name}`, so the assertions below read
+        // the name back to check the id was pinned.
+        DocumentSheetConfig: { registerSheet },
+      },
       api: {
         HandlebarsApplicationMixin: (base) =>
           class extends base {
@@ -95,14 +100,8 @@ function installFoundryGlobals() {
     data: { fields: {} },
     documents: {
       collections: {
-        Actors: {
-          registerSheet: actorRegistry,
-          unregisterSheet: actorUnregister,
-        },
-        Items: {
-          registerSheet: itemRegistry,
-          unregisterSheet: itemUnregister,
-        },
+        Actors: { unregisterSheet: actorUnregister },
+        Items: { unregisterSheet: itemUnregister },
       },
     },
     utils: {
@@ -127,7 +126,7 @@ function installFoundryGlobals() {
     },
   };
 
-  return { hooks, settings, actorRegistry, itemRegistry, actorUnregister, itemUnregister };
+  return { hooks, settings, registerSheet, actorUnregister, itemUnregister };
 }
 
 let env;
@@ -179,16 +178,28 @@ describe('vttforge-example — boot', () => {
     env.hooks.get('init')();
     expect(env.actorUnregister).toHaveBeenCalled();
     expect(env.itemUnregister).toHaveBeenCalled();
-    expect(env.actorRegistry).toHaveBeenCalledWith(
+    expect(env.registerSheet).toHaveBeenCalledWith(
+      expect.anything(),
       'vttforge-example',
       expect.any(Function),
       expect.objectContaining({ types: ['character'], makeDefault: true }),
     );
-    expect(env.itemRegistry).toHaveBeenCalledWith(
+    expect(env.registerSheet).toHaveBeenCalledWith(
+      expect.anything(),
       'vttforge-example',
       expect.any(Function),
       expect.objectContaining({ types: ['gear'], makeDefault: true }),
     );
+  });
+
+  it('gives each sheet a key that a rebuild cannot move', async () => {
+    await import('../scripts/main.mjs?bootE2');
+    env.hooks.get('init')();
+    // Foundry saves `${scope}.${sheetClass.name}` on every document using the
+    // sheet, and a minifier renames classes between builds. The `id` is what
+    // makes these two keys the same in every build.
+    const keys = env.registerSheet.mock.calls.map(([, scope, cls]) => `${scope}.${cls.name}`);
+    expect(keys).toEqual(['vttforge-example.character', 'vttforge-example.gear']);
   });
 
   it('runs migrations on ready (advancing schemaVersion to 0.1.0)', async () => {


### PR DESCRIPTION
## What

`examples/simple-system` declares its sheets on `registerSystem({ sheets })` with explicit ids, instead of calling `Actors.registerSheet` / `Items.registerSheet`.

## Why

The example is the reference consumer, and it was demonstrating the pattern that breaks.

Foundry derives a sheet's key from the class name and saves that key on every document using the sheet. The example's own key proves the problem:

- before `keepNames`: `vttforge-example.e`
- after: `vttforge-example.CharacterSheet`

Same source, different key, and every saved selection pointing at the old one falls back to the default in silence.

With an id it is `vttforge-example.character` in every build, derived from something written down.

## Ordering

`unregisterSheet` moves to `onBeforeInit`, which runs before the `sheets` are registered — the core sheets have to go first for ours to take the default.

## Verified

Read out of a live Foundry world:

```
actor: vttforge-example.character (default), pdf-character-sheet.fillable
item:  vttforge-example.gear (default)
```

and the character sheet renders.

The boot test now asserts the key rather than just the call — it reads `${scope}.${cls.name}` back and pins both to `vttforge-example.character` and `vttforge-example.gear`.

## Test harness

The harness stubbed `Actors.registerSheet`, which the SDK no longer routes through. It now stubs `foundry.applications.apps.DocumentSheetConfig.registerSheet`, which is where `registerSheets` goes.

That surfaced a separate gap: `withMockFoundry` in `@vttforge/testing` has no `DocumentSheetConfig` either, so a consumer cannot test the `sheets` option at all. Follow-up PR.