### PR TITLE
ci: pin every action to a commit SHA

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     if: github.repository == 'vttforge/vttforge'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 
@@ -36,7 +36,7 @@ jobs:
         run: pnpm install --frozen-lockfile --force
 
       - name: Create Version PR (publishing happens in publish.yml under OIDC)
-        uses: changesets/action@v2
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         with:
           version-script: pnpm changeset:version
           commit-message: 'chore(release): version packages'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
     name: Lint (biome + syncpack)
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 
@@ -45,9 +45,9 @@ jobs:
     name: Typecheck
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 
@@ -67,9 +67,9 @@ jobs:
     name: Test
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 
@@ -89,9 +89,9 @@ jobs:
     name: Build
     runs-on: [self-hosted, linux, x64, gcp]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 
@@ -108,7 +108,7 @@ jobs:
         run: pnpm build
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: |
@@ -121,9 +121,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     needs: build
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 
@@ -150,9 +150,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, gcp]
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,9 +33,9 @@ jobs:
     name: Build and assemble
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 
@@ -57,9 +57,9 @@ jobs:
       - name: Assemble
         run: node scripts/assemble-site.mjs
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: site
 
@@ -72,4 +72,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '26'
 


### PR DESCRIPTION
Every `uses:` in this repo referenced a tag. A tag is a moving pointer: whoever controls an action's repository can retag `v4` at any commit, and every workflow trusting that tag runs the new code on the next push, with whatever permissions the job holds.

Here that includes the publish job's OIDC identity for npm and the Pages deploy — the two places in this repo where a compromised action would matter most.

| Action | Pinned to |
|---|---|
| `actions/checkout` | `3d3c42e5…` (v7) |
| `actions/setup-node` | `820762786…` (v7) |
| `actions/upload-artifact` | `043fb46d1…` (v7) |
| `actions/configure-pages` | `983d7736d…` (v5) |
| `actions/deploy-pages` | `d6db90164…` (v4) |
| `actions/upload-pages-artifact` | `7b1f4a764…` (v4) |
| `changesets/action` | `8488615a6…` (v2) |

Each SHA was resolved from the tag it replaces via the GitHub API, not copied from anywhere. The tag stays in a trailing comment so a human can read what version this is and Dependabot can still offer the bump.

One note: `changesets/action@v2` is a **branch**, not a tag — it currently points at the same commit as `v2.1.1`. A branch is an even weaker promise than a tag, which makes it the one most worth pinning.

The module repo gets the same treatment separately; its workflow lives in another repository.