### PR TITLE
docs: bring the README and landing page back in line with what shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![FoundryVTT](https://img.shields.io/badge/FoundryVTT-v13%2B-orange?style=flat-square)](https://foundryvtt.com)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org)
 
-[📖 Guide](apps/docs/guide/getting-started.md) · [🗺️ Roadmap](#roadmap) · [🐛 Report bug](https://github.com/vttforge/vttforge/issues)
+[📖 Documentation](https://vttforge.dev/docs/) · [🗺️ Roadmap](#roadmap) · [🐛 Report bug](https://github.com/vttforge/vttforge/issues)
 
 </div>
 
@@ -120,7 +120,7 @@ Create a world on **VTTForge Example System** and add a Character. The sheet ren
 
 ## Design system
 
-The **Forge theme**: warm-dark surfaces, an ember accent, a `{ d20 }` mark, a 4-pt grid. Preview it by opening `packages/styles/preview/index.html` in a browser.
+The **Forge theme**: warm-dark surfaces, an ember accent, a `{ d20 }` mark, a 4-pt grid. It is live at [vttforge.dev/design-system](https://vttforge.dev/design-system/).
 
 - **Tokens** — `packages/styles/tokens.json` (W3C DTCG) compiles to `dist/tokens.css`. Three blocks: Forge, `[data-theme="light"]`, and an opt-in `[data-theme="foundry"]` that follows the GM's Theme V2 setting.
 - **Primitives** — buttons, badges, code blocks, form controls, tabs and the `.sh-*` sheet primitives consume only `--vttf-*` tokens. ARIA state drives the variants.
@@ -143,7 +143,8 @@ The **Forge theme**: warm-dark surfaces, an ember accent, a `{ d20 }` mark, a 4-
 - ✅ **Dev loop** — templates, styles and language files reload in place, without a page refresh
 - ✅ **Design system** — tokens, primitives, themes, brand
 - ✅ **Published** — every package on npm under OIDC trusted publishing, with provenance
-- 🛠️ **Now** — deploying the docs site, and widening `@vttforge/types` so the base factories stop returning `any`
+- ✅ **Documentation** — [vttforge.dev](https://vttforge.dev) carries the guide, the recipes, the error catalogue and the design system
+- 🛠️ **Now** — widening `@vttforge/types` so the base factories stop returning `any`
 - 🚀 **v1.0** — a stable API, decorators once the toolchain allows them, and enough adopters to know which of the remaining gaps are real
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -7,143 +7,154 @@
 [![npm version](https://img.shields.io/npm/v/@vttforge/core.svg?style=flat-square)](https://www.npmjs.com/package/@vttforge/core)
 [![License](https://img.shields.io/npm/l/@vttforge/core.svg?style=flat-square)](LICENSE)
 [![FoundryVTT](https://img.shields.io/badge/FoundryVTT-v13%2B-orange?style=flat-square)](https://foundryvtt.com)
-[![TypeScript](https://img.shields.io/badge/TypeScript-6.x-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org)
 
-[📖 Documentation](#) · [🗺️ Roadmap](#roadmap) · [🐛 Report bug](https://github.com/vttforge/vttforge/issues)
+[📖 Guide](apps/docs/guide/getting-started.md) · [🗺️ Roadmap](#roadmap) · [🐛 Report bug](https://github.com/vttforge/vttforge/issues)
 
 </div>
 
 ---
 
-> ⚠️ **Status:** Pre-release. The full v0.1 surface is shipped on `main` and validated end-to-end inside Foundry v13+. `@vttforge/core` ships `registerSystem`, `BaseTypeDataModel` + `InferSchema<T>`, `BaseActorSheet` / `BaseItemSheet`, `createMigrationRunner`, and the `VTTF-NNNN` error catalogue (100+ tests). `@vttforge/styles` ships the full Forge design system (tokens, sheet primitives, preview page). `@vttforge/vite-plugin` owns the build contract: one Vite config, one `pnpm build`, a deployable `dist/`. The brand mark and landing page for `vttforge.dev` are in `brand/` and `apps/web/`. **Not on npm yet** — npm Trusted Publisher is the only thing standing between the current `main` and the first public release.
+> **Status:** published on npm and usable today. Every package is on its own 0.x line, so a caret pins the minor and a minor bump is a breaking change — the versioning and Node support story is in [STABILITY.md](STABILITY.md).
 
-## Why VTTForge?
+## Start here
 
-If you've built a FoundryVTT system, you've copy-pasted these:
+```bash
+pnpm create vttforge my-system --type system --lang ts
+cd my-system
+pnpm build
+```
+
+That scaffolds a Foundry-loadable system, installs it, and builds a `dist/` plus a release zip with the manifest at the root — which is what foundryvtt.com expects. Every prompt is also a flag, so the same line runs in CI with `--yes`.
+
+`npx @vttforge/cli init` does the same thing if you would rather not go through `create`.
+
+Then point Foundry at it:
+
+```bash
+pnpm dev
+```
+
+This builds, symlinks `dist/` into your Foundry data directory, and watches. Save a template and the open sheet redraws in place — no page reload. The first run asks where Foundry keeps its data and remembers the answer; if Foundry runs in a container and cannot follow a symlink, it prints the compose mount to use instead.
+
+## Why
+
+If you have built a Foundry system, you have written these by hand:
 
 ```ts
-// Every. Single. Sheet.
-#createDragDropHandlers() { /* 36 lines of identical wiring */ }
+#createDragDropHandlers() { /* the same 36 lines, in every sheet */ }
+
 async _prepareContext(options) {
   const context = await super._prepareContext(options);
-  context.tabs = { primary: this._prepareTabs("primary"), ... };  // every group, every sheet
+  context.tabs = { primary: this._prepareTabs("primary") };  // every group, every sheet
   return context;
 }
+
 async _onDropItem(event, data) {
-  const item = await fromUuid(data.uuid);  // fromUuid ceremony in every sheet
-  // …type-switching, validation, transfer logic
+  const item = await fromUuid(data.uuid);  // the fromUuid ceremony, again
 }
 ```
 
-VTTForge replaces all of that with declarative APIs:
+VTTForge declares them instead:
 
 ```ts
 import { BaseActorSheet, fields, type InferSchema } from "@vttforge/core";
 
 class CharacterSheet extends BaseActorSheet() {
   static PARTS = { /* your templates */ };
-  static TABS  = { /* declared once; context.tabs[group] auto-filled in _prepareContext */ };
+  static TABS = { /* declared once; context.tabs is filled in for you */ };
   static DRAG_DROP = [{ dragSelector: ".item[draggable=true]" }];
 
-  // Typed drop sugar — fromUuid already done. Return undefined to fall through to Foundry's default.
-  async onDropItem(item, event) { /* … */ }
+  // fromUuid already done. Return undefined to fall through to Foundry.
+  override async onDropItem(item, event) { /* … */ }
 }
-
-// Same defineSchema() drives both runtime validation AND your TypeScript types.
-class CharacterData extends BaseTypeDataModel() {
-  static defineSchema() {
-    const f = fields();
-    return { level: new f.NumberField({ required: true, initial: 1 }) };
-  }
-}
-type CharacterSystem = InferSchema<ReturnType<typeof CharacterData.defineSchema>>;
-// → { level: number }
 ```
 
-VTTForge eliminates **hundreds of lines of structural boilerplate** with zero functionality regression — validated against a real production FoundryVTT system before each API ships. Where Foundry already does something well (`editImage` from `DocumentSheetV2`, the `_getTabs()` state machine on ApplicationV2), we don't reinvent it.
+And one `defineSchema()` drives both runtime validation and your types:
 
-## Packages
+```ts
+class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
 
-| Package | What it does | Status |
-|---|---|---|
-| [`@vttforge/core`](https://www.npmjs.com/package/@vttforge/core) | Runtime utilities: `BaseTypeDataModel`, `BaseActorSheet`, `BaseItemSheet`, `SystemConfig`, `registerSystem`, `fields()`, `InferSchema<T>`, `createMigrationRunner`, `getErrorManifest`, `VttfError` | 🛠️ shipped on `main` (pending first npm release) |
-| `@vttforge/styles` | Design tokens (Forge theme, OKLCH, generated from W3C DTCG), sheet primitives, `.vttf-*` component classes (button, badge, input, code block, checkbox/radio/switch/range/segment, tabs, sheet primitives), opt-in themes via CSS Cascade Layers. Storybook-lite preview at `packages/styles/preview/`. | 🎨 shipped on `main` (pending first npm release) |
-| [`@vttforge/vite-plugin`](https://www.npmjs.com/package/@vttforge/vite-plugin) | Vite plugin that bundles a Foundry v13+ system or module to a deployable `dist/`: browser-ESM entry (no hashing, `@vttforge/*` inlined), CSS bundle with `@import "@vttforge/styles"` resolved at build time, manifest copied under Foundry's canonical filename with `version` synced from `package.json` and `esmodules` / `styles` rewritten to the bundled output. | 🧰 shipped on `main` (pending first npm release) |
-| [`@vttforge/cli`](https://www.npmjs.com/package/@vttforge/cli) | `vttforge init / dev / build` | 📋 next major track |
-| [`@vttforge/testing`](https://www.npmjs.com/package/@vttforge/testing) | Quench helpers for system/module tests | 📋 v1.0 |
-| [`@vttforge/types`](https://www.npmjs.com/package/@vttforge/types) | Shared TypeScript types | 📋 v1.0 |
+type CharacterSystem = InferSchema<ReturnType<typeof defineCharacterSchema>>;
+// → { level: number; biography: string; hp: { value: number; max: number } }
+```
 
-## Design system
+Where Foundry already does something well — `editImage` on `DocumentSheetV2`, the `_getTabs()` state machine — VTTForge leaves it alone.
 
-VTTForge ships its own design language — the **Forge theme**: warm-dark surfaces, an ember accent, a `{ d20 }` brand mark, and a 4-pt grid. The full system is documented in `packages/styles/` and previewed at `packages/styles/preview/index.html` (open the file in a browser; toggle dark / light / foundry / auto themes).
+## What is actually in the box
 
-- **Brand** — `brand/` ships the mark (full color, mono, plated favicon) at `logo.svg` / `logo-mono.svg` / `favicon.svg`, plus PNG rasters at 32 / 180 / 512 px. Usage rules live in `brand/README.md`.
-- **Tokens** — W3C Design Tokens source at `packages/styles/tokens.json` is compiled by Style Dictionary into `dist/tokens.css`. Three selector blocks: Forge default, `[data-theme="light"]`, and an opt-in `[data-theme="foundry"]` mapping that follows the GM's Theme V2 setting.
-- **Primitives** — buttons, badges, code block + syntax tokens, form controls, tabs, code-block, and the `.sh-*` sheet primitives (portrait, quick stats, items list, dropzone, foot strip) all consume only `--vttf-*` tokens. ARIA states drive variants; `:focus-visible` is owned by the base layer.
-- **Themes** — Forge is the default. Four documented recipe themes (Codex / Parchment / Grimdark / Neon) live in `examples/themes/` and re-theme everything by overriding `--vttf-*` tokens on a parent class.
-- **Reference Foundry sheet** — `examples/simple-system` renders the canonical reference sheet (HP / AC / SPD / INIT quick stats, four tabs, ability scores grid with roll buttons, items list with kind pills, drop affordance) using the Forge theme. Boot it via the Docker compose below to see the SDK + design system together.
+Most of these exist because something failed quietly in a real world, not because the API looked tidy.
 
-Stability, versioning and Node support: [STABILITY.md](STABILITY.md).
+| Package | What it does |
+|---|---|
+| [`@vttforge/core`](https://www.npmjs.com/package/@vttforge/core) | `registerSystem` / `registerModule`, sheet and enricher registration, `BaseTypeDataModel` + `InferSchema<T>`, `BaseActorSheet` / `BaseItemSheet` / `BaseDocumentSheet` / `BaseApplication`, `SystemConfig`, `createMigrationRunner`, and the `VTTF-NNNN` error catalogue |
+| [`@vttforge/cli`](https://www.npmjs.com/package/@vttforge/cli) | `vttforge init` / `dev` / `build` / `audit` — scaffolding, the symlink-and-watch dev loop, the release zip, and a manifest linter |
+| [`@vttforge/vite-plugin`](https://www.npmjs.com/package/@vttforge/vite-plugin) | The build contract: browser-ESM output with no hashing, CSS bundled, manifest copied under Foundry's filename with `version` and entry paths rewritten |
+| [`@vttforge/styles`](https://www.npmjs.com/package/@vttforge/styles) | The Forge design system — W3C DTCG tokens compiled to CSS, `.vttf-*` primitives, sheet primitives, opt-in themes over cascade layers |
+| [`@vttforge/testing`](https://www.npmjs.com/package/@vttforge/testing) | `withMockFoundry` for Vitest, and a Quench half for what a mock cannot answer |
+| [`@vttforge/types`](https://www.npmjs.com/package/@vttforge/types) | Shared TypeScript types |
+| [`@vttforge/dev-module`](https://www.npmjs.com/package/@vttforge/dev-module) | The in-world half of the dev loop — installed for you by `vttforge dev` |
+| [`create-vttforge`](https://www.npmjs.com/package/create-vttforge) | So `pnpm create vttforge` works |
 
-## Try it today
+### Three things it stops you getting wrong
 
-The repo ships a working Foundry v13 system you can boot in one command. Requires Docker + a [foundryvtt.com](https://foundryvtt.com) license:
+**A sheet key that survives your next build.** Foundry keys a registered sheet by `${package id}.${class name}` and saves that key on every document whose owner picked the sheet. A minifier renames classes, so the key moves and the reader's choice silently falls back to the default. Registering through `sheets` with an explicit `id` writes the key down instead of deriving it.
+
+**An enricher that actually fires.** `CONFIG.TextEditor.enrichers` takes an entry and does nothing with it in four ways, none of which say so — `onRender` without an `id` never runs, a duplicate `id` loses to whoever registered first, and a pattern without the `g` flag throws inside someone's chat message. Registering through `enrichers` namespaces the id and checks the rest up front.
+
+**A sheet that renders something other than a template.** `BaseActorSheet` mixes in Handlebars, which is right for `static PARTS` and wrong for a canvas, an embedded PDF, or a framework mount — and using it for one of those renders nothing, with a clean console. `BaseDocumentSheet` is the same plumbing without the mixin.
+
+## Try the example
+
+The repo ships a working Foundry v13 system. Requires Docker and a [foundryvtt.com](https://foundryvtt.com) license:
 
 ```bash
 git clone https://github.com/vttforge/vttforge && cd vttforge
 corepack enable && pnpm install
-pnpm build                                       # bundles the example system via @vttforge/vite-plugin into examples/simple-system/dist/
-cp .env.example .env                             # fill in FOUNDRY_LICENSE_KEY / USERNAME / PASSWORD
+pnpm build
+cp .env.example .env                             # FOUNDRY_LICENSE_KEY / USERNAME / PASSWORD
 docker compose -f docker-compose.dev.yml up      # → http://localhost:30000
 ```
 
-Inside Foundry: create a world on **VTTForge Example System**, add a Character actor. The sheet renders the canonical reference layout — header with HP / AC / SPD / INIT quick stats, four tabs (Abilities · Inventory · Spells · Biography), ability scores grid with roll buttons, items list with kind pills (`equipped` / `valued` / `stowed`), drop affordance, and the demo migration runs at world load.
+Create a world on **VTTForge Example System** and add a Character. The sheet renders the reference layout — quick stats, four tabs, an ability grid with roll buttons, an items list with kind pills — and the demo migration runs at world load.
 
-## Quick start (after `@vttforge/cli` ships)
+## Design system
 
-> Coming with `@vttforge/cli`. The shape will look like this:
+The **Forge theme**: warm-dark surfaces, an ember accent, a `{ d20 }` mark, a 4-pt grid. Preview it by opening `packages/styles/preview/index.html` in a browser.
 
-```bash
-# Scaffold a new FoundryVTT system in TypeScript
-npx @vttforge/cli init my-system --type system --lang ts
-
-# Start the dev server with HMR for .hbs templates
-cd my-system
-vttforge dev --foundry-data ~/Library/Application\ Support/FoundryVTT/Data
-
-# Production build
-vttforge build
-```
-
-Until then, the contract is already runnable today via the Vite plugin directly — see `examples/simple-system/vite.config.mjs` for the minimal setup.
+- **Tokens** — `packages/styles/tokens.json` (W3C DTCG) compiles to `dist/tokens.css`. Three blocks: Forge, `[data-theme="light"]`, and an opt-in `[data-theme="foundry"]` that follows the GM's Theme V2 setting.
+- **Primitives** — buttons, badges, code blocks, form controls, tabs and the `.sh-*` sheet primitives consume only `--vttf-*` tokens. ARIA state drives the variants.
+- **Themes** — four recipes (Codex, Parchment, Grimdark, Neon) in `examples/themes/`, each re-theming everything by overriding tokens on a parent class.
+- **Brand** — `brand/` has the mark and rasters; usage rules in `brand/README.md`.
 
 ## Design principles
 
-1. **Zero lock-in.** VTTForge outputs plain `.mjs` files that Foundry loads natively. You can drop VTTForge from your project at any time.
-2. **Type-safe by default.** Full TypeScript declarations. Eventually, schema-to-type inference (Zod-style) so you stop double-typing your data models.
-3. **Battle-tested.** Every API is validated against a real production FoundryVTT system before being shipped.
-4. **Modern tooling.** pnpm 10+ with Corepack and catalogs, Turborepo, `tsdown` (Rolldown-based), Vite (consumer dev server), Biome (+ optional Oxlint), Changesets with npm OIDC trusted publishing, `publint` + `attw` + `knip` + `syncpack`, `lefthook`. The same stack the rest of the JS ecosystem uses in 2026.
-5. **Community first.** MIT licensed. No paid tiers. Sponsor optional.
+1. **Zero lock-in.** The output is plain `.mjs` that Foundry loads natively. Drop VTTForge whenever you like.
+2. **Validated against something real.** Every API is used by a real Foundry module before it ships. Several exist only because that module broke in a way nothing reported.
+3. **Fail loudly or not at all.** Where Foundry accepts something and quietly does nothing with it, VTTForge either refuses it up front or makes the mistake impossible to express.
+4. **Modern tooling.** pnpm with catalogs, Turborepo, tsdown, Vite, Biome, Changesets with npm OIDC trusted publishing, publint, attw, knip, syncpack, lefthook.
+5. **Community first.** MIT. No paid tiers.
 
 ## Roadmap
 
-- ✅ **Foundation** — Monorepo (pnpm + Turborepo), CI on self-hosted runners, npm OIDC publish workflow, six `@vttforge/*` package stubs
-- ✅ **Core SDK** — `registerSystem`, `BaseTypeDataModel` + `InferSchema<T>` (partial), `BaseActorSheet` / `BaseItemSheet`, `createMigrationRunner`, `VTTF-NNNN` error registry
-- ✅ **Design system** — Forge tokens (W3C DTCG), `.vttf-*` primitives, brand mark, Storybook-lite preview, landing page
-- ✅ **Build pipeline** — `@vttforge/vite-plugin` (browser-ESM bundle, CSS pipeline, manifest sync, watch graph)
-- 📦 **Next: first public release** — wire up npm Trusted Publisher, flip the repo public, tag-and-publish all six packages via OIDC
-- 🛠️ **After that** — `@vttforge/cli` scaffolding, `vttforge.dev` docs site (VitePress + Pagefind), Foundry-aware HMR for `.hbs`
-- 🚀 **v1.0** — Full schema-to-type inference, decorators (`@SystemSetting`, `@DocumentSheet`), Quench-based `@vttforge/testing`, stable API
+- ✅ **Core SDK** — registration, data models with type inference, the sheet and application bases, migrations, the error registry
+- ✅ **Build pipeline** — one Vite config, a deployable `dist/`, a release zip
+- ✅ **CLI** — `init` with four templates, `dev`, `build`, `audit`
+- ✅ **Dev loop** — templates, styles and language files reload in place, without a page refresh
+- ✅ **Design system** — tokens, primitives, themes, brand
+- ✅ **Published** — every package on npm under OIDC trusted publishing, with provenance
+- 🛠️ **Now** — deploying the docs site, and widening `@vttforge/types` so the base factories stop returning `any`
+- 🚀 **v1.0** — a stable API, decorators once the toolchain allows them, and enough adopters to know which of the remaining gaps are real
 
 ## Contributing
 
-VTTForge is in pre-release. The core API is being shaped against a real production system, so contributions are most useful as:
+The API is being shaped against real Foundry projects, so the most useful contributions right now are:
 
-- **Reporting boilerplate patterns** in your own system/module that VTTForge could eliminate
-- **Trying the v0.1 release** when it lands and giving feedback on rough edges
-- **Documentation improvements** (always welcome)
+- **Boilerplate you keep writing** in your own system or module that VTTForge could remove
+- **Rough edges** in the packages as published
+- **Documentation** — always welcome
 
-Once the core API stabilizes in v1.0, we'll open up to broader code contributions. Read [CONTRIBUTING.md](./CONTRIBUTING.md) when it lands.
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License
 

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -3,11 +3,13 @@
 ## Scaffold
 
 ```bash
-npx @vttforge/cli init my-system --type system --lang ts
+pnpm create vttforge my-system --type system --lang ts
 cd my-system
-npm install
-npm run build
+pnpm build
 ```
+
+`create` installs for you, so there is no separate install step. If you would
+rather not go through it, `npx @vttforge/cli init` takes the same arguments.
 
 That produces a Foundry-loadable tree in `dist/` and a release zip with the
 manifest at the root, which is what foundryvtt.com expects.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -32,7 +32,7 @@
         <a class="brand" href="#top">
           <svg class="brand-mark" width="30" height="30" aria-hidden="true"><use href="#vttf-mark" /></svg>
           <span class="brand-name"><span class="v">VTT</span>Forge</span>
-          <span class="ver-pill">v0.1 · pre-release</span>
+          <span class="ver-pill">on npm</span>
         </a>
         <nav class="top-nav">
           <a href="#why">Why</a>
@@ -70,7 +70,7 @@
           <div class="hero-ctas">
             <div class="install-cmd">
               <span class="prompt">$</span>
-              <span id="install-text">npm i @vttforge/core</span>
+              <span id="install-text">pnpm create vttforge</span>
               <button class="copy-btn" id="copy-btn" type="button" aria-label="Copy install command">
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="4" y="4" width="9" height="10" rx="1.5" stroke="currentColor" stroke-width="1.4"/><path d="M3 11V3a1 1 0 0 1 1-1h7" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
                 <span class="lbl">copy</span>
@@ -365,7 +365,7 @@
         <div class="shell">
           <div class="cta-strip">
             <h2>Built one Foundry system the hard way?<br />Try building the next one with VTTForge.</h2>
-            <p>v0.1 lands soon. Star the repo, file an issue with the boilerplate patterns you'd like eliminated, or open the design system to see what's shipping.</p>
+            <p>Every package is on npm. Scaffold one, file an issue with the boilerplate you keep writing by hand, or open the design system to see what ships with it.</p>
             <div class="row">
               <a href="https://github.com/vttforge/vttforge" class="top-cta">Star on GitHub →</a>
               <a href="/design-system" class="btn-secondary">View design system</a>


### PR DESCRIPTION
## The problem

The README said the packages were not on npm, and that npm Trusted Publishing was "the only thing standing between the current `main` and the first public release". All eight have been published for a while.

It also listed `@vttforge/cli` as a future track, described `@vttforge/testing` as Quench helpers when its main half is `withMockFoundry` for Vitest, linked documentation at `#`, and carried a v0.1 roadmap for a repo whose packages sit on six different 0.x lines.

## Verified, not assumed

The quick-start was rewritten against a scaffold run from the **published** CLI, not from the templates in this repo:

```
pnpm create vttforge my-system --type system --lang ts
```

resolves `@vttforge/core@0.10.0`, `@vttforge/vite-plugin@0.4.0`, `@vttforge/styles@0.3.1`, and `pnpm build` produces a 42 KB release zip. That is the same "read it out of the published artifact" check that caught the stale template pins, applied to the docs.

## No version numbers in the prose

Every package moves on its own 0.x line, so any number written into the README is stale by the next release. STABILITY.md carries the versioning and Node story; the README points at it.

## The documentation link

Points at the guide in this repo, not at `vttforge.dev`. The site builds and Pagefind indexes 20 pages, but **no workflow deploys it** — there is no Pages job and no CNAME. Swapping one false claim for another is not a fix. Deploying it is on the roadmap section as current work.

## New section

"Three things it stops you getting wrong" — the sheet key that moves when a minifier renames a class, the four ways an enricher entry is accepted and ignored, and the Handlebars mixin that renders nothing for a canvas or PDF sheet.

"Eliminates boilerplate" undersells the SDK. Most of that API exists because something failed silently in a real Foundry world, and the README never said so.

## Also

- `apps/web/index.html` — the `v0.1 · pre-release` pill, the "v0.1 lands soon" line, and an install command for a package nobody installs directly.
- `apps/docs/guide/getting-started.md` — leads with `pnpm create vttforge`, which is the entry point `create-vttforge` exists for, and drops the `npm install` step that `create` already does.

Neither the root README nor `apps/web/` ships in a tarball, and the package READMEs were already accurate, so no changeset.