### PR TITLE
feat(testing): record sheets and enrichers in withMockFoundry

### DIFF
--- a/.changeset/mock-sheet-enricher-registries.md
+++ b/.changeset/mock-sheet-enricher-registries.md
@@ -1,0 +1,21 @@
+---
+'@vttforge/testing': minor
+---
+
+`withMockFoundry` records sheets and enrichers.
+
+Registering a sheet through `registerSystem({ sheets })` goes via `foundry.applications.apps.DocumentSheetConfig`, which the mock did not have — so a consumer's boot test got "Foundry is not available" rather than a result. Enrichers landed on `CONFIG.TextEditor.enrichers` with no way to read them back.
+
+Both are now on the handle:
+
+```ts
+const foundry = withMockFoundry();
+registerSystem({ id: 'my-system', sheets: [{ id: 'character', document: 'Actor', sheet: CharacterSheet }] });
+foundry.callHook('init');
+
+foundry.sheets.map((s) => s.key); // ['my-system.character']
+```
+
+`key` is the assertion worth writing. Foundry saves it on every document whose owner picked the sheet and builds it from the class name, which a bundler is free to rename between builds — so pinning the key is pinning that the reader's choice survives your next release.
+
+`foundry.enrichers` reads back the namespaced id, pattern and `onRender`.

--- a/apps/docs/guide/testing.md
+++ b/apps/docs/guide/testing.md
@@ -18,14 +18,34 @@ foundry.restore();
 
 `withMockFoundry` installs `foundry`, `game`, `CONFIG`, `Hooks`, `ui` and
 `CONST`, and hands back a handle that **records** what your code registered —
-hooks, settings, notifications. You assert on what happened, not merely on what
-did not throw.
+hooks, settings, notifications, sheets, enrichers. You assert on what happened,
+not merely on what did not throw.
 
 `restore()` puts every global back, including deleting the ones that never
 existed.
 
 Importing from this entry also declares the globals, so `game.settings` in a
 test does not produce "Cannot find name 'game'". There is nothing to configure.
+
+### Assert the sheet key, not the call
+
+```ts
+const foundry = withMockFoundry();
+registerSystem({
+  id: 'my-system',
+  sheets: [{ id: 'character', document: 'Actor', sheet: CharacterSheet, makeDefault: true }],
+});
+foundry.callHook('init');
+
+foundry.sheets.map((s) => s.key); // ['my-system.character']
+```
+
+`key` is the thing worth pinning. Foundry saves it on every document whose
+owner picked the sheet, and it is built from the class name — which a bundler
+is free to rename between builds. A test that asserts the key is a test that
+the reader's choice survives your next release.
+
+`foundry.enrichers` reads back the same way, with the namespaced id.
 
 ### Mock documents behave like documents
 

--- a/packages/testing/src/__tests__/registries.test.ts
+++ b/packages/testing/src/__tests__/registries.test.ts
@@ -27,10 +27,23 @@ function registerSheet(
   Object.defineProperty(sheet, 'name', { value: id, configurable: true });
   const { DocumentSheetConfig } = (
     globalThis as unknown as {
-      foundry: { applications: { apps: { DocumentSheetConfig: Record<string, Function> } } };
+      foundry: {
+        applications: {
+          apps: {
+            DocumentSheetConfig: {
+              registerSheet(
+                documentClass: unknown,
+                scope: string,
+                sheetClass: unknown,
+                sheetOptions: Record<string, unknown>,
+              ): void;
+            };
+          };
+        };
+      };
     }
   ).foundry.applications.apps;
-  DocumentSheetConfig.registerSheet?.('ActorClass', packageId, sheet, options);
+  DocumentSheetConfig.registerSheet('ActorClass', packageId, sheet, options);
 }
 
 /** What `registerEnrichers` does: namespace the id, then push. */

--- a/packages/testing/src/__tests__/registries.test.ts
+++ b/packages/testing/src/__tests__/registries.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The two registries a consumer could not reach before.
+ *
+ * `registerSystem({ sheets })` registers through
+ * `foundry.applications.apps.DocumentSheetConfig`, which the mock did not
+ * have — so a consumer's boot test got "Foundry is not available" instead of
+ * a result. Enrichers landed on `CONFIG.TextEditor.enrichers` with no way to
+ * read them back.
+ *
+ * These drive the globals the way `@vttforge/core` drives them, rather than
+ * importing it: the package deliberately has no core dependency, and
+ * `dogfood.test.ts` already stands a module entry up by hand for the same
+ * reason.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { type MockFoundry, withMockFoundry } from '../vitest/with-mock-foundry.js';
+
+let mock: MockFoundry | undefined;
+
+/** What `registerSheets` does: pin the class name, then register. */
+function registerSheet(
+  packageId: string,
+  id: string,
+  sheet: { name: string },
+  options: Record<string, unknown> = {},
+): void {
+  Object.defineProperty(sheet, 'name', { value: id, configurable: true });
+  const { DocumentSheetConfig } = (
+    globalThis as unknown as {
+      foundry: { applications: { apps: { DocumentSheetConfig: Record<string, Function> } } };
+    }
+  ).foundry.applications.apps;
+  DocumentSheetConfig.registerSheet?.('ActorClass', packageId, sheet, options);
+}
+
+/** What `registerEnrichers` does: namespace the id, then push. */
+function registerEnricher(packageId: string, entry: Record<string, unknown>): void {
+  const { CONFIG } = globalThis as unknown as {
+    CONFIG: { TextEditor: { enrichers: Array<Record<string, unknown>> } };
+  };
+  CONFIG.TextEditor.enrichers.push({ ...entry, id: `${packageId}.${entry.id}` });
+}
+
+afterEach(() => {
+  mock?.restore();
+  mock = undefined;
+});
+
+describe('sheets', () => {
+  it('records the key Foundry would persist', () => {
+    mock = withMockFoundry();
+    // The name a minifier leaves behind.
+    class e {}
+    registerSheet('my-system', 'character', e, { types: ['character'], makeDefault: true });
+
+    expect(mock.sheets).toHaveLength(1);
+    expect(mock.sheets[0]?.key).toBe('my-system.character');
+    expect(mock.sheets[0]?.id).toBe('character');
+    expect(mock.sheets[0]?.options).toMatchObject({ types: ['character'], makeDefault: true });
+  });
+
+  it('keeps them in registration order', () => {
+    mock = withMockFoundry();
+    registerSheet('my-system', 'character', class {});
+    registerSheet('my-system', 'gear', class {});
+    expect(mock.sheets.map((s) => s.key)).toEqual(['my-system.character', 'my-system.gear']);
+  });
+
+  it('starts empty for each mock, so one test cannot leak into the next', () => {
+    mock = withMockFoundry();
+    registerSheet('my-system', 'character', class {});
+    expect(mock.sheets).toHaveLength(1);
+    mock.restore();
+
+    mock = withMockFoundry();
+    expect(mock.sheets).toHaveLength(0);
+  });
+});
+
+describe('enrichers', () => {
+  it('reads back what landed on CONFIG.TextEditor.enrichers', () => {
+    mock = withMockFoundry();
+    const pattern = /@PDF\[(.+?)\]/g;
+    const onRender = () => undefined;
+    registerEnricher('my-system', { id: 'link', pattern, enricher: () => null, onRender });
+
+    expect(mock.enrichers).toHaveLength(1);
+    expect(mock.enrichers[0]?.id).toBe('my-system.link');
+    expect(mock.enrichers[0]?.pattern).toBe(pattern);
+    expect(mock.enrichers[0]?.onRender).toBe(onRender);
+  });
+
+  it('starts empty for each mock', () => {
+    mock = withMockFoundry();
+    registerEnricher('first-system', { id: 'link', pattern: /a/g, enricher: () => null });
+    expect(mock.enrichers).toHaveLength(1);
+    mock.restore();
+
+    mock = withMockFoundry();
+    expect(mock.enrichers).toHaveLength(0);
+  });
+});

--- a/packages/testing/src/vitest/index.ts
+++ b/packages/testing/src/vitest/index.ts
@@ -17,8 +17,10 @@ export {
 } from './mock-foundry.js';
 export {
   type MockFoundry,
+  type RecordedEnricher,
   type RecordedHook,
   type RecordedSetting,
+  type RecordedSheet,
   withMockFoundry,
 } from './with-mock-foundry.js';
 

--- a/packages/testing/src/vitest/with-mock-foundry.ts
+++ b/packages/testing/src/vitest/with-mock-foundry.ts
@@ -24,6 +24,27 @@ export interface RecordedSetting {
   config: Record<string, unknown>;
 }
 
+/** One `DocumentSheetConfig.registerSheet`, as VTTForge makes it. */
+export interface RecordedSheet {
+  /** The key Foundry persists: `<package id>.<sheet id>`. */
+  readonly key: string;
+  /** The package that registered it. */
+  readonly scope: string;
+  /** The sheet id — the class name VTTForge pinned. */
+  readonly id: string;
+  readonly sheetClass: unknown;
+  readonly documentClass: unknown;
+  readonly options: Record<string, unknown>;
+}
+
+/** One entry pushed onto `CONFIG.TextEditor.enrichers`. */
+export interface RecordedEnricher {
+  /** The namespaced id: `<package id>.<enricher id>`. */
+  readonly id: string;
+  readonly pattern: RegExp;
+  readonly onRender?: unknown;
+}
+
 export interface MockFoundry {
   /** Every `Hooks.on` and `Hooks.once`, in order. */
   readonly hooks: ReadonlyArray<RecordedHook>;
@@ -31,6 +52,21 @@ export interface MockFoundry {
   readonly settings: ReadonlyArray<RecordedSetting>;
   /** Every notification raised, by severity. */
   readonly notifications: ReadonlyArray<{ level: 'info' | 'warn' | 'error'; message: string }>;
+  /**
+   * Every sheet registered, in order.
+   *
+   * `key` is the thing worth asserting: Foundry saves it on each document
+   * using the sheet, so a test that pins the key is a test that the reader's
+   * choice survives your next build.
+   */
+  readonly sheets: ReadonlyArray<RecordedSheet>;
+  /**
+   * Every text enricher registered, in order.
+   *
+   * `id` is namespaced, which is what stops a common name from colliding with
+   * another package — and what makes `onRender` fire at all.
+   */
+  readonly enrichers: ReadonlyArray<RecordedEnricher>;
   /** Fire a hook the way Foundry would, for the listeners registered so far. */
   callHook(event: string, ...args: unknown[]): unknown[];
   /** Read back a registered setting's current value. */
@@ -132,12 +168,15 @@ export function withMockFoundry(options: MockFoundryOptions = {}): MockFoundry {
 
   const user = { id: 'user000000000001', isGM: true, name: 'Gamemaster', ...options.user };
 
+  const sheets: RecordedSheet[] = [];
+  const enrichers: RecordedEnricher[] = [];
+
   scope.Hooks = Hooks;
   scope.CONST = { DOCUMENT_OWNERSHIP_LEVELS: { NONE: 0, LIMITED: 1, OBSERVER: 2, OWNER: 3 } };
   scope.CONFIG = {
     Actor: { dataModels: {}, sheetClasses: {} },
     Item: { dataModels: {}, sheetClasses: {} },
-    TextEditor: { enrichers: [] },
+    TextEditor: { enrichers },
     Combat: {},
     ActiveEffect: {},
     statusEffects: [],
@@ -165,11 +204,37 @@ export function withMockFoundry(options: MockFoundryOptions = {}): MockFoundry {
     applications: {
       api: { ApplicationV2: class {}, HandlebarsApplicationMixin: (b: unknown) => b },
       sheets: { ActorSheetV2: class {}, ItemSheetV2: class {} },
+      apps: {
+        // Where `registerSystem({ sheets })` and `registerModule({ sheets })`
+        // register. Foundry builds the key from the class name, so this
+        // records the same key it would persist.
+        DocumentSheetConfig: {
+          registerSheet(
+            documentClass: unknown,
+            scope: string,
+            sheetClass: { name: string },
+            sheetOptions: Record<string, unknown> = {},
+          ) {
+            sheets.push({
+              key: `${scope}.${sheetClass.name}`,
+              scope,
+              id: sheetClass.name,
+              sheetClass,
+              documentClass,
+              options: sheetOptions,
+            });
+          },
+          unregisterSheet: () => {},
+        },
+      },
       ux: {},
       instances: new Map(),
     },
     documents: {
-      collections: { Actors: { registerSheet: () => {} }, Items: { registerSheet: () => {} } },
+      collections: {
+        Actors: { registerSheet: () => {}, unregisterSheet: () => {} },
+        Items: { registerSheet: () => {}, unregisterSheet: () => {} },
+      },
     },
     ...options.foundry,
   };
@@ -202,6 +267,8 @@ export function withMockFoundry(options: MockFoundryOptions = {}): MockFoundry {
     hooks,
     settings,
     notifications,
+    sheets,
+    enrichers,
     callHook,
     getSetting: (namespace, key) => values.get(`${namespace}.${key}`),
     restore() {


### PR DESCRIPTION
## What

`withMockFoundry` now provides `foundry.applications.apps.DocumentSheetConfig` and records both registries on its handle:

```ts
const foundry = withMockFoundry();
registerSystem({
  id: 'my-system',
  sheets: [{ id: 'character', document: 'Actor', sheet: CharacterSheet }],
});
foundry.callHook('init');

foundry.sheets.map((s) => s.key); // ['my-system.character']
foundry.enrichers.map((e) => e.id); // ['my-system.link']
```

## Why

A consumer could not test either registration.

`registerSystem({ sheets })` goes through `DocumentSheetConfig`, which the mock did not have, so a boot test got VTTF-0002 "Foundry is not available" rather than a result. Enrichers landed on `CONFIG.TextEditor.enrichers` with nothing to read them back from.

Found the hard way while converting `examples/simple-system` onto the `sheets` option — its boot test broke the moment the SDK stopped routing through `Actors.registerSheet`.

## `key` is the assertion worth writing

Foundry builds a sheet's key from the class name and saves it on every document whose owner picked the sheet. A bundler is free to rename that class between builds. So a test that pins `key` is a test that the reader's sheet choice survives your next release — which is the failure that started this whole series.

## Note on the tests

They drive the globals the way core drives them rather than importing `@vttforge/core`. The package has no core dependency on purpose, and `dogfood.test.ts` already stands a module entry up by hand for the same reason.