### PR TITLE
ci(docs): deploy the landing page, docs and design system to Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,75 @@
+name: Deploy site
+
+# The landing page, the docs and the styles preview go out together, because
+# Pages serves one artifact per repository. `scripts/assemble-site.mjs` is what
+# decides the layout; this workflow only builds the inputs and hands the result
+# over.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/web/**'
+      - 'apps/docs/**'
+      - 'packages/styles/**'
+      - 'packages/core/src/errors/**' # the error pages are generated from the registry
+      - 'scripts/assemble-site.mjs'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write # Pages deploys under OIDC, the same as npm — no token to store
+
+# A queued deploy is always more current than the one it is waiting behind, but
+# cancelling one mid-flight would leave the site half-published.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and assemble
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '26'
+
+      - name: Activate pnpm via Corepack
+        run: |
+          npm install -g corepack@latest
+          corepack enable
+          corepack install -g pnpm@11.25.0
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # Covers both sites as well as the packages. It has to: the error pages
+      # under apps/docs/errors are written by the core build from the
+      # VTTF-NNNN registry, so the docs cannot be built on their own.
+      - name: Build
+        run: pnpm build
+
+      - name: Assemble
+        run: node scripts/assemble-site.mjs
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ skills-lock.json
 # Build outputs
 dist/
 **/.vitepress/cache/
+# The assembled Pages artifact — built by scripts/assemble-site.mjs.
+site/
 **/.vitepress/dist/
 build/
 *.tsbuildinfo

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -16,12 +16,21 @@ function errorPages() {
 
 export default defineConfig({
   title: 'VTTForge',
+  // The landing page owns the root of vttforge.dev; the docs live under it,
+  // in one Pages artifact.
+  base: '/docs/',
   description: 'An SDK and CLI for building Foundry VTT v13+ systems and modules.',
   cleanUrls: true,
   lastUpdated: true,
 
-  // Pagefind indexes the built output, so the built-in search is off.
   themeConfig: {
+    // Was Pagefind, which built an index nothing ever loaded: no theme
+    // component mounted its UI, so the navbar search slot rendered empty and
+    // the site shipped with no search at all. At twenty pages VitePress's own
+    // local index is enough, and it is one line instead of a component plus
+    // asset loading.
+    search: { provider: 'local' },
+
     nav: [
       { text: 'Guide', link: '/guide/getting-started' },
       { text: 'Recipes', link: '/recipes/' },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,11 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vitepress dev .",
-    "build": "vitepress build . && pagefind --site .vitepress/dist",
+    "build": "vitepress build .",
     "preview": "vitepress preview ."
   },
   "devDependencies": {
-    "pagefind": "catalog:",
     "vitepress": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ catalogs:
     lefthook:
       specifier: ^2.1.12
       version: 2.1.12
-    pagefind:
-      specifier: ^1.5.2
-      version: 1.5.2
     publint:
       specifier: ^0.3.24
       version: 0.3.24
@@ -116,9 +113,6 @@ importers:
 
   apps/docs:
     devDependencies:
-      pagefind:
-        specifier: 'catalog:'
-        version: 1.5.2
       vitepress:
         specifier: 'catalog:'
         version: 1.6.4(@algolia/client-search@5.57.0)(@types/node@26.4.0)(change-case@5.4.4)(jiti@2.7.0)(lightningcss@1.33.0)(postcss@8.5.26)(search-insights@2.17.3)(typescript@7.0.2)(yaml@2.9.0)
@@ -1216,41 +1210,6 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@pagefind/darwin-arm64@1.5.2':
-    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pagefind/darwin-x64@1.5.2':
-    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@pagefind/freebsd-x64@1.5.2':
-    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@pagefind/linux-arm64@1.5.2':
-    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pagefind/linux-x64@1.5.2':
-    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pagefind/windows-arm64@1.5.2':
-    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pagefind/windows-x64@1.5.2':
-    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
 
@@ -2933,10 +2892,6 @@ packages:
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
-  pagefind@1.5.2:
-    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
-    hasBin: true
-
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
 
@@ -4549,27 +4504,6 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
 
-  '@pagefind/darwin-arm64@1.5.2':
-    optional: true
-
-  '@pagefind/darwin-x64@1.5.2':
-    optional: true
-
-  '@pagefind/freebsd-x64@1.5.2':
-    optional: true
-
-  '@pagefind/linux-arm64@1.5.2':
-    optional: true
-
-  '@pagefind/linux-x64@1.5.2':
-    optional: true
-
-  '@pagefind/windows-arm64@1.5.2':
-    optional: true
-
-  '@pagefind/windows-x64@1.5.2':
-    optional: true
-
   '@pnpm/deps.graph-sequencer@1100.0.1': {}
 
   '@publint/pack@0.1.7':
@@ -6056,16 +5990,6 @@ snapshots:
   p-try@2.2.0: {}
 
   package-manager-detector@1.8.0: {}
-
-  pagefind@1.5.2:
-    optionalDependencies:
-      '@pagefind/darwin-arm64': 1.5.2
-      '@pagefind/darwin-x64': 1.5.2
-      '@pagefind/freebsd-x64': 1.5.2
-      '@pagefind/linux-arm64': 1.5.2
-      '@pagefind/linux-x64': 1.5.2
-      '@pagefind/windows-arm64': 1.5.2
-      '@pagefind/windows-x64': 1.5.2
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,6 @@ packages:
 
 catalog:
   vitepress: ^1.6.4
-  pagefind: ^1.5.2
   '@arethetypeswrong/cli': ^0.18.5
   '@biomejs/biome': ^2.5.11
   '@changesets/cli': ^3.0.1

--- a/scripts/assemble-site.mjs
+++ b/scripts/assemble-site.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Assemble everything vttforge.dev serves into one directory.
+ *
+ * GitHub Pages publishes a single artifact per repository and allows a single
+ * custom domain, so the three things this repo has to serve share one tree
+ * rather than one host each:
+ *
+ *   /                 the landing page      (apps/web)
+ *   /docs/            the documentation     (apps/docs, built with base '/docs/')
+ *   /design-system/   the styles preview    (packages/styles/preview)
+ *
+ * The preview is the awkward one. It is authored to sit inside the styles
+ * package and reach `../index.css`, which pulls in five siblings through
+ * `@import`. Copying it alone gives an unstyled page; copying the graph to
+ * where the page expects it would scatter `reset.css`, `components.css` and a
+ * `dist/` directory across the site root. So the stylesheet graph is copied
+ * beside the page and the one reference is rewritten to match.
+ */
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const out = join(repoRoot, 'site');
+
+/** The domain Pages serves this from. Written as a file, which is what Pages reads. */
+const DOMAIN = 'vttforge.dev';
+
+/** Everything `packages/styles/index.css` reaches, relative to the package root. */
+const STYLE_GRAPH = [
+  'index.css',
+  'reset.css',
+  'base.css',
+  'components.css',
+  'styles.layer.css',
+  'themes/forge.css',
+  'dist/tokens.css',
+];
+
+function requireBuilt(path, what) {
+  if (!existsSync(path)) {
+    console.error(`Missing ${what}: ${path}`);
+    console.error('Run `pnpm build` first — this script assembles, it does not build.');
+    process.exit(1);
+  }
+}
+
+const webDist = join(repoRoot, 'apps/web/dist');
+const docsDist = join(repoRoot, 'apps/docs/.vitepress/dist');
+const stylesRoot = join(repoRoot, 'packages/styles');
+
+requireBuilt(webDist, 'landing page build');
+requireBuilt(docsDist, 'docs build');
+requireBuilt(join(stylesRoot, 'dist/tokens.css'), 'compiled design tokens');
+
+rmSync(out, { recursive: true, force: true });
+mkdirSync(out, { recursive: true });
+
+// Landing page at the root.
+cpSync(webDist, out, { recursive: true });
+
+// Docs under /docs/. VitePress already built every internal path with that
+// prefix, so this is a plain copy.
+cpSync(docsDist, join(out, 'docs'), { recursive: true });
+
+// Styles preview under /design-system/, with its stylesheet graph beside it.
+const preview = join(out, 'design-system');
+mkdirSync(preview, { recursive: true });
+cpSync(join(stylesRoot, 'preview/preview.js'), join(preview, 'preview.js'));
+for (const file of STYLE_GRAPH) {
+  const from = join(stylesRoot, file);
+  if (!existsSync(from)) continue;
+  const to = join(preview, file);
+  mkdirSync(dirname(to), { recursive: true });
+  cpSync(from, to);
+}
+
+// The one rewrite: the page reaches up a directory for its stylesheet because
+// of where it lives in the repo, and here it does not live there.
+const previewHtml = readFileSync(join(stylesRoot, 'preview/index.html'), 'utf8').replace(
+  '../index.css',
+  './index.css',
+);
+writeFileSync(join(preview, 'index.html'), previewHtml);
+
+// Pages serves this from a custom domain; without the file it reverts to
+// github.io on every deploy.
+writeFileSync(join(out, 'CNAME'), `${DOMAIN}\n`);
+
+// Jekyll would otherwise skip any path starting with an underscore, which is
+// where VitePress puts its assets.
+writeFileSync(join(out, '.nojekyll'), '');
+
+console.log(`Assembled → ${out}`);
+console.log(`  /               landing page`);
+console.log(`  /docs/          documentation`);
+console.log(`  /design-system/ styles preview`);


### PR DESCRIPTION
The docs site has never been deployed. There was no Pages workflow and no CNAME, which is why the README could not honestly link `vttforge.dev`.

## Layout

Pages serves **one artifact per repository** and allows **one custom domain**, so the three things this repo publishes share a tree rather than a host each:

```
/                 landing page      (apps/web)
/docs/            documentation     (apps/docs, base '/docs/')
/design-system/   styles preview    (packages/styles/preview)
```

`scripts/assemble-site.mjs` owns that layout; the workflow only builds the inputs and hands over the result.

## Two things were broken before anything could ship

**The docs had no search.** The config said Pagefind indexed the build, and it did — 20 pages, 1080 words. Nothing loaded it. No theme component mounted Pagefind's UI, so the navbar rendered `<div class="VPNavBarSearch search"><!----></div>` and the site shipped a dead search affordance.

At twenty pages VitePress's own local index is enough and is one config line, so Pagefind is removed from the build script, the catalog and the lockfile rather than left half-wired. This reverses a documented decision, deliberately.

**The landing page linked `/design-system` three times** and nothing built that route.

The preview lives inside the styles package and reaches `../index.css`, which pulls in five siblings through `@import`. Copying the page alone gives an unstyled wall of text; copying the graph where the page expects it would scatter `reset.css`, `components.css` and a `dist/` directory across the site root. So the graph is copied beside the page and the single reference is rewritten.

## Verified on the assembled artifact

Served the built tree and checked it, rather than trusting two green builds:

| Check | Result |
|---|---|
| `/`, `/docs/`, `/docs/guide/getting-started`, `/design-system/` | all 200 |
| docs asset paths | `/docs/assets/...` — base applied |
| design-system CSS graph (7 files) | all 200 |
| preview rendering | `--vttf-bg` resolves to `oklch(0.165 0.012 50)` |
| search | "enricher" → 6 hits, including the generated `VTTF-0007` page |
| absolute Markdown links | VitePress base-prefixes them itself; no manual fix needed |

## Deploy

Runs under OIDC with `id-token: write`, the same as the npm publish — no token to store. Triggers on pushes touching the sites, the styles package, the error registry the docs pages are generated from, or the workflow itself.

## DNS is not part of this

The domain currently resolves to an AWS parking IP through GoDaddy nameservers. Pointing it at Pages replaces those A records — the exact values are in the PR discussion, and the change is the owner's to make in GoDaddy.

## Note on action pinning

Actions are pinned by tag to match the three workflows already here. Moving all four to SHAs is worth doing in one pass rather than leaving the set inconsistent.