### PR TITLE
fix(cli): ship the template pins instead of only correcting them

### DIFF
--- a/.changeset/ship-current-template-pins.md
+++ b/.changeset/ship-current-template-pins.md
@@ -1,0 +1,13 @@
+---
+'@vttforge/cli': patch
+---
+
+Ship the template pins that were already corrected.
+
+The templates under `templates/*` name the `@vttforge/*` ranges a scaffolded project starts with. Those pins were kept current in the repo — a guard has caught a stale one eight times — but they were only ever corrected *in the repo*. The templates ride inside this package's tarball, and this package was never released alongside the bumps, so nothing reached anyone.
+
+`pnpm create vttforge` has been scaffolding `@vttforge/core@^0.6.0` while core shipped 0.10.0. A new project could not see sheet registration, text enrichers, or `BaseDocumentSheet`, and its lockfile would resolve a core four minors old.
+
+Templates now pin `@vttforge/core@^0.10.0` and `@vttforge/vite-plugin@^0.4.0`.
+
+The guard also learned the second half: if a release bumps a package the templates pin, it has to include `@vttforge/cli`, or the corrected pin sits in the repo and ships to nobody.

--- a/scripts/check-template-pins.mjs
+++ b/scripts/check-template-pins.mjs
@@ -18,6 +18,23 @@
  * Those planned versions come from `changeset status --output`, which is
  * changesets' own logic and mutates nothing. Packages with no pending release
  * fall back to their current version.
+ *
+ * ## The second half, learned the hard way
+ *
+ * Keeping the pins right in the repo is not the same as shipping them. The
+ * templates live inside the `@vttforge/cli` tarball, so a corrected pin only
+ * reaches anyone when the CLI itself is published. It never was: the pin edits
+ * rode along in other packages' releases without a changeset of their own, and
+ * `pnpm create vttforge` kept scaffolding `@vttforge/core@^0.6.0` while core
+ * shipped 0.10.0. Four minors of API — sheet registration, enrichers, a
+ * non-Handlebars document sheet — that a new project could not see.
+ *
+ * Nothing catches that, because every check here passes: the repo is
+ * consistent with itself and the release is consistent with the repo. The
+ * released scaffold is the only thing out of step, and it is nobody's diff.
+ *
+ * So the second check: if a template pins a package that this release bumps,
+ * the release has to include `@vttforge/cli` too.
  */
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -29,6 +46,8 @@ import semver from 'semver';
 // is no other channel to report a bad pin through.
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+/** The package whose tarball carries the templates. */
+const CLI_PACKAGE = '@vttforge/cli';
 const templatesDir = join(repoRoot, 'packages', 'cli', 'templates');
 const packagesDir = join(repoRoot, 'packages');
 
@@ -109,9 +128,47 @@ for (const entry of readdirSync(templatesDir, { withFileTypes: true })) {
   }
 }
 
-if (problems.length === 0) {
+/**
+ * Packages this release bumps that the templates pin.
+ *
+ * Each one means a template pin had to move, and a moved pin reaches a user
+ * only inside a new CLI tarball.
+ */
+const bumpedAndPinned = new Set();
+for (const entry of readdirSync(templatesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  let pkg;
+  try {
+    pkg = readJson(join(templatesDir, entry.name, 'package.json'));
+  } catch {
+    continue;
+  }
+  for (const group of ['dependencies', 'devDependencies']) {
+    for (const name of Object.keys(pkg[group] ?? {})) {
+      if (name !== CLI_PACKAGE && planned.has(name)) bumpedAndPinned.add(name);
+    }
+  }
+}
+
+const cliUnshipped = bumpedAndPinned.size > 0 && !planned.has(CLI_PACKAGE);
+
+if (problems.length === 0 && !cliUnshipped) {
   console.log(`Template pins OK — ${current.size} workspace packages checked.`);
   process.exit(0);
+}
+
+if (cliUnshipped) {
+  console.error(`This release bumps packages the templates pin, but not ${CLI_PACKAGE}:\n`);
+  for (const name of [...bumpedAndPinned].sort()) {
+    console.error(`  ${name} → ${planned.get(name)}`);
+  }
+  console.error(
+    `\nThe templates ship inside the ${CLI_PACKAGE} tarball, so a pin corrected here reaches`,
+  );
+  console.error('nobody until the CLI is published too. Add a patch changeset for it:\n');
+  console.error(`  pnpm changeset  # patch ${CLI_PACKAGE}`);
+  if (problems.length === 0) process.exit(1);
+  console.error('');
 }
 
 console.error('Template pins name versions the next release will not publish:\n');


### PR DESCRIPTION
## The bug

`pnpm create vttforge` scaffolds a project pinned to **`@vttforge/core@^0.6.0`**. Core is on 0.10.0.

Read out of the published tarball rather than inferred:

```bash
npm pack @vttforge/cli@0.5.0
```
```json
// package/templates/system-ts/package.json
"@vttforge/core": "^0.6.0",
"@vttforge/vite-plugin": "^0.3.0",
```

A new project cannot see sheet registration, text enrichers, or `BaseDocumentSheet`, and on 0.x a caret pins the minor, so its lockfile resolves a core four minors old.

## Why nothing caught it

The pins were kept current — a guard has fired on a stale one eight times. Every catch fixed the **repo**.

The templates ship inside the `@vttforge/cli` tarball. The pin edits rode along in core's and vite-plugin's releases, which do not republish the CLI. So the corrected pin landed on `main` and stopped there.

Every existing check passed the whole time: the repo agreed with itself, and the release agreed with the repo. The released scaffold was the only thing out of step, and it is nobody's diff.

## The fix, both halves

Templates pin `@vttforge/core@^0.10.0` and `@vttforge/vite-plugin@^0.4.0`, and this patch releases the CLI so they actually go out.

The guard learned the second half: if a release bumps a package the templates pin, it must include `@vttforge/cli`.

```
This release bumps packages the templates pin, but not @vttforge/cli:

  @vttforge/core → 0.10.1

The templates ship inside the @vttforge/cli tarball, so a pin corrected here reaches
nobody until the CLI is published too. Add a patch changeset for it:

  pnpm changeset  # patch @vttforge/cli
```

Verified by adding a throwaway core changeset and watching the guard fail, then removing it.