### PR TITLE
feat(core): type the Foundry surface the bases stand on

### DIFF
--- a/.changeset/ship-core-011-templates.md
+++ b/.changeset/ship-core-011-templates.md
@@ -1,0 +1,7 @@
+---
+'@vttforge/cli': patch
+---
+
+Templates pin `@vttforge/core@^0.11.0`.
+
+The base classes stopped carrying an index signature in that release, so a project scaffolded against an older core would not see the errors the new typing exists to raise.

--- a/.changeset/typed-foundry-surface.md
+++ b/.changeset/typed-foundry-surface.md
@@ -1,0 +1,36 @@
+---
+'@vttforge/core': minor
+---
+
+Replace the index signature on the base classes with the Foundry members they stand on.
+
+The base factories returned an instance typed `Added & { [member: string]: any }`. The index signature was meant as a middle ground — our half typed, Foundry's half reachable. Measured against two real consumers, it turned out to be the worse of the two failures.
+
+It made every property access legal:
+
+```ts
+const viewer = new PdfViewer();
+viewer.goToPage(3);      // no such method — accepted
+viewer.tpyoDeVerdade();  // not even a real name — accepted
+```
+
+A module shipped a release calling `url` and `goToPage` on a viewer that had neither, and nothing reported it.
+
+And it did not buy the thing it looked like it bought. An index signature is not a declaration, so `override` on a Foundry member was rejected anyway — `error TS4113`. It permitted what should have failed and forbade what should have worked.
+
+`ApplicationV2Members` and `DocumentSheetV2Members` now describe the Foundry surface these bases rely on: `element`, `title`, `rendered`, `options`, `render`, `close`, `_prepareContext`, `_onRender`, `_onFirstRender`, plus `document` and `isEditable` for sheets. It is not the whole ApplicationV2 API and does not claim to be.
+
+**This will surface errors in existing code, and that is the point.** Two shapes:
+
+- **A member you call that nobody declared.** Either a typo, or a Foundry member outside the set above. The second needs a cast — one line, written on purpose, instead of an index signature writing it for you on every line.
+- **`this.document` is `unknown`.** Which document a sheet is for is yours to know. A getter says it once:
+
+  ```ts
+  get actor(): MyActor {
+    return this.document as MyActor;
+  }
+  ```
+
+`UntypedFoundryMembers` is gone. Nothing exported it usefully — it only ever widened.
+
+`BaseTypeDataModel()` with no schema now gives the hooks and nothing invented. Pass your schema function to get the fields typed too, which is what the example system does.

--- a/examples/simple-system/scripts/data/character-data.mjs
+++ b/examples/simple-system/scripts/data/character-data.mjs
@@ -20,7 +20,9 @@ import { BaseTypeDataModel, fields } from '@vttforge/core';
  * form and nobody noticed, because an index signature was making every
  * property access legal.
  */
-export const defineCharacterSchema = () => {
+// Not exported: only the class below needs it, and the inferred shape is
+// already reachable as `CharacterData['$inferData']`.
+const defineCharacterSchema = () => {
   const f = fields();
   // The six ability scores are written once, as a factory rather than a
   // shared options object: a field keeps the options it was handed, and

--- a/examples/simple-system/scripts/data/character-data.mjs
+++ b/examples/simple-system/scripts/data/character-data.mjs
@@ -10,87 +10,111 @@
 
 import { BaseTypeDataModel, fields } from '@vttforge/core';
 
-export class CharacterData extends BaseTypeDataModel() {
-  static defineSchema() {
-    const f = fields();
-    // The six ability scores are written once, as a factory rather than a
-    // shared options object: a field keeps the options it was handed, and
-    // some field classes write back into them.
-    const score = () =>
-      new f.NumberField({
+/**
+ * The schema, as a function passed to the factory rather than a `static
+ * defineSchema()` on the class.
+ *
+ * Both work at runtime. Only this one is typed: hand the factory your schema
+ * and `this.level` is a number inside `prepareDerivedData`, while the
+ * no-argument form leaves every field unknown. The example used the untyped
+ * form and nobody noticed, because an index signature was making every
+ * property access legal.
+ */
+export const defineCharacterSchema = () => {
+  const f = fields();
+  // The six ability scores are written once, as a factory rather than a
+  // shared options object: a field keeps the options it was handed, and
+  // some field classes write back into them.
+  // One ability. `value` is what is stored and what the sheet's input writes
+  // to (`name="system.abilities.str.value"`); `mod` is derived below and
+  // deliberately absent here, because a derived value is not source data.
+  //
+  // This used to be a bare NumberField while the form wrote to `.value` and
+  // prepareDerivedData replaced the number with an object. Three shapes for
+  // one field, and nothing said so until the schema started being typed.
+  const score = () =>
+    new f.SchemaField({
+      value: new f.NumberField({
         required: true,
         nullable: false,
         integer: true,
         min: 1,
         max: 30,
         initial: 10,
-      });
-    return {
-      level: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 1,
-        max: 20,
-        initial: 1,
       }),
-      speed: new f.NumberField({
+      // Derived: rewritten by prepareDerivedData on every preparation, and
+      // never meaningful as stored data. It is in the schema anyway because
+      // this file is JavaScript, and JavaScript has no `declare` — a class
+      // field would emit and set the property to undefined at construction.
+      // A TypeScript system writes `declare mod: number` on the class and
+      // leaves this out.
+      mod: new f.NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
+    });
+  return {
+    level: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 1,
+      max: 20,
+      initial: 1,
+    }),
+    speed: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 0,
+      initial: 30,
+    }),
+    abilities: new f.SchemaField({
+      str: score(),
+      dex: score(),
+      con: score(),
+      int: score(),
+      wis: score(),
+      cha: score(),
+    }),
+    health: new f.SchemaField({
+      value: new f.NumberField({
         required: true,
         nullable: false,
         integer: true,
         min: 0,
-        initial: 30,
+        initial: 10,
       }),
-      abilities: new f.SchemaField({
-        str: score(),
-        dex: score(),
-        con: score(),
-        int: score(),
-        wis: score(),
-        cha: score(),
+      max: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 10,
       }),
-      health: new f.SchemaField({
-        value: new f.NumberField({
-          required: true,
-          nullable: false,
-          integer: true,
-          min: 0,
-          initial: 10,
-        }),
-        max: new f.NumberField({
-          required: true,
-          nullable: false,
-          integer: true,
-          min: 0,
-          initial: 10,
-        }),
+    }),
+    power: new f.SchemaField({
+      value: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 5,
       }),
-      power: new f.SchemaField({
-        value: new f.NumberField({
-          required: true,
-          nullable: false,
-          integer: true,
-          min: 0,
-          initial: 5,
-        }),
-        max: new f.NumberField({
-          required: true,
-          nullable: false,
-          integer: true,
-          min: 0,
-          initial: 5,
-        }),
+      max: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 5,
       }),
-      biography: new f.HTMLField(),
-    };
-  }
+    }),
+    biography: new f.HTMLField(),
+  };
+};
 
+export class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {
   /** @override */
   prepareDerivedData() {
-    for (const [key, value] of Object.entries(this.abilities)) {
-      const score = typeof value === 'number' ? value : (value?.value ?? 10);
-      const mod = Math.floor((score - 10) / 2);
-      this.abilities[key] = { value: score, mod };
+    for (const ability of Object.values(this.abilities)) {
+      ability.mod = Math.floor((ability.value - 10) / 2);
     }
 
     const conMod = this.abilities.con.mod;

--- a/examples/simple-system/scripts/data/gear-data.mjs
+++ b/examples/simple-system/scripts/data/gear-data.mjs
@@ -10,29 +10,32 @@ import { BaseTypeDataModel, fields } from '@vttforge/core';
 
 const GEAR_KINDS = /** @type {const} */ (['equipped', 'valued', 'stowed']);
 
-export class GearData extends BaseTypeDataModel() {
-  static defineSchema() {
-    const f = fields();
-    return {
-      quantity: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 1,
-      }),
-      weight: new f.NumberField({
-        required: true,
-        nullable: false,
-        min: 0,
-        initial: 0,
-      }),
-      kind: new f.StringField({
-        required: true,
-        choices: GEAR_KINDS,
-        initial: 'stowed',
-      }),
-      description: new f.HTMLField(),
-    };
-  }
-}
+// Passed to the factory rather than declared as `static defineSchema()`, so
+// the fields are typed. Both forms work at runtime; only this one tells
+// TypeScript what `this.quantity` is.
+const defineGearSchema = () => {
+  const f = fields();
+  return {
+    quantity: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 0,
+      initial: 1,
+    }),
+    weight: new f.NumberField({
+      required: true,
+      nullable: false,
+      min: 0,
+      initial: 0,
+    }),
+    kind: new f.StringField({
+      required: true,
+      choices: GEAR_KINDS,
+      initial: 'stowed',
+    }),
+    description: new f.HTMLField(),
+  };
+};
+
+export class GearData extends BaseTypeDataModel(defineGearSchema) {}

--- a/examples/simple-system/scripts/sheets/character-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/character-sheet.mjs
@@ -88,13 +88,30 @@ export class CharacterSheet extends BaseActorSheet() {
   ];
 
   /**
+   * The actor this sheet is for.
+   *
+   * `this.document` is deliberately `unknown` on the base: which document a
+   * sheet is for, and what its `system` holds, is the system's to know. One
+   * getter says it once, and every use below is typed from here.
+   *
+   * Typed `any` for now, and deliberately in one place: Foundry's own Actor
+   * type is not wired into this repo yet. When it is, this getter is the
+   * single line that changes, rather than every use below.
+   *
+   * @returns {any}
+   */
+  get actor() {
+    return this.document;
+  }
+
+  /**
    * @override
    * @param {Record<string, unknown>} options
    * @returns {Promise<Record<string, unknown>>}
    */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    const actor = this.document;
+    const actor = this.actor;
     const system = actor.system;
     const abilityLabels = {
       str: 'VTTFORGE_EXAMPLE.Ability.str',
@@ -159,7 +176,7 @@ export class CharacterSheet extends BaseActorSheet() {
     const key = target?.dataset?.ability;
     if (!key) return;
     // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 action handlers are declared static but invoked with `this` bound to the sheet instance
-    const actor = this.document;
+    const actor = this.actor;
     const mod = actor.system.abilities?.[key]?.mod ?? 0;
     const roll = new Roll(`1d20 + ${mod}`, actor.getRollData());
     await roll.evaluate();
@@ -179,7 +196,7 @@ export class CharacterSheet extends BaseActorSheet() {
   static async _onCreateGear(_event, _target) {
     const cls = CONFIG.Item.documentClass;
     // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
-    const parent = this.document;
+    const parent = this.actor;
     await cls.create(
       { name: game.i18n.localize('VTTFORGE_EXAMPLE.Sheet.NewGearName'), type: 'gear' },
       { parent, renderSheet: true },
@@ -196,7 +213,7 @@ export class CharacterSheet extends BaseActorSheet() {
     const id = row?.dataset?.itemId;
     if (!id) return;
     // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
-    const item = this.document.items.get(id);
+    const item = this.actor.items.get(id);
     await item?.delete();
   }
 }

--- a/examples/simple-system/scripts/sheets/gear-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/gear-sheet.mjs
@@ -53,13 +53,22 @@ export class GearSheet extends BaseItemSheet() {
   };
 
   /**
+   * The item this sheet is for. See the note on CharacterSheet#actor.
+   *
+   * @returns {any}
+   */
+  get item() {
+    return this.document;
+  }
+
+  /**
    * @override
    * @param {Record<string, unknown>} options
    * @returns {Promise<Record<string, unknown>>}
    */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    const item = this.document;
+    const item = this.item;
     context.item = item;
     context.system = item.system;
     context.isEditable = this.isEditable;

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.10.0"
+    "@vttforge/core": "^0.11.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.10.0"
+    "@vttforge/core": "^0.11.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.5.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.10.0",
+    "@vttforge/core": "^0.11.0",
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.10.0",
+    "@vttforge/core": "^0.11.0",
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/base-actor-sheet.test.ts
+++ b/packages/core/src/__tests__/base-actor-sheet.test.ts
@@ -4,6 +4,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseActorSheet, type DragDropConfig, VTTFORGE_SHEET_CLASS } from '../base-actor-sheet.js';
 import { VttfError } from '../errors/registry.js';
 
+/**
+ * Set a member Foundry exposes as a getter.
+ *
+ * `element`, `document` and `isEditable` are readonly on the base types
+ * because that is what they are on the real classes. A test standing an
+ * instance up has to write them anyway, so it says so here once rather than
+ * casting at every line.
+ */
+function stub<T extends object>(instance: T, values: Record<string, unknown>): void {
+  Object.assign(instance as Record<string, unknown>, values);
+}
+
 class FakeActorSheetV2 {
   async _prepareContext(_options: unknown): Promise<Record<string, unknown>> {
     return { fromSuper: true };
@@ -189,7 +201,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
   it('does nothing when DRAG_DROP is empty', () => {
     const Sub = BaseActorSheet();
     const instance = new Sub();
-    instance.element = document.createElement('div');
+    stub(instance, { element: document.createElement('div') });
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(0);
   });
@@ -204,8 +216,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     }
     const instance = new Sheet();
     const element = document.createElement('div');
-    instance.element = element;
-    instance.isEditable = true;
+    stub(instance, { element: element, isEditable: true });
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(2);
     const first = dragDropBinds[0];
@@ -233,8 +244,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
       ];
     }
     const instance = new Sheet();
-    instance.element = document.createElement('div');
-    instance.isEditable = true;
+    stub(instance, { element: document.createElement('div'), isEditable: true });
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(1);
     const entry = dragDropBinds[0];
@@ -252,8 +262,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
       static override DRAG_DROP: ReadonlyArray<DragDropConfig> = [{ dragSelector: '.item' }];
     }
     const instance = new Sheet();
-    instance.element = document.createElement('div');
-    instance.isEditable = false;
+    stub(instance, { element: document.createElement('div'), isEditable: false });
     instance._onRender({}, {});
     const lockedEntry = dragDropBinds[0];
     if (!lockedEntry) throw new Error('expected dragDropBinds[0]');
@@ -270,9 +279,11 @@ describe('BaseActorSheet — default _onDragStart', () => {
   it('serializes the item identified by data-item-id', () => {
     const Sub = BaseActorSheet();
     const instance = new Sub();
-    instance.document = {
-      items: { get: (id: string) => ({ uuid: `Item.${id}` }) },
-    };
+    stub(instance, {
+      document: {
+        items: { get: (id: string) => ({ uuid: `Item.${id}` }) },
+      },
+    });
     const setData = vi.fn();
     const target = document.createElement('li');
     target.dataset.itemId = 'abc';

--- a/packages/core/src/__tests__/base-item-sheet.test.ts
+++ b/packages/core/src/__tests__/base-item-sheet.test.ts
@@ -5,6 +5,11 @@ import { VTTFORGE_SHEET_CLASS } from '../base-actor-sheet.js';
 import { BaseItemSheet } from '../base-item-sheet.js';
 import { VttfError } from '../errors/registry.js';
 
+/** Set a member Foundry exposes as a getter; see the actor-sheet test. */
+function stub<T extends object>(instance: T, values: Record<string, unknown>): void {
+  Object.assign(instance as Record<string, unknown>, values);
+}
+
 class FakeItemSheetV2 {
   async _prepareContext(_options: unknown): Promise<Record<string, unknown>> {
     return { fromSuper: true };
@@ -128,8 +133,7 @@ describe('BaseItemSheet', () => {
       static override DRAG_DROP = [{ dragSelector: '.item' }];
     }
     const instance = new Sheet();
-    instance.element = document.createElement('div');
-    instance.isEditable = true;
+    stub(instance, { element: document.createElement('div'), isEditable: true });
     instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(1);
     const entry = dragDropBinds[0];

--- a/packages/core/src/__tests__/base-type-data-model.test.ts
+++ b/packages/core/src/__tests__/base-type-data-model.test.ts
@@ -138,12 +138,15 @@ describe('BaseTypeDataModel(defineSchema) — types', () => {
     expectTypeOf<CharacterData['prepareDerivedData']>().toEqualTypeOf<() => void>();
   });
 
-  it('leaves the no-argument form untyped, as it was', () => {
-    // Every scaffolded template calls it this way. The typed overload must
-    // not capture the no-argument call and hand it a schema of nothing.
+  it('gives the no-argument form the hooks and nothing invented', () => {
+    // Every scaffolded template calls it this way, and the typed overload
+    // must not capture it and hand it a schema of nothing. What it does NOT
+    // do any more is accept every member name: this used to compile with
+    // `this.anythingAtAll = 1`, which is how a real module shipped a call to
+    // a method that did not exist.
     class Legacy extends BaseTypeDataModel() {
       whatever(): void {
-        this.anythingAtAll = 1;
+        this.prepareDerivedData();
       }
     }
     expect(typeof Legacy).toBe('function');

--- a/packages/core/src/__tests__/foundry-base.test-d.ts
+++ b/packages/core/src/__tests__/foundry-base.test-d.ts
@@ -1,0 +1,45 @@
+/**
+ * The hole this typing closed, pinned so it cannot reopen.
+ *
+ * These bases used to return an instance with `[member: string]: any`. That
+ * made every property access legal — a module shipped a release calling
+ * `url` and `goToPage` on a viewer that had neither, and nothing reported it.
+ *
+ * `@ts-expect-error` is the assertion here: each one fails the build if the
+ * line it guards ever starts compiling again.
+ */
+import { describe, expectTypeOf, it } from 'vitest';
+import type { BaseApplication } from '../base-application.js';
+import type { ApplicationV2Members, DocumentSheetV2Members } from '../foundry-base.js';
+
+declare const app: InstanceType<ReturnType<typeof BaseApplication>>;
+
+describe('the base instance type', () => {
+  it('carries the Foundry members these bases stand on', () => {
+    expectTypeOf(app.render).toBeFunction();
+    expectTypeOf(app.close).toBeFunction();
+    expectTypeOf(app.element).toEqualTypeOf<HTMLElement | undefined>();
+    expectTypeOf(app.title).toBeString();
+  });
+
+  it('carries what the factory itself adds', () => {
+    expectTypeOf(app._replaceHTML).toBeFunction();
+  });
+
+  it('refuses a member nobody declared', () => {
+    // @ts-expect-error — the shape of the bug this exists to prevent
+    void app.goToPage;
+    // @ts-expect-error — and a plain typo, which the index signature also ate
+    void app.tpyoDeVerdade;
+  });
+
+  it('keeps the document surface off a plain application', () => {
+    // @ts-expect-error — `document` belongs to a document sheet, not to this
+    void app.document;
+  });
+
+  it('separates the two Foundry surfaces', () => {
+    expectTypeOf<DocumentSheetV2Members>().toMatchTypeOf<ApplicationV2Members>();
+    expectTypeOf<DocumentSheetV2Members['isEditable']>().toBeBoolean();
+  });
+});

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -30,7 +30,7 @@
  */
 
 import { VttfError } from './errors/registry.js';
-import type { UntypedFoundryMembers } from './foundry-base.js';
+import type { DocumentSheetV2Members } from './foundry-base.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: Foundry's ActorSheetV2 shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
@@ -78,7 +78,7 @@ export interface SheetBaseStatics {
  *
  * Only the members a subclass actually reaches for. The rest of the Foundry
  * surface stays reachable and untyped until `@vttforge/types` describes it —
- * see `UntypedFoundryMembers`.
+ * see `DocumentSheetV2Members`.
  */
 export interface SheetBaseMembers {
   /** Fills in `context.tabs` for every group in `static TABS`. */
@@ -95,11 +95,24 @@ export interface SheetBaseMembers {
   onDropActor(actor: unknown, event: DragEvent): Promise<unknown>;
   onDropFolder(folder: unknown, event: DragEvent): Promise<unknown>;
   onDropActiveEffect(effect: unknown, event: DragEvent): Promise<unknown>;
+
+  /**
+   * Foundry's own drop entry points, implemented here to resolve the payload
+   * and hand it to the `onDropX` hook above.
+   *
+   * Declared because the base really does define them — an earlier version
+   * left them off, and nothing said so while an index signature was making
+   * every member name legal. Override `onDropItem` rather than this.
+   */
+  _onDropItem(event: DragEvent, data: unknown): Promise<unknown>;
+  _onDropActor(event: DragEvent, data: unknown): Promise<unknown>;
+  _onDropFolder(event: DragEvent, data: unknown): Promise<unknown>;
+  _onDropActiveEffect(event: DragEvent, data: unknown): Promise<unknown>;
 }
 
 export interface SheetBaseCtor extends SheetBaseStatics {
   // biome-ignore lint/suspicious/noExplicitAny: mirrors ApplicationV2's constructor arity, which subclasses pass straight through
-  new (...args: any[]): SheetBaseMembers & UntypedFoundryMembers;
+  new (...args: any[]): SheetBaseMembers & DocumentSheetV2Members;
 }
 
 interface DragDropInstance {

--- a/packages/core/src/base-application.ts
+++ b/packages/core/src/base-application.ts
@@ -20,7 +20,7 @@
  */
 
 import { VttfError } from './errors/registry.js';
-import type { VttforgeClass } from './foundry-base.js';
+import type { ApplicationV2Members, VttforgeClass } from './foundry-base.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: Foundry's ApplicationV2 shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
@@ -72,7 +72,11 @@ export interface BaseApplicationMembers {
   _replaceHTML(result: HTMLElement, content: HTMLElement): void;
 }
 
-export function BaseApplication(): VttforgeClass<BaseApplicationMembers> {
+export function BaseApplication(): VttforgeClass<
+  BaseApplicationMembers,
+  unknown,
+  ApplicationV2Members
+> {
   const Base = resolveApplicationV2();
 
   class VttforgeBaseApplication extends Base {
@@ -99,5 +103,9 @@ export function BaseApplication(): VttforgeClass<BaseApplicationMembers> {
     }
   }
 
-  return VttforgeBaseApplication as unknown as VttforgeClass<BaseApplicationMembers>;
+  return VttforgeBaseApplication as unknown as VttforgeClass<
+    BaseApplicationMembers,
+    unknown,
+    ApplicationV2Members
+  >;
 }

--- a/packages/core/src/base-document-sheet.ts
+++ b/packages/core/src/base-document-sheet.ts
@@ -17,7 +17,7 @@
  */
 
 import { VttfError } from './errors/registry.js';
-import type { VttforgeClass } from './foundry-base.js';
+import type { DocumentSheetV2Members, VttforgeClass } from './foundry-base.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: Foundry's sheet shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
@@ -75,7 +75,7 @@ function resolveSheetBase(kind: DocumentSheetKind): AnyConstructor {
  */
 export function BaseDocumentSheet(
   kind: DocumentSheetKind,
-): VttforgeClass<BaseDocumentSheetMembers> {
+): VttforgeClass<BaseDocumentSheetMembers, unknown, DocumentSheetV2Members> {
   const Base = resolveSheetBase(kind);
 
   class VttforgeBaseDocumentSheet extends Base {
@@ -95,5 +95,9 @@ export function BaseDocumentSheet(
     }
   }
 
-  return VttforgeBaseDocumentSheet as unknown as VttforgeClass<BaseDocumentSheetMembers>;
+  return VttforgeBaseDocumentSheet as unknown as VttforgeClass<
+    BaseDocumentSheetMembers,
+    unknown,
+    DocumentSheetV2Members
+  >;
 }

--- a/packages/core/src/foundry-base.ts
+++ b/packages/core/src/foundry-base.ts
@@ -2,39 +2,114 @@
  * How a base factory reports what it returns.
  *
  * These factories mix VTTForge behaviour into a Foundry class resolved at
- * runtime. Two halves, and they are not equally knowable: what we add is
- * ours and can be typed exactly; what Foundry brings lives in a type package
- * that is not wired up yet.
+ * runtime, so the result has two halves: what we add, and what Foundry brings.
  *
- * Returning `any` for the whole thing — which is what every factory did —
- * gives up on both. It costs more than it looks: a subclass cannot write
- * `override` on a member it really is overriding, and a call to a method
- * that does not exist passes silently. Both happened while porting a real
- * module onto the SDK, the second one shipping a broken call into a release.
+ * ## What the index signature cost
  *
- * So: type our half, and let Foundry's half through an index signature. A
- * property we know about carries its real type; anything else is reachable
- * and `any`, the same as before. When `@vttforge/types` lands, the index
- * signature is what it replaces.
+ * The first version returned `any` for the whole thing. The second kept our
+ * half typed and let Foundry's through `[member: string]: any`. Both were
+ * measured against two real consumers, and the index signature turned out to
+ * be the worse of the two failures rather than a middle ground:
+ *
+ * ```ts
+ * const viewer = new PdfViewer();
+ * viewer.goToPage(3);      // no such method — accepted
+ * viewer.tpyoDeVerdade();  // not even a real name — accepted
+ * ```
+ *
+ * A module shipped a release calling `url` and `goToPage` on a viewer that
+ * had neither, and nothing reported it. An index signature makes every
+ * property access legal, so a typo in the consumer's own subclass reads as
+ * valid code.
+ *
+ * And it did not even buy the thing it looked like it bought:
+ *
+ * ```
+ * error TS4113: This member cannot have an 'override' modifier because it is
+ * not declared in the base class.
+ * ```
+ *
+ * An index signature is not a declaration, so `override` on a Foundry member
+ * was rejected anyway. It permitted what should have failed and forbade what
+ * should have worked.
+ *
+ * ## What replaced it
+ *
+ * The Foundry members these factories actually stand on are written down
+ * below. Removing the index signature and running both consumers produced
+ * thirty-three errors naming eight distinct members — a set small enough to
+ * declare, which is what settled the design. It is not the whole ApplicationV2
+ * surface and does not claim to be; `@vttforge/types` is where that lands.
+ *
+ * Reaching a member that is not here is a cast, and a cast is a sentence you
+ * write on purpose. That is the difference from an index signature, which
+ * writes it for you on every line.
  */
 
 /**
- * The part of an instance this SDK does not describe yet.
+ * The ApplicationV2 surface these bases rely on.
  *
- * Deliberately permissive. Narrowing it before the Foundry types exist would
- * only mean rejecting code that works.
+ * Deliberately small. Every member here is one a real consumer used, not one
+ * that exists in Foundry — the point is to describe what the factories stand
+ * on, not to restate Foundry's API.
  */
-export interface UntypedFoundryMembers {
-  // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed by fvtt-types / @vttforge/types, not here
-  [member: string]: any;
+export interface ApplicationV2Members {
+  /** The window's root element once rendered. `undefined` before that. */
+  readonly element: HTMLElement | undefined;
+
+  /** The window title, from `options.window.title`. */
+  readonly title: string;
+
+  /** Whether the window is currently rendered. */
+  readonly rendered: boolean;
+
+  /** Render the application. Resolves when the render completes. */
+  render(options?: unknown, _options?: unknown): Promise<unknown>;
+
+  /** Close the window. */
+  close(options?: unknown): Promise<unknown>;
+
+  /** Build the render context. */
+  _prepareContext(options: unknown): Promise<Record<string, unknown>>;
+
+  /** Runs after every render. */
+  _onRender(context: unknown, options: unknown): void;
+
+  /** Runs after the first render only. */
+  _onFirstRender(context: unknown, options: unknown): void;
+
+  /** The resolved options this instance was constructed with. */
+  readonly options: Record<string, unknown>;
+}
+
+/**
+ * What a document sheet adds on top of an application.
+ */
+export interface DocumentSheetV2Members extends ApplicationV2Members {
+  /**
+   * The document this sheet is for.
+   *
+   * Typed loosely on purpose: which document, and what its `system` holds,
+   * is the consumer's to know. Narrow it with a getter on your subclass.
+   */
+  readonly document: unknown;
+
+  /** Whether the current user may edit this document. */
+  readonly isEditable: boolean;
 }
 
 /**
  * A class this SDK built on top of a Foundry one.
  *
- * `Added` is what the factory contributes. Everything else stays reachable.
+ * `Added` is what the factory contributes; `Foundry` is the part of Foundry's
+ * own surface the factory stands on. Anything outside both is a cast — see
+ * the note at the top of this file for why that is the point.
+ *
+ * `Foundry` defaults to nothing rather than to the application surface. A
+ * `TypeDataModel` is not an application, and defaulting the other way handed
+ * data models a `render` and a `close` they do not have.
  */
-export type VttforgeClass<Added, Statics = unknown> = Statics & {
+export type VttforgeClass<Added, Statics = unknown, Foundry = unknown> = Statics & {
   // biome-ignore lint/suspicious/noExplicitAny: forwards Foundry's own constructor arity
-  new (...args: any[]): Added & UntypedFoundryMembers;
+  new (...args: any[]): Added & Foundry;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,7 +108,11 @@ export {
   type VttfErrorCode,
   type VttfErrorEntry,
 } from './errors/registry.js';
-export type { UntypedFoundryMembers, VttforgeClass } from './foundry-base.js';
+export type {
+  ApplicationV2Members,
+  DocumentSheetV2Members,
+  VttforgeClass,
+} from './foundry-base.js';
 export type {
   ActiveEffectConfig,
   CombatConfig,


### PR DESCRIPTION
The base factories returned `Added & { [member: string]: any }`. The index signature was meant as a middle ground — our half typed, Foundry's half reachable. Measured against both real consumers, it was the worse of the two failures.

## What it cost

It made every property access legal:

```ts
const viewer = new PdfViewer();
viewer.goToPage(3);      // no such method — accepted
viewer.tpyoDeVerdade();  // not even a real name — accepted
```

A module shipped a release calling `url` and `goToPage` on a viewer that had neither, and nothing reported it.

And it did not buy what it looked like it bought:

```
error TS4113: This member cannot have an 'override' modifier because it is
not declared in the base class.
```

An index signature is not a declaration. It **permitted what should have failed and forbade what should have worked.**

## The measurement that settled it

Rather than argue architecture, I removed the index signature and counted. Both consumers, 33 errors, **8 distinct member names**:

`document`, `element`, `render`, `close`, `title`, `isEditable`, `_onRender`, `_onFirstRender`

A set that small is one you write down. `ApplicationV2Members` and `DocumentSheetV2Members` now describe it. It is not the whole ApplicationV2 API and does not claim to be — reaching past it is a cast, which is a sentence you write on purpose rather than one an index signature writes for you on every line.

## Three things the strictness surfaced

**The base never declared its own dispatch methods.** It implements `_onDropItem` and siblings to resolve the payload and call the `onDropX` hooks. Nothing said so while every member name was legal.

**The reference consumer was not using the typed path.** `examples/simple-system` called `BaseTypeDataModel()` with no schema and declared its own `static defineSchema()` — the untyped overload. The typed path the SDK documents was untested by its own example.

**Converting it found a genuine modelling bug.** `abilities.str` was a bare `NumberField`, the sheet's input wrote to `system.abilities.str.value`, and `prepareDerivedData` replaced the number with `{ value, mod }`. Three shapes for one field, none of them agreeing.

## A gap this exposed and did not close

The documented pattern for derived data is `declare armorClass: number` — which is TypeScript. A **JavaScript** system cannot use it: a class field emits and sets the property to `undefined` at construction. The JS example carries its derived field in the schema instead, with a note. The `system-js` and `module-js` templates have the same limitation.

## Migration

This raises errors in existing code, which is the point. Two shapes, both in the changeset:

- a member nobody declared — a typo, or a Foundry member outside the set, which needs one cast
- `this.document` is `unknown` — a getter narrows it once for the whole class

## Verified

- both consumers typecheck at zero
- `foundry-base.test-d.ts` pins the hole shut with `@ts-expect-error` on the exact call that shipped broken
- 189 tests, typecheck, lint, build all pass