### PR TITLE
fix(cli): rewrite the init templates against the current SDK

### DIFF
--- a/.changeset/templates-on-current-sdk.md
+++ b/.changeset/templates-on-current-sdk.md
@@ -1,0 +1,13 @@
+---
+"@vttforge/cli": patch
+---
+
+Rewrite the four `init` templates against the current SDK.
+
+The scaffolds still showed the patterns the SDK exists to replace: `as any` on the sheet bases, sheets registered by hand with `Actors.registerSheet`, untyped data models, and module templates that never called `registerModule`. A project created today contradicted the docs from its first file.
+
+- `system-ts` / `system-js`: data models use the typed `BaseTypeDataModel(defineSchema)` factory; sheets are declared in `registerSystem({ sheets })` with stable ids; each sheet narrows `this.document` once in an `actor` / `item` getter; `tsconfig` turns on `noImplicitOverride`.
+- `module-ts` / `module-js`: built on `registerModule`. The scaffold adds a `note` Item sub-type (declared under `documentTypes`, keyed with `moduleSubType`), a sheet on `BaseItemSheet`, an `@Note[id]` enricher, a setting and a public API.
+- READMEs no longer say the packages are unpublished.
+- `vttforge audit` rules VTTF-AUDIT-004 and VTTF-AUDIT-007 now attribute a schema declared in a named factory (`class X extends BaseTypeDataModel(defineSchema)`) to the class that uses it. Before, a system on the typed factory was flagged for token attributes its schema did declare.
+- The template test now typechecks the TypeScript variants against the workspace `@vttforge/core`, so a template that drifts from the SDK fails in CI.

--- a/packages/cli/src/__tests__/audit/source-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/source-rules.test.ts
@@ -431,6 +431,27 @@ registerSystem({ id: 'my-system', actorDataModels: { character: CharacterData } 
       expect(await runSourceRules(cwd)).toEqual([]);
     });
 
+    it('reads a factory with a return type and a brace inside a string', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', primaryTokenAttribute: 'health' }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `const defineCharacterSchema = (): Record<string, unknown> => {
+  const label = 'closes: }'; // and a comment with }
+  return {
+    health: new fields.SchemaField({ value: new fields.NumberField(), max: new fields.NumberField() }),
+  };
+};
+export class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
+registerSystem({ id: 'my-system', actorDataModels: { character: CharacterData } });`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
     it('still scopes a factory schema to the class that owns it', async () => {
       // The factory belongs to an Item model; token bars read actor.system.
       await writeFile(

--- a/packages/cli/src/__tests__/audit/source-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/source-rules.test.ts
@@ -145,6 +145,31 @@ class BData extends TypeDataModel {}`,
   });
 
   describe('VTTF-AUDIT-004 — HTMLField / FilePathField not declared', () => {
+    it('attributes a factory schema to its class for the per-subtype check', async () => {
+      // `biography` is declared for `Actor.character` but the factory
+      // schema is registered under `Actor.npc` too. Without factory
+      // ownership the rule would fall back to the global union and pass.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          documentTypes: { Actor: { character: { htmlFields: ['biography'] }, npc: {} } },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `const defineSchema = () => ({ biography: new fields.HTMLField() });
+class PersonData extends BaseTypeDataModel(defineSchema) {}
+registerSystem({ id: 'my-system', actorDataModels: { character: PersonData, npc: PersonData } });`,
+        'utf8',
+      );
+      const four = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four).toHaveLength(1);
+      expect(four[0]?.message).toContain('Actor.npc');
+    });
+
     it('flags HTMLField that is missing from manifest documentTypes', async () => {
       await writeFile(
         join(cwd, 'system.json'),
@@ -379,6 +404,56 @@ class BData extends TypeDataModel {}`,
   });
 
   describe('VTTF-AUDIT-007 — token attribute SchemaField', () => {
+    it('resolves a schema declared in a named factory handed to BaseTypeDataModel()', async () => {
+      // The typed factory keeps the schema in a function outside the class.
+      // With the class registered as an Actor model, the rule scopes to
+      // Actor classes — and must still find the field through the factory.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', primaryTokenAttribute: 'health' }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `const defineCharacterSchema = () => {
+  const f = fields();
+  return {
+    health: new f.SchemaField({
+      value: new f.NumberField(),
+      max: new f.NumberField(),
+    }),
+  };
+};
+export class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
+registerSystem({ id: 'my-system', actorDataModels: { character: CharacterData } });`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
+    it('still scopes a factory schema to the class that owns it', async () => {
+      // The factory belongs to an Item model; token bars read actor.system.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', primaryTokenAttribute: 'health' }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `function defineGearSchema() {
+  return {
+    health: new fields.SchemaField({ value: new fields.NumberField(), max: new fields.NumberField() }),
+  };
+}
+class GearData extends BaseTypeDataModel(defineGearSchema) {}
+class CharacterData extends BaseTypeDataModel(() => ({})) {}
+registerSystem({ id: 'my-system', actorDataModels: { character: CharacterData }, itemDataModels: { gear: GearData } });`,
+        'utf8',
+      );
+      const seven = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-007');
+      expect(seven).toHaveLength(1);
+    });
+
     it('passes when health resolves to {value, max} SchemaField', async () => {
       await writeFile(
         join(cwd, 'system.json'),

--- a/packages/cli/src/__tests__/templates.integration.test.ts
+++ b/packages/cli/src/__tests__/templates.integration.test.ts
@@ -3,11 +3,40 @@
  * the basic shape of the generated project. Catches template drift early
  * (missing files, broken JSON syntax, unresolved placeholders, etc.).
  */
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { type ScaffoldVars, scaffold, templatesRoot } from '../scaffold.js';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * The TypeScript variants are typechecked against the workspace's own
+ * `@vttforge/core` source, so a template that stops matching the SDK fails
+ * here rather than on the first `pnpm typecheck` a user runs.
+ */
+const CORE_SOURCE = join(templatesRoot(), '..', '..', 'core', 'src', 'index.ts');
+
+/** `tsc.js` sits next to the package's main entry; the `bin` path is not exported. */
+const TSC = join(dirname(require.resolve('typescript')), 'tsc.js');
+
+function typecheck(projectDir: string): string {
+  const tsconfig = join(projectDir, 'tsconfig.typecheck.json');
+  writeFileSync(
+    tsconfig,
+    JSON.stringify({
+      extends: './tsconfig.json',
+      compilerOptions: { paths: { '@vttforge/core': [CORE_SOURCE] } },
+    }),
+  );
+  const result = spawnSync(process.execPath, [TSC, '--noEmit', '-p', tsconfig], {
+    encoding: 'utf8',
+  });
+  return `${result.stdout}${result.stderr}`.trim();
+}
 
 const VARS: ScaffoldVars = {
   ID: 'my-pack',
@@ -24,6 +53,7 @@ const VARS: ScaffoldVars = {
 const SYSTEM_VARIANTS = ['system-ts', 'system-js'] as const;
 const MODULE_VARIANTS = ['module-ts', 'module-js'] as const;
 const ALL_VARIANTS = [...SYSTEM_VARIANTS, ...MODULE_VARIANTS];
+const TS_VARIANTS = ['system-ts', 'module-ts'] as const;
 
 describe('scaffolded templates', () => {
   let destDir: string;
@@ -133,7 +163,7 @@ describe('scaffolded templates', () => {
 
   for (const variant of MODULE_VARIANTS) {
     describe(`${variant} (module-specific)`, () => {
-      it('produces a v13-shaped module.json without documentTypes', async () => {
+      it('produces a v13-shaped module.json that declares its sub-type', async () => {
         await scaffold({
           templateDir: join(templatesRoot(), variant),
           destDir,
@@ -144,11 +174,36 @@ describe('scaffolded templates', () => {
         expect(manifest.title).toBe('My Pack');
         expect(manifest.styles).toEqual([{ src: 'styles/main.css' }]);
         expect(manifest.flags.hotReload).toEqual({
-          extensions: ['css', 'json'],
-          paths: ['styles', 'lang'],
+          extensions: ['css', 'hbs', 'json'],
+          paths: ['styles', 'templates', 'lang'],
         });
-        expect(manifest.documentTypes).toBeUndefined();
+        // The bare name here; `registerModule` files it as `my-pack.note`.
+        expect(manifest.documentTypes).toEqual({ Item: { note: { htmlFields: ['body'] } } });
       });
+
+      it('ships the note sheet template and its type label', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+        expect(existsSync(join(destDir, 'templates', 'item', 'note-sheet.hbs'))).toBe(true);
+        const lang = JSON.parse(readFileSync(join(destDir, 'lang', 'en.json'), 'utf8'));
+        expect(lang.TYPES.Item['my-pack'].note).toBe('Note');
+      });
+    });
+  }
+
+  for (const variant of TS_VARIANTS) {
+    describe(`${variant} (typecheck)`, () => {
+      it('typechecks against the workspace @vttforge/core', async () => {
+        await scaffold({
+          templateDir: join(templatesRoot(), variant),
+          destDir,
+          vars: VARS,
+        });
+        expect(typecheck(destDir)).toBe('');
+      }, 60_000);
     });
   }
 });

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -205,6 +205,58 @@ function findEnclosingClass(ranges: ClassRange[], idx: number): string | undefin
 }
 
 /**
+ * A class built on the `BaseTypeDataModel(defineSchema)` factory keeps its
+ * schema in a function outside the class body. Rules that ask "which class
+ * owns this field" would otherwise see the field as unowned. So the body of
+ * that function is reported as a range owned by the class, alongside the
+ * class's own body.
+ *
+ * Both the arrow and the `function` form are recognised, as long as the
+ * function is named and passed by name. An inline arrow is already inside
+ * the `class ... {` match and needs no help.
+ */
+function findSchemaFactoryRanges(content: string): ClassRange[] {
+  const out: ClassRange[] = [];
+  const classRe = /class\s+(\w+)\s+extends\s+(?:[\w.]+\.)?BaseTypeDataModel\s*\(\s*(\w+)\s*\)/g;
+  for (const match of content.matchAll(classRe)) {
+    const className = match[1];
+    const fnName = match[2];
+    if (!className || !fnName) continue;
+    const fnRe = new RegExp(
+      String.raw`(?:(?:const|let|var)\s+${fnName}\s*=\s*(?:async\s*)?(?:\([^)]*\)|\w+)\s*=>\s*\(?\s*\{|function\s+${fnName}\s*\([^)]*\)\s*\{)`,
+    );
+    const fnMatch = fnRe.exec(content);
+    if (fnMatch === null) continue;
+    const openIdx = fnMatch.index + fnMatch[0].length - 1;
+    const endIdx = findMatchingBrace(content, openIdx);
+    if (endIdx < 0) continue;
+    let line = 1;
+    for (let i = 0; i < fnMatch.index; i += 1) {
+      if (content[i] === '\n') line += 1;
+    }
+    out.push({ className, startLine: line, openIdx, endIdx });
+  }
+  return out;
+}
+
+/** Every range whose fields belong to a class: class bodies, then factory bodies. */
+function findSchemaOwnerRanges(content: string): ClassRange[] {
+  return [...findClassRanges(content), ...findSchemaFactoryRanges(content)];
+}
+
+function findMatchingBrace(content: string, openIdx: number): number {
+  let depth = 0;
+  for (let i = openIdx; i < content.length; i += 1) {
+    if (content[i] === '{') depth += 1;
+    else if (content[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
  * Detect class→subtype registrations in three forms:
  *
  *   1. `CONFIG.<Doc>.dataModels.<subtype> = <ClassName>` (direct assignment)
@@ -457,7 +509,7 @@ function rule004(
   declared: DeclaredFields,
   classToSubtypes: Map<string, ConfigMapping[]>,
 ): RuleResult[] {
-  const classes = findClassRanges(content);
+  const classes = findSchemaOwnerRanges(content);
   const usages = findRichFields(content, classes);
   const out: RuleResult[] = [];
   for (const usage of usages) {
@@ -595,7 +647,7 @@ async function sourceHasValueMaxSchemaAtPath(
     } catch {
       continue;
     }
-    const classes = findClassRanges(content);
+    const classes = findSchemaOwnerRanges(content);
     for (const decl of findAllSchemaFields(content)) {
       if (decl.path !== targetPath) continue;
       // Token bars read `actor.system`, so only a schema registered as an

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -223,7 +223,9 @@ function findSchemaFactoryRanges(content: string): ClassRange[] {
     const fnName = match[2];
     if (!className || !fnName) continue;
     const fnRe = new RegExp(
-      String.raw`(?:(?:const|let|var)\s+${fnName}\s*=\s*(?:async\s*)?(?:\([^)]*\)|\w+)\s*=>\s*\(?\s*\{|function\s+${fnName}\s*\([^)]*\)\s*\{)`,
+      // An arrow may carry a return type between `)` and `=>`; a function
+      // may carry one between `)` and `{`. Neither is captured.
+      String.raw`(?:(?:const|let|var)\s+${fnName}\s*=\s*(?:async\s*)?(?:\([^)]*\)|\w+)\s*(?::[^=]*?)?=>\s*\(?\s*\{|function\s+${fnName}\s*\([^)]*\)\s*(?::[^{]*?)?\{)`,
     );
     const fnMatch = fnRe.exec(content);
     if (fnMatch === null) continue;
@@ -244,14 +246,42 @@ function findSchemaOwnerRanges(content: string): ClassRange[] {
   return [...findClassRanges(content), ...findSchemaFactoryRanges(content)];
 }
 
+/**
+ * Index of the `}` that closes the `{` at `openIdx`, skipping braces inside
+ * string literals, template literals and comments. Returns -1 when unbalanced.
+ */
 function findMatchingBrace(content: string, openIdx: number): number {
   let depth = 0;
-  for (let i = openIdx; i < content.length; i += 1) {
-    if (content[i] === '{') depth += 1;
-    else if (content[i] === '}') {
+  let i = openIdx;
+  while (i < content.length) {
+    const ch = content[i];
+    const next = content[i + 1];
+    if (ch === '/' && next === '/') {
+      i = content.indexOf('\n', i);
+      if (i < 0) return -1;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i = content.indexOf('*/', i + 2);
+      if (i < 0) return -1;
+      i += 2;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i += 1;
+      while (i < content.length && content[i] !== ch) {
+        if (content[i] === '\\') i += 1;
+        i += 1;
+      }
+      i += 1;
+      continue;
+    }
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
       depth -= 1;
       if (depth === 0) return i;
     }
+    i += 1;
   }
   return -1;
 }

--- a/packages/cli/templates/module-js/README.md
+++ b/packages/cli/templates/module-js/README.md
@@ -2,55 +2,79 @@
 
 {{DESCRIPTION}}
 
-A Foundry VTT module built on [VTTForge](https://github.com/vttforge/vttforge) — uses `SystemConfig` from `@vttforge/core` for typed settings, ships an example hook listener, and exposes a small public API on `game.modules.get("{{ID}}").api`.
-
-> **Note** — VTTForge is currently in pre-release and not yet published to npm. Dependencies in `package.json` will resolve once VTTForge ships its first public release.
+A Foundry VTT v13+ module built on [VTTForge](https://vttforge.dev). It adds a
+`note` Item type to whatever system the world runs, a sheet for it, and an
+`@Note[id]` enricher that links to one from any text field.
 
 ## Quick start
 
 ```bash
 pnpm install
-pnpm dev      # vite build --watch + auto-symlinks dist/ into Foundry's Data
-pnpm build    # one-shot build + emits {{ID}}-<version>.zip for foundryvtt.com
+pnpm dev      # build, link dist/ into Foundry's data dir, watch
+pnpm build    # dist/ plus {{ID}}-<version>.zip
 ```
 
-`pnpm dev` (`vttforge dev` under the hood) auto-detects your Foundry user-data
-directory on the first run, prompts you to confirm it, and saves the choice to
-`.vttforge/config.json` for next time. Override with `--data-dir <path>` or set
-`FOUNDRY_DATA_DIR` in your environment.
+`pnpm dev` asks where Foundry keeps its data on the first run and remembers
+the answer in `.vttforge/config.json`. Override with `--foundry-data <path>`
+or `FOUNDRY_DATA_DIR`. If Foundry runs in a container it cannot follow the
+symlink, and the command prints the compose mount to use instead.
 
-Run Foundry with `--hotReload` to pick up changes without refreshing the page.
-Then enable **{{TITLE}}** in any world.
+Save a template and the open sheet redraws in place; save a stylesheet and the
+CSS swaps. Enable **VTTForge Dev** in the world once — `pnpm dev` links it in.
+
+Then enable **{{TITLE}}** in a world and create a Note from the Items sidebar.
 
 ## What's inside
 
 | Path | Purpose |
 |---|---|
-| `module.json` | Manifest |
-| `scripts/main.mjs` | Entry point — settings registration, hook listeners, public API |
-| `styles/main.css` | Stylesheet, scoped under `.{{ID}}` |
-| `lang/en.json` | Localization strings |
+| `module.json` | Manifest — declares the `note` sub-type under `documentTypes` and the hot-reload paths |
+| `scripts/main.mjs` | One `registerModule` call: data model, sheet, enricher, settings, API |
+| `scripts/constants.mjs` | `MODULE_ID` and `NOTE_TYPE` — the prefixed key Foundry files the sub-type under |
+| `scripts/data/note-data.mjs` | The data model. The schema is a function handed to `BaseTypeDataModel` |
+| `scripts/sheets/note-sheet.mjs` | The sheet, on `BaseItemSheet` |
+| `scripts/enricher.mjs` | `@Note[id]` → a link that opens the note |
+| `templates/` | Handlebars, using v13's own elements (`<prose-mirror>`, `data-action`) |
+| `styles/main.css` | Scoped under `.{{ID}}`, colours from Foundry's variables |
+| `lang/en.json` | Strings, under the `{{LOCALE_PREFIX}}` prefix, plus the `TYPES.Item` label |
+
+## Two things worth knowing before you edit
+
+**A module's sub-types are namespaced.** You register `note`; Foundry files it
+as `{{ID}}.note`, and so must the manifest. `registerModule` adds the prefix,
+and `NOTE_TYPE` in `constants.ts` is the one place it is spelled out.
+
+**Sheets are registered by id, not by class name.** `registerModule({ sheets })`
+pins each sheet under `{{ID}}.<id>`. Foundry saves that key on every item
+whose owner picked the sheet, and derives it from the class name unless told
+otherwise — which a bundler renames between builds. Keep the ids.
 
 ## Public API
 
-The module exposes its API on `game.modules.get("{{ID}}").api`:
-
 ```js
 const api = game.modules.get("{{ID}}").api;
-api.greet("world");                   // returns "Hello, world!"
-api.getSetting("showWelcome");        // returns the current value
+await api.createNote("Session 3", "<p>The party reached the gate.</p>");
+api.noteType; // "{{ID}}.note"
 ```
 
-Extend `scripts/main.mjs` to add real methods — the example exists to show the registration pattern.
+## Checks
 
-## Releasing to Foundry
+```bash
+npx vttforge audit    # manifest + source against the v13 list of quiet breakages
+```
 
-Tag-push triggers `.github/workflows/release.yml` to build, zip, and attach `{{ID}}-<version>.zip` + `dist/module.json` to a GitHub Release. Point Foundry at the `latest/download/module.json` URL.
+## Releasing
+
+Push a tag and `.github/workflows/release.yml` builds, zips, and attaches
+`{{ID}}-<version>.zip` plus `module.json` to a GitHub Release:
 
 ```bash
 git tag v0.1.0
 git push --tags
 ```
+
+Point Foundry — and foundryvtt.com — at the release's
+`latest/download/module.json`, so installs auto-update on every tag.
 
 ## License
 

--- a/packages/cli/templates/module-js/lang/en.json
+++ b/packages/cli/templates/module-js/lang/en.json
@@ -1,4 +1,11 @@
 {
+  "TYPES": {
+    "Item": {
+      "{{ID}}": {
+        "note": "Note"
+      }
+    }
+  },
   "{{LOCALE_PREFIX}}": {
     "Settings": {
       "showWelcome": {
@@ -6,6 +13,17 @@
         "hint": "Display a one-shot toast when {{TITLE}} loads in a world."
       }
     },
-    "Welcome": "{{TITLE}} loaded — try `game.modules.get(\"{{ID}}\").api.greet(\"GM\")` in the console."
+    "Welcome": "{{TITLE}} loaded — create a Note from the Items sidebar, or try `game.modules.get(\"{{ID}}\").api.createNote(\"Hello\")` in the console.",
+    "Sheet": {
+      "NamePlaceholder": "Name",
+      "Note": {
+        "title": "Note"
+      }
+    },
+    "Note": {
+      "NewName": "New Note",
+      "Pinned": "Pinned",
+      "ReferenceHint": "Paste this in any text field to link here."
+    }
   }
 }

--- a/packages/cli/templates/module-js/module.json
+++ b/packages/cli/templates/module-js/module.json
@@ -11,10 +11,15 @@
   "esmodules": ["main.mjs"],
   "styles": [{ "src": "styles/main.css" }],
   "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
+  "documentTypes": {
+    "Item": {
+      "note": { "htmlFields": ["body"] }
+    }
+  },
   "flags": {
     "hotReload": {
-      "extensions": ["css", "json"],
-      "paths": ["styles", "lang"]
+      "extensions": ["css", "hbs", "json"],
+      "paths": ["styles", "templates", "lang"]
     }
   }
 }

--- a/packages/cli/templates/module-js/scripts/constants.mjs
+++ b/packages/cli/templates/module-js/scripts/constants.mjs
@@ -1,0 +1,12 @@
+import { moduleSubType } from '@vttforge/core';
+
+export const MODULE_ID = '{{ID}}';
+
+/**
+ * The key Foundry files the `note` sub-type under: `{{ID}}.note`.
+ *
+ * A module's sub-types are namespaced by Foundry. Use this constant wherever
+ * the type is named — `item.type === NOTE_TYPE`, `types: [NOTE_TYPE]` — and
+ * the prefix cannot be forgotten.
+ */
+export const NOTE_TYPE = moduleSubType(MODULE_ID, 'note');

--- a/packages/cli/templates/module-js/scripts/data/note-data.mjs
+++ b/packages/cli/templates/module-js/scripts/data/note-data.mjs
@@ -1,0 +1,18 @@
+/**
+ * NoteData — the `note` Item sub-type this module adds to any system.
+ *
+ * The schema is a function handed to the factory. It has to be a function
+ * because `fields()` reads a Foundry global that does not exist when this
+ * module is first evaluated.
+ */
+import { BaseTypeDataModel, fields } from '@vttforge/core';
+
+const defineNoteSchema = () => {
+  const f = fields();
+  return {
+    body: new f.HTMLField(),
+    pinned: new f.BooleanField({ required: true, nullable: false, initial: false }),
+  };
+};
+
+export class NoteData extends BaseTypeDataModel(defineNoteSchema) {}

--- a/packages/cli/templates/module-js/scripts/enricher.mjs
+++ b/packages/cli/templates/module-js/scripts/enricher.mjs
@@ -8,6 +8,10 @@
  */
 import { NOTE_TYPE } from './constants.mjs';
 
+/**
+ * @param {string} id
+ * @returns {any}
+ */
 function findNote(id) {
   const item = game.items.get(id);
   return item?.type === NOTE_TYPE ? item : undefined;
@@ -18,6 +22,7 @@ export const noteEnricher = {
   id: 'note',
   pattern: /@Note\[([^\]]+)\]/g,
 
+  /** @param {RegExpMatchArray} match */
   enricher(match) {
     const id = match[1];
     const note = id === undefined ? undefined : findNote(id);
@@ -29,13 +34,18 @@ export const noteEnricher = {
     link.className = '{{ID}}-note-link';
     link.dataset.noteId = id;
     link.draggable = false;
-    link.append(Object.assign(document.createElement('i'), { className: 'fa-solid fa-note-sticky' }));
-    link.append(note.name);
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid fa-note-sticky';
+    link.append(icon, note.name);
     return link;
   },
 
+  /** @param {HTMLElement} element */
   onRender(element) {
-    for (const link of element.querySelectorAll('a.{{ID}}-note-link')) {
+    const links = /** @type {NodeListOf<HTMLElement>} */ (
+      element.querySelectorAll('a.{{ID}}-note-link')
+    );
+    for (const link of links) {
       link.addEventListener('click', (event) => {
         event.preventDefault();
         const { noteId } = link.dataset;

--- a/packages/cli/templates/module-js/scripts/enricher.mjs
+++ b/packages/cli/templates/module-js/scripts/enricher.mjs
@@ -1,0 +1,46 @@
+/**
+ * `@Note[id]` — a link to a note from any enriched text field.
+ *
+ * Declared as data and handed to `registerModule({ enrichers })`, which
+ * registers it as `{{ID}}.note`. The pattern carries the `g` flag because
+ * enrichment runs it through `matchAll`, and `onRender` binds the click
+ * where the markup is declared rather than in a separate hook.
+ */
+import { NOTE_TYPE } from './constants.mjs';
+
+function findNote(id) {
+  const item = game.items.get(id);
+  return item?.type === NOTE_TYPE ? item : undefined;
+}
+
+/** @type {import('@vttforge/core').EnricherRegistration} */
+export const noteEnricher = {
+  id: 'note',
+  pattern: /@Note\[([^\]]+)\]/g,
+
+  enricher(match) {
+    const id = match[1];
+    const note = id === undefined ? undefined : findNote(id);
+    // Leave the text alone when the note is gone: a dead link is worse than
+    // the raw reference, which at least says what was meant.
+    if (note === undefined) return null;
+
+    const link = document.createElement('a');
+    link.className = '{{ID}}-note-link';
+    link.dataset.noteId = id;
+    link.draggable = false;
+    link.append(Object.assign(document.createElement('i'), { className: 'fa-solid fa-note-sticky' }));
+    link.append(note.name);
+    return link;
+  },
+
+  onRender(element) {
+    for (const link of element.querySelectorAll('a.{{ID}}-note-link')) {
+      link.addEventListener('click', (event) => {
+        event.preventDefault();
+        const { noteId } = link.dataset;
+        if (noteId) findNote(noteId)?.sheet.render(true);
+      });
+    }
+  },
+};

--- a/packages/cli/templates/module-js/scripts/main.mjs
+++ b/packages/cli/templates/module-js/scripts/main.mjs
@@ -1,65 +1,87 @@
 /**
  * {{TITLE}} — entry point.
  *
- * Demonstrates the typical Foundry module lifecycle:
- *
- * - `Hooks.once("init")` — register settings (here via `SystemConfig` from
- *   `@vttforge/core` for typed access) and expose the public API on
- *   `game.modules.get(MODULE_ID).api`.
- * - `Hooks.once("ready")` — surface a one-shot notification if the user
- *   opted in via settings.
- * - `Hooks.on("renderActorSheetV2", ...)` — example hook listener that
- *   tags any actor sheet with a discreet `.{{ID}}-badge` so you can verify
- *   the module is actually attached without hunting through devtools.
+ * One `registerModule` call replaces the `Hooks.once("init", ...)` block most
+ * modules copy from each other: the sub-type, its sheet, the enricher, the
+ * settings, and the public API.
  */
-import { SystemConfig } from '@vttforge/core';
+import { registerModule, SystemConfig, VttfError } from '@vttforge/core';
+import { MODULE_ID, NOTE_TYPE } from './constants.mjs';
+import { NoteData } from './data/note-data.mjs';
+import { noteEnricher } from './enricher.mjs';
+import { NoteSheet } from './sheets/note-sheet.mjs';
 
-const MODULE_ID = '{{ID}}';
 const settings = new SystemConfig(MODULE_ID);
 
-Hooks.once('init', () => {
-  settings.register('showWelcome', {
-    name: '{{LOCALE_PREFIX}}.Settings.showWelcome.name',
-    hint: '{{LOCALE_PREFIX}}.Settings.showWelcome.hint',
-    scope: 'client',
-    config: true,
-    type: Boolean,
-    default: true,
+/** What `game.modules.get("{{ID}}").api` offers other modules and macros. */
+const api = {
+  /** The prefixed type key, for `item.type === api.noteType` checks. */
+  noteType: NOTE_TYPE,
+  /**
+   * @param {string} name
+   * @param {string} [body]
+   */
+  createNote(name, body = '') {
+    return CONFIG.Item.documentClass.create(
+      { name, type: NOTE_TYPE, system: { body } },
+      { renderSheet: true },
+    );
+  },
+};
+
+try {
+  registerModule({
+    id: MODULE_ID,
+
+    // Registered as `{{ID}}.note` — the prefix is added for you, and the
+    // manifest declares the same key under `documentTypes.Item`.
+    itemDataModels: { note: NoteData },
+
+    // Declared here rather than with `Items.registerSheet`. Foundry keys a
+    // sheet by `${scope}.${class name}` and saves that key on every document
+    // using it; a bundler renames classes between builds, and the saved key
+    // then names a sheet that no longer exists. The `id` is written down, so
+    // the key does not move. Pick it once and keep it.
+    sheets: [
+      {
+        id: 'note',
+        document: 'Item',
+        sheet: NoteSheet,
+        types: [NOTE_TYPE],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Note.title',
+      },
+    ],
+
+    enrichers: [noteEnricher],
+
+    // Runs first inside `init` — the usual home for the module API, so it is
+    // there before anything that might hook `init` after us asks for it.
+    onBeforeInit: () => {
+      const handle = game.modules.get(MODULE_ID);
+      if (handle) handle.api = api;
+    },
+
+    onAfterInit: () => {
+      settings.register('showWelcome', {
+        name: '{{LOCALE_PREFIX}}.Settings.showWelcome.name',
+        hint: '{{LOCALE_PREFIX}}.Settings.showWelcome.hint',
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: true,
+      });
+    },
+
+    onReady: () => {
+      if (settings.get('showWelcome')) {
+        ui.notifications?.info(game.i18n.localize('{{LOCALE_PREFIX}}.Welcome'));
+      }
+    },
   });
-
-  const api = {
-    greet(name) {
-      return `Hello, ${name}!`;
-    },
-    getSetting(key) {
-      return settings.get(key);
-    },
-  };
-
-  const moduleHandle = game.modules.get(MODULE_ID);
-  if (moduleHandle) {
-    moduleHandle.api = api;
+} catch (err) {
+  if (err instanceof VttfError) {
+    console.error(`[${err.code}] ${err.message} — see ${err.docsUrl}`);
   }
-});
-
-Hooks.once('ready', () => {
-  const shouldWelcome = settings.get('showWelcome');
-  if (shouldWelcome) {
-    ui.notifications?.info(game.i18n.localize('{{LOCALE_PREFIX}}.Welcome'));
-  }
-});
-
-Hooks.on('renderActorSheetV2', (_app, element) => {
-  // Decorative: tag the rendered sheet so it's obvious the module is
-  // active. Remove or replace with real behaviour once you start shipping
-  // module features.
-  const header = element.querySelector('.window-header .window-title');
-  if (header && !header.querySelector(`.{{ID}}-badge`)) {
-    const badge = document.createElement('span');
-    badge.className = '{{ID}}-badge';
-    // Double-quoted because `vttforge init` rejects `"` and `\` in the
-    // title — apostrophes in titles like "Daisy's Module" stay intact.
-    badge.textContent = "{{TITLE}}";
-    header.appendChild(badge);
-  }
-});
+  throw err;
+}

--- a/packages/cli/templates/module-js/scripts/sheets/note-sheet.mjs
+++ b/packages/cli/templates/module-js/scripts/sheets/note-sheet.mjs
@@ -1,0 +1,60 @@
+/**
+ * NoteSheet — the `note` Item sheet on `BaseItemSheet()`.
+ *
+ * One part, no tabs, one action. The smallest sheet a module can ship.
+ */
+import { BaseItemSheet } from '@vttforge/core';
+import { MODULE_ID } from '../constants.mjs';
+
+export class NoteSheet extends BaseItemSheet() {
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    super.DEFAULT_OPTIONS,
+    {
+      id: '{{ID}}-note',
+      classes: ['{{ID}}', 'sheet', 'item', 'note'],
+      window: {
+        title: '{{LOCALE_PREFIX}}.Sheet.Note.title',
+        icon: 'fa-solid fa-note-sticky',
+      },
+      position: { width: 480, height: 480 },
+      actions: {
+        togglePinned: NoteSheet._onTogglePinned,
+      },
+    },
+    { inplace: false },
+  );
+
+  static PARTS = {
+    sheet: { template: `modules/${MODULE_ID}/templates/item/note-sheet.hbs` },
+  };
+
+  /**
+   * The item this sheet is for. One place to read `this.document` from, so
+   * the rest of the sheet says `this.item` and means it.
+   * @returns {any}
+   */
+  get item() {
+    return this.document;
+  }
+
+  /** @override */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const { item } = this;
+    context.item = item;
+    context.system = item.system;
+    context.isEditable = this.isEditable;
+    context.reference = `@Note[${item.id}]`;
+    context.enrichedBody = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      item.system.body,
+      { relativeTo: item, secrets: item.isOwner },
+    );
+    return context;
+  }
+
+  // ApplicationV2 declares action handlers static and calls them with `this`
+  // bound to the sheet instance.
+  static async _onTogglePinned() {
+    await this.item.update({ 'system.pinned': !this.item.system.pinned });
+  }
+}

--- a/packages/cli/templates/module-js/scripts/sheets/note-sheet.mjs
+++ b/packages/cli/templates/module-js/scripts/sheets/note-sheet.mjs
@@ -7,6 +7,7 @@ import { BaseItemSheet } from '@vttforge/core';
 import { MODULE_ID } from '../constants.mjs';
 
 export class NoteSheet extends BaseItemSheet() {
+  /** @override */
   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
     super.DEFAULT_OPTIONS,
     {
@@ -37,7 +38,11 @@ export class NoteSheet extends BaseItemSheet() {
     return this.document;
   }
 
-  /** @override */
+  /**
+   * @override
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<Record<string, unknown>>}
+   */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const { item } = this;
@@ -52,9 +57,13 @@ export class NoteSheet extends BaseItemSheet() {
     return context;
   }
 
-  // ApplicationV2 declares action handlers static and calls them with `this`
-  // bound to the sheet instance.
+  /**
+   * @this {NoteSheet} ApplicationV2 declares action handlers static but calls
+   *   them with `this` bound to the sheet instance.
+   */
   static async _onTogglePinned() {
-    await this.item.update({ 'system.pinned': !this.item.system.pinned });
+    // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
+    const { item } = this;
+    await item.update({ 'system.pinned': !item.system.pinned });
   }
 }

--- a/packages/cli/templates/module-js/styles/main.css
+++ b/packages/cli/templates/module-js/styles/main.css
@@ -1,16 +1,77 @@
 /**
  * {{TITLE}} stylesheet.
  *
- * Scope all rules under the `.{{ID}}` namespace so they don't leak into
- * other modules or the host system's sheets. Foundry's CSS cascade is
- * already layered, but namespacing makes intent explicit.
+ * Every rule is scoped under `.{{ID}}` so nothing leaks into the host system's
+ * sheets. Colours come from Foundry's own variables so the sheet follows the
+ * light and dark themes.
  */
-.{{ID}}-badge {
+.{{ID}}.sheet .sheet-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.{{ID}}.sheet .sheet-header .portrait {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border: 1px solid var(--color-border-dark, #7a7971);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.{{ID}}.sheet .sheet-header input[name="name"] {
+  flex: 1;
+  font-size: var(--font-size-20, 1.25rem);
+}
+
+.{{ID}}.sheet .sheet-header .pin {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  opacity: 0.5;
+}
+
+.{{ID}}.sheet .sheet-header .pin.active {
+  opacity: 1;
+  color: var(--color-warm-2, #c9593f);
+}
+
+.{{ID}}.sheet .sheet-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  height: 100%;
+}
+
+.{{ID}}.sheet prose-mirror,
+.{{ID}}.sheet .body-readonly {
+  flex: 1;
+  min-height: 12rem;
+}
+
+.{{ID}}.sheet .reference {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  color: var(--color-text-secondary, #4b4a44);
+  font-size: var(--font-size-12, 0.75rem);
+}
+
+/* Rendered by the `note` enricher wherever `@Note[id]` appears. */
+a.{{ID}}-note-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.4em;
-  padding: 0.15em 0.5em;
-  border-radius: 4px;
-  background: rgba(0, 0, 0, 0.08);
-  font-size: 0.8em;
+  gap: 0.25em;
+  padding: 0 0.35em;
+  border: 1px dotted var(--color-border-dark, #7a7971);
+  border-radius: 3px;
+  background: var(--color-bg-tertiary, rgba(0, 0, 0, 0.06));
+  text-decoration: none;
+}
+
+a.{{ID}}-note-link:hover {
+  border-style: solid;
+  text-shadow: none;
 }

--- a/packages/cli/templates/module-js/templates/item/note-sheet.hbs
+++ b/packages/cli/templates/module-js/templates/item/note-sheet.hbs
@@ -1,0 +1,34 @@
+{{!-- Note sheet — one part, no tabs. --}}
+<form autocomplete="off">
+
+  <header class="sheet-header">
+    <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
+    <input type="text" name="name" value="{{item.name}}"
+           placeholder="{{localize '{{LOCALE_PREFIX}}.Sheet.NamePlaceholder'}}" />
+    <button type="button" class="pin {{#if system.pinned}}active{{/if}}"
+            data-action="togglePinned"
+            title="{{localize '{{LOCALE_PREFIX}}.Note.Pinned'}}">
+      <i class="fa-solid fa-thumbtack"></i>
+    </button>
+  </header>
+
+  <section class="sheet-body">
+    {{#if isEditable}}
+      <prose-mirror name="system.body"
+                    button="true"
+                    editable="{{isEditable}}"
+                    toggled="false"
+                    value="{{system.body}}">
+        {{{enrichedBody}}}
+      </prose-mirror>
+    {{else}}
+      <div class="body-readonly">{{{enrichedBody}}}</div>
+    {{/if}}
+
+    <footer class="reference">
+      <code>{{reference}}</code>
+      <small>{{localize '{{LOCALE_PREFIX}}.Note.ReferenceHint'}}</small>
+    </footer>
+  </section>
+
+</form>

--- a/packages/cli/templates/module-ts/README.md
+++ b/packages/cli/templates/module-ts/README.md
@@ -2,55 +2,84 @@
 
 {{DESCRIPTION}}
 
-A Foundry VTT module built on [VTTForge](https://github.com/vttforge/vttforge) — uses `SystemConfig` from `@vttforge/core` for typed settings, ships an example hook listener, and exposes a small public API on `game.modules.get("{{ID}}").api`.
-
-> **Note** — VTTForge is currently in pre-release and not yet published to npm. Dependencies in `package.json` will resolve once VTTForge ships its first public release.
+A Foundry VTT v13+ module built on [VTTForge](https://vttforge.dev). It adds a
+`note` Item type to whatever system the world runs, a sheet for it, and an
+`@Note[id]` enricher that links to one from any text field.
 
 ## Quick start
 
 ```bash
 pnpm install
-pnpm dev      # vite build --watch + auto-symlinks dist/ into Foundry's Data
-pnpm build    # one-shot build + emits {{ID}}-<version>.zip for foundryvtt.com
+pnpm dev      # build, link dist/ into Foundry's data dir, watch
+pnpm build    # dist/ plus {{ID}}-<version>.zip
 ```
 
-`pnpm dev` (`vttforge dev` under the hood) auto-detects your Foundry user-data
-directory on the first run, prompts you to confirm it, and saves the choice to
-`.vttforge/config.json` for next time. Override with `--data-dir <path>` or set
-`FOUNDRY_DATA_DIR` in your environment.
+`pnpm dev` asks where Foundry keeps its data on the first run and remembers
+the answer in `.vttforge/config.json`. Override with `--foundry-data <path>`
+or `FOUNDRY_DATA_DIR`. If Foundry runs in a container it cannot follow the
+symlink, and the command prints the compose mount to use instead.
 
-Run Foundry with `--hotReload` to pick up changes without refreshing the page.
-Then enable **{{TITLE}}** in any world.
+Save a template and the open sheet redraws in place; save a stylesheet and the
+CSS swaps. Enable **VTTForge Dev** in the world once — `pnpm dev` links it in.
+
+Then enable **{{TITLE}}** in a world and create a Note from the Items sidebar.
 
 ## What's inside
 
 | Path | Purpose |
 |---|---|
-| `module.json` | Manifest |
-| `scripts/main.ts` | Entry point — settings registration, hook listeners, public API |
-| `styles/main.css` | Stylesheet, scoped under `.{{ID}}` |
-| `lang/en.json` | Localization strings |
+| `module.json` | Manifest — declares the `note` sub-type under `documentTypes` and the hot-reload paths |
+| `scripts/main.ts` | One `registerModule` call: data model, sheet, enricher, settings, API |
+| `scripts/constants.ts` | `MODULE_ID` and `NOTE_TYPE` — the prefixed key Foundry files the sub-type under |
+| `scripts/data/note-data.ts` | The data model. The schema is a function handed to `BaseTypeDataModel`, which is what makes `this.body` a `string` |
+| `scripts/sheets/note-sheet.ts` | The sheet, on `BaseItemSheet` |
+| `scripts/enricher.ts` | `@Note[id]` → a link that opens the note |
+| `templates/` | Handlebars, using v13's own elements (`<prose-mirror>`, `data-action`) |
+| `styles/main.css` | Scoped under `.{{ID}}`, colours from Foundry's variables |
+| `lang/en.json` | Strings, under the `{{LOCALE_PREFIX}}` prefix, plus the `TYPES.Item` label |
+
+## Three things worth knowing before you edit
+
+**A module's sub-types are namespaced.** You register `note`; Foundry files it
+as `{{ID}}.note`, and so must the manifest. `registerModule` adds the prefix,
+and `NOTE_TYPE` in `constants.ts` is the one place it is spelled out.
+
+**Sheets are registered by id, not by class name.** `registerModule({ sheets })`
+pins each sheet under `{{ID}}.<id>`. Foundry saves that key on every item
+whose owner picked the sheet, and derives it from the class name unless told
+otherwise — which a bundler renames between builds. Keep the ids.
+
+**`this.document` is `unknown` on the sheet bases.** Which document a sheet is
+for is yours to know. The sheet narrows it once in a getter (`item`) and
+everything below reads typed.
 
 ## Public API
 
-The module exposes its API on `game.modules.get("{{ID}}").api`:
-
 ```ts
 const api = game.modules.get("{{ID}}").api;
-api.greet("world");                   // returns "Hello, world!"
-api.getSetting("showWelcome");        // returns the current value
+await api.createNote("Session 3", "<p>The party reached the gate.</p>");
+api.noteType; // "{{ID}}.note"
 ```
 
-Extend `scripts/main.ts` to add real methods — the example exists to show the registration pattern.
+## Checks
 
-## Releasing to Foundry
+```bash
+pnpm typecheck        # tsc against the real @vttforge/core types
+npx vttforge audit    # manifest + source against the v13 list of quiet breakages
+```
 
-Tag-push triggers `.github/workflows/release.yml` to build, zip, and attach `{{ID}}-<version>.zip` + `dist/module.json` to a GitHub Release. Point Foundry at the `latest/download/module.json` URL.
+## Releasing
+
+Push a tag and `.github/workflows/release.yml` builds, zips, and attaches
+`{{ID}}-<version>.zip` plus `module.json` to a GitHub Release:
 
 ```bash
 git tag v0.1.0
 git push --tags
 ```
+
+Point Foundry — and foundryvtt.com — at the release's
+`latest/download/module.json`, so installs auto-update on every tag.
 
 ## License
 

--- a/packages/cli/templates/module-ts/lang/en.json
+++ b/packages/cli/templates/module-ts/lang/en.json
@@ -1,4 +1,11 @@
 {
+  "TYPES": {
+    "Item": {
+      "{{ID}}": {
+        "note": "Note"
+      }
+    }
+  },
   "{{LOCALE_PREFIX}}": {
     "Settings": {
       "showWelcome": {
@@ -6,6 +13,17 @@
         "hint": "Display a one-shot toast when {{TITLE}} loads in a world."
       }
     },
-    "Welcome": "{{TITLE}} loaded — try `game.modules.get(\"{{ID}}\").api.greet(\"GM\")` in the console."
+    "Welcome": "{{TITLE}} loaded — create a Note from the Items sidebar, or try `game.modules.get(\"{{ID}}\").api.createNote(\"Hello\")` in the console.",
+    "Sheet": {
+      "NamePlaceholder": "Name",
+      "Note": {
+        "title": "Note"
+      }
+    },
+    "Note": {
+      "NewName": "New Note",
+      "Pinned": "Pinned",
+      "ReferenceHint": "Paste this in any text field to link here."
+    }
   }
 }

--- a/packages/cli/templates/module-ts/module.json
+++ b/packages/cli/templates/module-ts/module.json
@@ -11,10 +11,15 @@
   "esmodules": ["main.mjs"],
   "styles": [{ "src": "styles/main.css" }],
   "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
+  "documentTypes": {
+    "Item": {
+      "note": { "htmlFields": ["body"] }
+    }
+  },
   "flags": {
     "hotReload": {
-      "extensions": ["css", "json"],
-      "paths": ["styles", "lang"]
+      "extensions": ["css", "hbs", "json"],
+      "paths": ["styles", "templates", "lang"]
     }
   }
 }

--- a/packages/cli/templates/module-ts/scripts/constants.ts
+++ b/packages/cli/templates/module-ts/scripts/constants.ts
@@ -1,0 +1,12 @@
+import { moduleSubType } from '@vttforge/core';
+
+export const MODULE_ID = '{{ID}}';
+
+/**
+ * The key Foundry files the `note` sub-type under: `{{ID}}.note`.
+ *
+ * A module's sub-types are namespaced by Foundry. Use this constant wherever
+ * the type is named — `item.type === NOTE_TYPE`, `types: [NOTE_TYPE]` — and
+ * the prefix cannot be forgotten.
+ */
+export const NOTE_TYPE = moduleSubType(MODULE_ID, 'note');

--- a/packages/cli/templates/module-ts/scripts/data/note-data.ts
+++ b/packages/cli/templates/module-ts/scripts/data/note-data.ts
@@ -1,0 +1,19 @@
+/**
+ * NoteData — the `note` Item sub-type this module adds to any system.
+ *
+ * The schema is a function handed to the factory. It has to be a function
+ * because `fields()` reads a Foundry global that does not exist when this
+ * module is first evaluated, and handing it to `BaseTypeDataModel(...)` is
+ * what types `this.body` and `this.pinned` on the instance.
+ */
+import { BaseTypeDataModel, fields } from '@vttforge/core';
+
+const defineNoteSchema = () => {
+  const f = fields();
+  return {
+    body: new f.HTMLField(),
+    pinned: new f.BooleanField({ required: true, nullable: false, initial: false }),
+  };
+};
+
+export class NoteData extends BaseTypeDataModel(defineNoteSchema) {}

--- a/packages/cli/templates/module-ts/scripts/enricher.ts
+++ b/packages/cli/templates/module-ts/scripts/enricher.ts
@@ -1,0 +1,52 @@
+/**
+ * `@Note[id]` — a link to a note from any enriched text field.
+ *
+ * Declared as data and handed to `registerModule({ enrichers })`, which
+ * registers it as `{{ID}}.note`. The pattern carries the `g` flag because
+ * enrichment runs it through `matchAll`, and `onRender` binds the click
+ * where the markup is declared rather than in a separate hook.
+ */
+import type { EnricherRegistration } from '@vttforge/core';
+import { NOTE_TYPE } from './constants.js';
+
+interface NoteLike {
+  readonly name: string;
+  readonly type: string;
+  readonly sheet: { render(force?: boolean): unknown };
+}
+
+function findNote(id: string): NoteLike | undefined {
+  const item = game.items.get(id) as NoteLike | undefined;
+  return item?.type === NOTE_TYPE ? item : undefined;
+}
+
+export const noteEnricher: EnricherRegistration = {
+  id: 'note',
+  pattern: /@Note\[([^\]]+)\]/g,
+
+  enricher(match) {
+    const id = match[1];
+    const note = id === undefined ? undefined : findNote(id);
+    // Leave the text alone when the note is gone: a dead link is worse than
+    // the raw reference, which at least says what was meant.
+    if (note === undefined) return null;
+
+    const link = document.createElement('a');
+    link.className = '{{ID}}-note-link';
+    link.dataset.noteId = id;
+    link.draggable = false;
+    link.append(Object.assign(document.createElement('i'), { className: 'fa-solid fa-note-sticky' }));
+    link.append(note.name);
+    return link;
+  },
+
+  onRender(element) {
+    for (const link of element.querySelectorAll<HTMLElement>('a.{{ID}}-note-link')) {
+      link.addEventListener('click', (event) => {
+        event.preventDefault();
+        const { noteId } = link.dataset;
+        if (noteId) findNote(noteId)?.sheet.render(true);
+      });
+    }
+  },
+};

--- a/packages/cli/templates/module-ts/scripts/main.ts
+++ b/packages/cli/templates/module-ts/scripts/main.ts
@@ -1,71 +1,89 @@
 /**
  * {{TITLE}} — entry point.
  *
- * Demonstrates the typical Foundry module lifecycle:
- *
- * - `Hooks.once("init")` — register settings (here via `SystemConfig` from
- *   `@vttforge/core` for typed access) and expose the public API on
- *   `game.modules.get(MODULE_ID).api`.
- * - `Hooks.once("ready")` — surface a one-shot notification if the user
- *   opted in via settings.
- * - `Hooks.on("renderActorSheetV2", ...)` — example hook listener that
- *   tags any actor sheet with a discreet `.{{ID}}-badge` so you can verify
- *   the module is actually attached without hunting through devtools.
+ * One `registerModule` call replaces the `Hooks.once("init", ...)` block most
+ * modules copy from each other: the sub-type, its sheet, the enricher, the
+ * settings, and the public API.
  */
 import './foundry-globals.js';
-import { SystemConfig } from '@vttforge/core';
+import { registerModule, SystemConfig, VttfError } from '@vttforge/core';
+import { MODULE_ID, NOTE_TYPE } from './constants.js';
+import { NoteData } from './data/note-data.js';
+import { noteEnricher } from './enricher.js';
+import { NoteSheet } from './sheets/note-sheet.js';
 
-const MODULE_ID = '{{ID}}';
 const settings = new SystemConfig(MODULE_ID);
 
+/** What `game.modules.get("{{ID}}").api` offers other modules and macros. */
 interface ModuleApi {
-  greet(name: string): string;
-  getSetting<T>(key: string): T;
+  /** The prefixed type key, for `item.type === api.noteType` checks. */
+  readonly noteType: string;
+  createNote(name: string, body?: string): Promise<unknown>;
 }
 
-Hooks.once('init', () => {
-  settings.register('showWelcome', {
-    name: '{{LOCALE_PREFIX}}.Settings.showWelcome.name',
-    hint: '{{LOCALE_PREFIX}}.Settings.showWelcome.hint',
-    scope: 'client',
-    config: true,
-    type: Boolean,
-    default: true,
+const api: ModuleApi = {
+  noteType: NOTE_TYPE,
+  createNote(name, body = '') {
+    return CONFIG.Item.documentClass.create(
+      { name, type: NOTE_TYPE, system: { body } },
+      { renderSheet: true },
+    );
+  },
+};
+
+try {
+  registerModule({
+    id: MODULE_ID,
+
+    // Registered as `{{ID}}.note` — the prefix is added for you, and the
+    // manifest declares the same key under `documentTypes.Item`.
+    itemDataModels: { note: NoteData },
+
+    // Declared here rather than with `Items.registerSheet`. Foundry keys a
+    // sheet by `${scope}.${class name}` and saves that key on every document
+    // using it; a bundler renames classes between builds, and the saved key
+    // then names a sheet that no longer exists. The `id` is written down, so
+    // the key does not move. Pick it once and keep it.
+    sheets: [
+      {
+        id: 'note',
+        document: 'Item',
+        sheet: NoteSheet,
+        types: [NOTE_TYPE],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Note.title',
+      },
+    ],
+
+    enrichers: [noteEnricher],
+
+    // Runs first inside `init` — the usual home for the module API, so it is
+    // there before anything that might hook `init` after us asks for it.
+    onBeforeInit: () => {
+      const handle = game.modules.get(MODULE_ID);
+      if (handle) handle.api = api;
+    },
+
+    onAfterInit: () => {
+      settings.register('showWelcome', {
+        name: '{{LOCALE_PREFIX}}.Settings.showWelcome.name',
+        hint: '{{LOCALE_PREFIX}}.Settings.showWelcome.hint',
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: true,
+      });
+    },
+
+    onReady: () => {
+      if (settings.get<boolean>('showWelcome')) {
+        ui.notifications?.info(game.i18n.localize('{{LOCALE_PREFIX}}.Welcome'));
+      }
+    },
   });
-
-  const api: ModuleApi = {
-    greet(name: string): string {
-      return `Hello, ${name}!`;
-    },
-    getSetting<T>(key: string): T {
-      return settings.get(key) as T;
-    },
-  };
-
-  const moduleHandle = game.modules.get(MODULE_ID);
-  if (moduleHandle) {
-    moduleHandle.api = api;
+} catch (err) {
+  if (err instanceof VttfError) {
+    console.error(`[${err.code}] ${err.message} — see ${err.docsUrl}`);
   }
-});
-
-Hooks.once('ready', () => {
-  const shouldWelcome = settings.get<boolean>('showWelcome');
-  if (shouldWelcome) {
-    ui.notifications?.info(game.i18n.localize('{{LOCALE_PREFIX}}.Welcome'));
-  }
-});
-
-Hooks.on('renderActorSheetV2', (_app: unknown, element: HTMLElement) => {
-  // Decorative: tag the rendered sheet so it's obvious the module is
-  // active. Remove or replace with real behaviour once you start shipping
-  // module features.
-  const header = element.querySelector('.window-header .window-title');
-  if (header && !header.querySelector(`.{{ID}}-badge`)) {
-    const badge = document.createElement('span');
-    badge.className = '{{ID}}-badge';
-    // Double-quoted because `vttforge init` rejects `"` and `\` in the
-    // title — apostrophes in titles like "Daisy's Module" stay intact.
-    badge.textContent = "{{TITLE}}";
-    header.appendChild(badge);
-  }
-});
+  throw err;
+}

--- a/packages/cli/templates/module-ts/scripts/sheets/note-sheet.ts
+++ b/packages/cli/templates/module-ts/scripts/sheets/note-sheet.ts
@@ -1,0 +1,76 @@
+/**
+ * NoteSheet — the `note` Item sheet on `BaseItemSheet()`.
+ *
+ * One part, no tabs, one action. The smallest sheet a module can ship.
+ */
+import { BaseItemSheet } from '@vttforge/core';
+import { MODULE_ID } from '../constants.js';
+import type { NoteData } from '../data/note-data.js';
+
+/**
+ * What this sheet reads off its item.
+ *
+ * Foundry's own `Item` type is not wired in — see `foundry-globals.ts` — so
+ * the sheet says what it needs. Grow this as the sheet grows.
+ */
+interface NoteItem {
+  readonly id: string;
+  readonly name: string;
+  readonly img: string;
+  readonly isOwner: boolean;
+  readonly system: NoteData;
+  update(changes: Record<string, unknown>): Promise<unknown>;
+}
+
+export class NoteSheet extends BaseItemSheet() {
+  static override DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    super.DEFAULT_OPTIONS,
+    {
+      id: '{{ID}}-note',
+      classes: ['{{ID}}', 'sheet', 'item', 'note'],
+      window: {
+        title: '{{LOCALE_PREFIX}}.Sheet.Note.title',
+        icon: 'fa-solid fa-note-sticky',
+      },
+      position: { width: 480, height: 480 },
+      actions: {
+        togglePinned: NoteSheet._onTogglePinned,
+      },
+    },
+    { inplace: false },
+  );
+
+  static PARTS = {
+    sheet: { template: `modules/${MODULE_ID}/templates/item/note-sheet.hbs` },
+  };
+
+  /**
+   * The item this sheet is for.
+   *
+   * `this.document` is `unknown` on the base — which document a sheet is for
+   * is the module's to know. One cast, here, and everything below is typed.
+   */
+  get item(): NoteItem {
+    return this.document as NoteItem;
+  }
+
+  override async _prepareContext(options: unknown): Promise<Record<string, unknown>> {
+    const context = await super._prepareContext(options);
+    const { item } = this;
+    context.item = item;
+    context.system = item.system;
+    context.isEditable = this.isEditable;
+    context.reference = `@Note[${item.id}]`;
+    context.enrichedBody = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      item.system.body,
+      { relativeTo: item, secrets: item.isOwner },
+    );
+    return context;
+  }
+
+  // ApplicationV2 declares action handlers static and calls them with `this`
+  // bound to the sheet instance. `this: NoteSheet` says so to TypeScript.
+  static async _onTogglePinned(this: NoteSheet): Promise<void> {
+    await this.item.update({ 'system.pinned': !this.item.system.pinned });
+  }
+}

--- a/packages/cli/templates/module-ts/styles/main.css
+++ b/packages/cli/templates/module-ts/styles/main.css
@@ -1,16 +1,77 @@
 /**
  * {{TITLE}} stylesheet.
  *
- * Scope all rules under the `.{{ID}}` namespace so they don't leak into
- * other modules or the host system's sheets. Foundry's CSS cascade is
- * already layered, but namespacing makes intent explicit.
+ * Every rule is scoped under `.{{ID}}` so nothing leaks into the host system's
+ * sheets. Colours come from Foundry's own variables so the sheet follows the
+ * light and dark themes.
  */
-.{{ID}}-badge {
+.{{ID}}.sheet .sheet-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.{{ID}}.sheet .sheet-header .portrait {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border: 1px solid var(--color-border-dark, #7a7971);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.{{ID}}.sheet .sheet-header input[name="name"] {
+  flex: 1;
+  font-size: var(--font-size-20, 1.25rem);
+}
+
+.{{ID}}.sheet .sheet-header .pin {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  opacity: 0.5;
+}
+
+.{{ID}}.sheet .sheet-header .pin.active {
+  opacity: 1;
+  color: var(--color-warm-2, #c9593f);
+}
+
+.{{ID}}.sheet .sheet-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  height: 100%;
+}
+
+.{{ID}}.sheet prose-mirror,
+.{{ID}}.sheet .body-readonly {
+  flex: 1;
+  min-height: 12rem;
+}
+
+.{{ID}}.sheet .reference {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  color: var(--color-text-secondary, #4b4a44);
+  font-size: var(--font-size-12, 0.75rem);
+}
+
+/* Rendered by the `note` enricher wherever `@Note[id]` appears. */
+a.{{ID}}-note-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.4em;
-  padding: 0.15em 0.5em;
-  border-radius: 4px;
-  background: rgba(0, 0, 0, 0.08);
-  font-size: 0.8em;
+  gap: 0.25em;
+  padding: 0 0.35em;
+  border: 1px dotted var(--color-border-dark, #7a7971);
+  border-radius: 3px;
+  background: var(--color-bg-tertiary, rgba(0, 0, 0, 0.06));
+  text-decoration: none;
+}
+
+a.{{ID}}-note-link:hover {
+  border-style: solid;
+  text-shadow: none;
 }

--- a/packages/cli/templates/module-ts/templates/item/note-sheet.hbs
+++ b/packages/cli/templates/module-ts/templates/item/note-sheet.hbs
@@ -1,0 +1,34 @@
+{{!-- Note sheet — one part, no tabs. --}}
+<form autocomplete="off">
+
+  <header class="sheet-header">
+    <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
+    <input type="text" name="name" value="{{item.name}}"
+           placeholder="{{localize '{{LOCALE_PREFIX}}.Sheet.NamePlaceholder'}}" />
+    <button type="button" class="pin {{#if system.pinned}}active{{/if}}"
+            data-action="togglePinned"
+            title="{{localize '{{LOCALE_PREFIX}}.Note.Pinned'}}">
+      <i class="fa-solid fa-thumbtack"></i>
+    </button>
+  </header>
+
+  <section class="sheet-body">
+    {{#if isEditable}}
+      <prose-mirror name="system.body"
+                    button="true"
+                    editable="{{isEditable}}"
+                    toggled="false"
+                    value="{{system.body}}">
+        {{{enrichedBody}}}
+      </prose-mirror>
+    {{else}}
+      <div class="body-readonly">{{{enrichedBody}}}</div>
+    {{/if}}
+
+    <footer class="reference">
+      <code>{{reference}}</code>
+      <small>{{localize '{{LOCALE_PREFIX}}.Note.ReferenceHint'}}</small>
+    </footer>
+  </section>
+
+</form>

--- a/packages/cli/templates/module-ts/tsconfig.json
+++ b/packages/cli/templates/module-ts/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noImplicitOverride": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,
@@ -13,6 +14,11 @@
     "resolveJsonModule": true,
     "allowImportingTsExtensions": false
   },
-  "include": ["scripts/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "scripts/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/packages/cli/templates/system-js/README.md
+++ b/packages/cli/templates/system-js/README.md
@@ -2,55 +2,73 @@
 
 {{DESCRIPTION}}
 
-Built on [VTTForge](https://github.com/vttforge/vttforge) — typed data models, declarative sheet boilerplate, migration runner, error catalogue, and a Vite-based build pipeline.
-
-> **Note** — VTTForge is currently in pre-release and not yet published to npm. The dependencies in `package.json` (`@vttforge/core`, `@vttforge/styles`, `@vttforge/vite-plugin`) will resolve once VTTForge ships its first public release. Until then, work from a local checkout: `pnpm link --global` from each VTTForge package, then `pnpm link --global @vttforge/core @vttforge/styles @vttforge/vite-plugin` here.
+A Foundry VTT v13+ system built on [VTTForge](https://vttforge.dev): typed
+data models, sheet bases that already know their tabs and drops, a migration
+runner, and a build that produces what foundryvtt.com expects.
 
 ## Quick start
 
 ```bash
 pnpm install
-pnpm dev      # vite build --watch + auto-symlinks dist/ into Foundry's Data
-pnpm build    # one-shot build + emits {{ID}}-<version>.zip for foundryvtt.com
+pnpm dev      # build, link dist/ into Foundry's data dir, watch
+pnpm build    # dist/ plus {{ID}}-<version>.zip
 ```
 
-`pnpm dev` (`vttforge dev` under the hood) auto-detects your Foundry user-data
-directory on the first run, prompts you to confirm it, and saves the choice to
-`.vttforge/config.json` for next time. Override with `--data-dir <path>` or set
-`FOUNDRY_DATA_DIR` in your environment.
+`pnpm dev` asks where Foundry keeps its data on the first run and remembers
+the answer in `.vttforge/config.json`. Override with `--foundry-data <path>`
+or `FOUNDRY_DATA_DIR`. If Foundry runs in a container it cannot follow the
+symlink, and the command prints the compose mount to use instead.
 
-Run Foundry with `--hotReload` so saved files reload the world without a page
-refresh — `dev` watches `dist/` for changes, and Foundry's built-in dispatcher
-swaps CSS / Handlebars / JSON on the fly.
+Save a template and the open sheet redraws in place; save a stylesheet and the
+CSS swaps. Enable **VTTForge Dev** in the world once — `pnpm dev` links it in.
 
-Then launch Foundry, create a world that uses **{{TITLE}}**, and open a character — the sheet is the `CharacterSheet` shipped in `scripts/sheets/`.
+Then create a world on **{{TITLE}}** and open a character.
 
 ## What's inside
 
 | Path | Purpose |
 |---|---|
-| `system.json` | Manifest (id, compatibility, document types, manifest-side sanitization paths) |
-| `template.json` | Foundry document type declarations (Actor + Item subtypes) |
-| `scripts/main.mjs` | Entry point — one call to `registerSystem` from `@vttforge/core` |
-| `scripts/data/*.mjs` | Typed data models (`BaseTypeDataModel()` from `@vttforge/core`) |
-| `scripts/sheets/*.mjs` | Sheet boilerplate eliminators (`BaseActorSheet()` / `BaseItemSheet()`) |
-| `scripts/migrations.mjs` | `createMigrationRunner()` — versioned data migrations |
-| `templates/` | Handlebars templates for sheets |
-| `styles/main.css` | Stylesheet — imports `@vttforge/styles` as the design system base |
-| `lang/en.json` | Localization strings |
+| `system.json` | Manifest — types, `htmlFields`, hot-reload paths, migration flags |
+| `template.json` | The type names Foundry expects to see declared |
+| `scripts/main.mjs` | One `registerSystem` call: models, sheets, initiative, settings, migrations |
+| `scripts/data/*.mjs` | Data models. The schema is a function handed to `BaseTypeDataModel`, which is what keeps the schema in one place |
+| `scripts/sheets/*.mjs` | Sheets on `BaseActorSheet` / `BaseItemSheet` — `static TABS`, `static DRAG_DROP`, `onDropItem` |
+| `scripts/migrations.mjs` | `createMigrationRunner` — versioned, idempotent, GM-gated |
+| `templates/` | Handlebars, using v13's own elements (`<prose-mirror>`, `data-action`) |
+| `styles/main.css` | Imports `@vttforge/styles` and scopes your rules under `.{{ID}}` |
+| `lang/en.json` | Strings, under the `{{LOCALE_PREFIX}}` prefix |
 
-## Releasing to Foundry
+## Two things worth knowing before you edit
 
-Tag-push triggers `.github/workflows/release.yml`, which builds the system, zips `dist/`, and attaches both `{{ID}}-<version>.zip` and `dist/system.json` to a GitHub Release.
+**Sheets are registered by id, not by class name.** `registerSystem({ sheets })`
+pins each sheet under `{{ID}}.<id>`. Foundry saves that key on every actor
+whose owner picked the sheet, and derives it from the class name unless told
+otherwise — which a bundler renames between builds. Keep the ids; renaming one
+loses the sheet choice on every document already using it.
+
+**Derived values live in the schema.** `mod` on each ability is computed in
+`prepareDerivedData`, but it is declared as a field. JavaScript has no
+`declare`: a plain class field would emit and reset the property to
+`undefined` after every data preparation.
+
+## Checks
+
+```bash
+npx vttforge audit    # manifest + source against the v13 list of quiet breakages
+```
+
+## Releasing
+
+Push a tag and `.github/workflows/release.yml` builds, zips, and attaches
+`{{ID}}-<version>.zip` plus `system.json` to a GitHub Release:
 
 ```bash
 git tag v0.1.0
 git push --tags
 ```
 
-Foundry installs from the `system.json` URL on the Release — point users at the `latest/download/system.json` URL in the release notes so they auto-update on every tag.
-
-For foundryvtt.com submissions, submit the same manifest URL pattern.
+Point Foundry — and foundryvtt.com — at the release's
+`latest/download/system.json`, so installs auto-update on every tag.
 
 ## License
 

--- a/packages/cli/templates/system-js/scripts/data/character-data.mjs
+++ b/packages/cli/templates/system-js/scripts/data/character-data.mjs
@@ -1,78 +1,84 @@
 /**
- * CharacterData — typed schema for the `character` Actor type.
+ * CharacterData — the `character` Actor type.
  *
- * Quick stats are HP / AC / SPD / INIT, abilities are the six classic
- * scores (str/dex/con/int/wis/cha). Derived state (modifiers, max HP,
- * armor class, initiative) is computed in-memory in `prepareDerivedData`.
- *
- * `prepareBaseData` initialises fields that Active Effects need to mutate
- * (base max HP before any AE bonus); `prepareDerivedData` then computes
- * the AE-aware values (modifiers, percentages, totals). Never write to the
- * database in either hook — they're purely in-memory derivations.
+ * Quick stats are HP / AC / SPD / INIT; abilities are the six classic scores.
+ * Derived state (modifiers, max HP, armour class, initiative) is computed in
+ * memory in `prepareDerivedData`. Never write to the database from there.
  */
 import { BaseTypeDataModel, fields } from '@vttforge/core';
 
-export class CharacterData extends BaseTypeDataModel() {
-  static defineSchema() {
-    const f = fields();
-    // The six ability scores are written once, as a factory rather than a
-    // shared options object: a field keeps the options it was handed, and
-    // some field classes write back into them.
-    const score = () =>
-      new f.NumberField({
+/**
+ * The schema, as a function handed to the factory.
+ *
+ * It has to be a function rather than an object because `fields()` reads a
+ * Foundry global that does not exist when this module is first evaluated.
+ * Handing it to `BaseTypeDataModel(...)` rather than declaring a `static
+ * defineSchema()` is also what types the fields if you ever add `checkJs`.
+ */
+const defineCharacterSchema = () => {
+  const f = fields();
+
+  // One ability. `value` is stored and is what the sheet's input writes to
+  // (`name="system.abilities.str.value"`). `mod` is derived on every data
+  // preparation; it lives in the schema because JavaScript has no `declare`
+  // — a class field would emit and reset the property to undefined.
+  const score = () =>
+    new f.SchemaField({
+      value: new f.NumberField({
         required: true,
         nullable: false,
         integer: true,
         min: 1,
         max: 30,
         initial: 10,
-      });
-    return {
-      level: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 1,
-        max: 20,
-        initial: 1,
       }),
-      speed: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 30,
-      }),
-      abilities: new f.SchemaField({
-        str: score(),
-        dex: score(),
-        con: score(),
-        int: score(),
-        wis: score(),
-        cha: score(),
-      }),
-      health: new f.SchemaField({
-        value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
-        max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
-      }),
-      power: new f.SchemaField({
-        value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
-        max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
-      }),
-      biography: new f.HTMLField(),
-    };
-  }
+      mod: new f.NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
+    });
 
+  return {
+    level: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 1,
+      max: 20,
+      initial: 1,
+    }),
+    speed: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 0,
+      initial: 30,
+    }),
+    abilities: new f.SchemaField({
+      str: score(),
+      dex: score(),
+      con: score(),
+      int: score(),
+      wis: score(),
+      cha: score(),
+    }),
+    health: new f.SchemaField({
+      value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
+      max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
+    }),
+    power: new f.SchemaField({
+      value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
+      max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
+    }),
+    biography: new f.HTMLField(),
+  };
+};
+
+export class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {
+  /** @override */
   prepareDerivedData() {
-    for (const [key, value] of Object.entries(this.abilities)) {
-      const score = typeof value === 'number' ? value : (value?.value ?? 10);
-      const mod = Math.floor((score - 10) / 2);
-      this.abilities[key] = { value: score, mod };
+    for (const ability of Object.values(this.abilities)) {
+      ability.mod = Math.floor((ability.value - 10) / 2);
     }
 
-    const conMod = this.abilities.con.mod;
-    this.health.max = 10 + this.level + conMod;
-
+    this.health.max = 10 + this.level + this.abilities.con.mod;
     this.armorClass = 10 + this.abilities.dex.mod;
     this.initiative = this.abilities.dex.mod;
   }

--- a/packages/cli/templates/system-js/scripts/data/gear-data.mjs
+++ b/packages/cli/templates/system-js/scripts/data/gear-data.mjs
@@ -1,37 +1,37 @@
 /**
- * GearData — typed schema for the `gear` Item type.
+ * GearData — the `gear` Item type.
  *
- * `kind` is an enum that drives the inventory pill on the character sheet:
- * `equipped` and `valued` render with the accent pill, `stowed` renders
- * muted.
+ * `kind` drives the inventory pill on the character sheet: `equipped` and
+ * `valued` render with the accent pill, `stowed` renders muted.
  */
 import { BaseTypeDataModel, fields } from '@vttforge/core';
 
-const GEAR_KINDS = /** @type {const} */ (['equipped', 'valued', 'stowed']);
+export const GEAR_KINDS = /** @type {const} */ (['equipped', 'valued', 'stowed']);
 
-export class GearData extends BaseTypeDataModel() {
-  static defineSchema() {
-    const f = fields();
-    return {
-      quantity: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 1,
-      }),
-      weight: new f.NumberField({
-        required: true,
-        nullable: false,
-        min: 0,
-        initial: 0,
-      }),
-      kind: new f.StringField({
-        required: true,
-        choices: GEAR_KINDS,
-        initial: 'stowed',
-      }),
-      description: new f.HTMLField(),
-    };
-  }
-}
+const defineGearSchema = () => {
+  const f = fields();
+  return {
+    quantity: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 0,
+      initial: 1,
+    }),
+    weight: new f.NumberField({
+      required: true,
+      nullable: false,
+      min: 0,
+      initial: 0,
+    }),
+    kind: new f.StringField({
+      required: true,
+      nullable: false,
+      choices: GEAR_KINDS,
+      initial: 'stowed',
+    }),
+    description: new f.HTMLField(),
+  };
+};
+
+export class GearData extends BaseTypeDataModel(defineGearSchema) {}

--- a/packages/cli/templates/system-js/scripts/main.mjs
+++ b/packages/cli/templates/system-js/scripts/main.mjs
@@ -1,11 +1,9 @@
 /**
  * {{TITLE}} — entry point.
  *
- * `registerSystem` from `@vttforge/core` replaces the ~60-line
- * `Hooks.once("init", ...)` block most systems copy-paste from each other:
- * data model registration, document class swap, initiative formula, sheet
- * registration, settings, and the `Hooks.once("ready", ...)` migration
- * gate are all wired by one call.
+ * One `registerSystem` call replaces the `Hooks.once("init", ...)` block most
+ * systems copy from each other: data models, initiative, sheets, settings,
+ * and the `ready`-time migration gate.
  */
 import { registerSystem, SystemConfig, VttfError } from '@vttforge/core';
 import { CharacterData } from './data/character-data.mjs';
@@ -26,6 +24,39 @@ try {
     combat: {
       initiative: { formula: '1d20 + @abilities.dex.mod', decimals: 2 },
     },
+
+    // The core sheets have to go before ours can be the default. This runs
+    // before the `sheets` below are registered.
+    onBeforeInit: () => {
+      const { Actors, Items } = foundry.documents.collections;
+      Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
+      Items.unregisterSheet('core', foundry.applications.sheets.ItemSheetV2);
+    },
+
+    // Declared here rather than with `Actors.registerSheet`. Foundry keys a
+    // sheet by `${scope}.${class name}` and saves that key on every document
+    // using it; a bundler renames classes between builds, and the saved key
+    // then names a sheet that no longer exists. The `id` is written down, so
+    // the key does not move. Pick it once and keep it.
+    sheets: [
+      {
+        id: 'character',
+        document: 'Actor',
+        sheet: CharacterSheet,
+        types: ['character'],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Character.title',
+      },
+      {
+        id: 'gear',
+        document: 'Item',
+        sheet: GearSheet,
+        types: ['gear'],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Gear.title',
+      },
+    ],
+
     onAfterInit: () => {
       settings.register('showTutorial', {
         name: '{{LOCALE_PREFIX}}.Settings.showTutorial.name',
@@ -36,24 +67,10 @@ try {
         default: true,
       });
 
-      // Register the schemaVersion setting so migrations.run() has somewhere
-      // to read and write the version flag.
+      // The schemaVersion setting `migrations.run()` reads and writes.
       migrations.register();
-
-      const { Actors, Items } = foundry.documents.collections;
-      Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
-      Actors.registerSheet(SYSTEM_ID, CharacterSheet, {
-        types: ['character'],
-        makeDefault: true,
-        label: '{{LOCALE_PREFIX}}.Sheet.Character.title',
-      });
-      Items.unregisterSheet('core', foundry.applications.sheets.ItemSheetV2);
-      Items.registerSheet(SYSTEM_ID, GearSheet, {
-        types: ['gear'],
-        makeDefault: true,
-        label: '{{LOCALE_PREFIX}}.Sheet.Gear.title',
-      });
     },
+
     onReady: async () => {
       if (!game.user?.isGM) return;
       try {

--- a/packages/cli/templates/system-js/scripts/sheets/character-sheet.mjs
+++ b/packages/cli/templates/system-js/scripts/sheets/character-sheet.mjs
@@ -1,18 +1,23 @@
 /**
- * CharacterSheet — tabbed character sheet built on `BaseActorSheet()` from
- * `@vttforge/core`. Demonstrates the full boilerplate-elimination surface:
+ * CharacterSheet — tabbed character sheet on `BaseActorSheet()`.
  *
- * - `static TABS` — `context.tabs.<group>` auto-populated by BaseActorSheet
- *   (no manual `_prepareTabs` call).
- * - `static DRAG_DROP` — wires `foundry.applications.ux.DragDrop` on first
- *   render with `isEditable`-gated permissions.
- * - Typed `onDropItem(item, event)` — pre-resolves UUIDs, rejects
- *   non-`gear` items with a notification, lets `gear` flow through to
- *   Foundry's default `_onDropItem` by returning `undefined`.
+ * - `static TABS` — `context.tabs.<group>` is filled in for you.
+ * - `static DRAG_DROP` — drag-drop wired on render, gated on `isEditable`.
+ * - `onDropItem(item, event)` — the item arrives resolved, not as a UUID.
+ *   Return `false` to refuse, `undefined` to hand the drop back to Foundry.
  */
 import { BaseActorSheet } from '@vttforge/core';
 
 const SYSTEM_ID = '{{ID}}';
+
+const ABILITY_LABELS = {
+  str: '{{LOCALE_PREFIX}}.Ability.str',
+  dex: '{{LOCALE_PREFIX}}.Ability.dex',
+  con: '{{LOCALE_PREFIX}}.Ability.con',
+  int: '{{LOCALE_PREFIX}}.Ability.int',
+  wis: '{{LOCALE_PREFIX}}.Ability.wis',
+  cha: '{{LOCALE_PREFIX}}.Ability.cha',
+};
 
 export class CharacterSheet extends BaseActorSheet() {
   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
@@ -35,9 +40,7 @@ export class CharacterSheet extends BaseActorSheet() {
   );
 
   static PARTS = {
-    sheet: {
-      template: `systems/${SYSTEM_ID}/templates/actor/character-sheet.hbs`,
-    },
+    sheet: { template: `systems/${SYSTEM_ID}/templates/actor/character-sheet.hbs` },
   };
 
   static TABS = {
@@ -72,34 +75,31 @@ export class CharacterSheet extends BaseActorSheet() {
     },
   };
 
-  static DRAG_DROP = [
-    {
-      dragSelector: '.sh-item[draggable=true]',
-      dropSelector: '.sh-body',
-    },
-  ];
+  static DRAG_DROP = [{ dragSelector: '.sh-item[draggable=true]', dropSelector: '.sh-body' }];
+
+  /**
+   * The actor this sheet is for. One place to read `this.document` from, so
+   * the rest of the sheet says `this.actor` and means it.
+   * @returns {any}
+   */
+  get actor() {
+    return this.document;
+  }
 
   /** @override */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    const actor = this.document;
-    const system = actor.system;
-    const abilityLabels = {
-      str: '{{LOCALE_PREFIX}}.Ability.str',
-      dex: '{{LOCALE_PREFIX}}.Ability.dex',
-      con: '{{LOCALE_PREFIX}}.Ability.con',
-      int: '{{LOCALE_PREFIX}}.Ability.int',
-      wis: '{{LOCALE_PREFIX}}.Ability.wis',
-      cha: '{{LOCALE_PREFIX}}.Ability.cha',
-    };
+    const { actor } = this;
+    const { system } = actor;
+
     context.actor = actor;
     context.system = system;
     context.isEditable = this.isEditable;
-    context.abilities = Object.entries(system.abilities ?? {}).map(([key, data]) => ({
+    context.abilities = Object.entries(system.abilities).map(([key, ability]) => ({
       key,
-      label: game.i18n.localize(abilityLabels[key] ?? key),
-      value: data?.value ?? data,
-      mod: data?.mod ?? 0,
+      label: game.i18n.localize(ABILITY_LABELS[key] ?? key),
+      value: ability.value,
+      mod: ability.mod,
     }));
     context.gear = actor.items
       .filter((item) => item.type === 'gear')
@@ -107,19 +107,19 @@ export class CharacterSheet extends BaseActorSheet() {
         id: item.id,
         name: item.name,
         img: item.img,
-        kind: item.system?.kind ?? 'stowed',
-        quantity: item.system?.quantity ?? 1,
-        weight: item.system?.weight ?? 0,
-        description: item.system?.description ?? '',
+        kind: item.system.kind,
+        quantity: item.system.quantity,
+        weight: item.system.weight,
+        description: item.system.description,
       }));
     context.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-      system.biography ?? '',
+      system.biography,
       { relativeTo: actor, secrets: actor.isOwner },
     );
     return context;
   }
 
-  /** Reject non-gear drops with a notification; let gear fall through. */
+  /** Only gear belongs in this inventory. Anything else is refused with a reason. */
   async onDropItem(item, _event) {
     if (item?.type !== 'gear') {
       ui.notifications?.warn(
@@ -130,11 +130,14 @@ export class CharacterSheet extends BaseActorSheet() {
     return undefined;
   }
 
+  // ApplicationV2 declares action handlers static and calls them with `this`
+  // bound to the sheet instance.
+
   static async _onRollAbility(_event, target) {
-    const key = target?.dataset?.ability;
+    const key = target.dataset.ability;
     if (!key) return;
-    const actor = this.document;
-    const mod = actor.system.abilities?.[key]?.mod ?? 0;
+    const { actor } = this;
+    const mod = actor.system.abilities[key]?.mod ?? 0;
     const roll = new Roll(`1d20 + ${mod}`, actor.getRollData());
     await roll.evaluate();
     await roll.toMessage({
@@ -145,20 +148,16 @@ export class CharacterSheet extends BaseActorSheet() {
     });
   }
 
-  static async _onCreateGear(_event, _target) {
-    const cls = CONFIG.Item.documentClass;
-    const parent = this.document;
-    await cls.create(
+  static async _onCreateGear() {
+    await CONFIG.Item.documentClass.create(
       { name: game.i18n.localize('{{LOCALE_PREFIX}}.Sheet.NewGearName'), type: 'gear' },
-      { parent, renderSheet: true },
+      { parent: this.actor, renderSheet: true },
     );
   }
 
   static async _onDeleteItem(_event, target) {
-    const row = target?.closest('[data-item-id]');
-    const id = row?.dataset?.itemId;
+    const id = target.closest('[data-item-id]')?.dataset.itemId;
     if (!id) return;
-    const item = this.document.items.get(id);
-    await item?.delete();
+    await this.actor.items.get(id)?.delete();
   }
 }

--- a/packages/cli/templates/system-js/scripts/sheets/gear-sheet.mjs
+++ b/packages/cli/templates/system-js/scripts/sheets/gear-sheet.mjs
@@ -1,7 +1,7 @@
 /**
- * GearSheet — minimal Item sheet built on `BaseItemSheet()` from
- * `@vttforge/core`. Single PART, single TABS group, no DRAG_DROP — exercises
- * the mirror surface of BaseActorSheet on ItemSheetV2.
+ * GearSheet — the `gear` Item sheet on `BaseItemSheet()`.
+ *
+ * Single part, one tab group, no drag-drop: the smallest useful sheet.
  */
 import { BaseItemSheet } from '@vttforge/core';
 
@@ -23,9 +23,7 @@ export class GearSheet extends BaseItemSheet() {
   );
 
   static PARTS = {
-    sheet: {
-      template: `systems/${SYSTEM_ID}/templates/item/gear-sheet.hbs`,
-    },
+    sheet: { template: `systems/${SYSTEM_ID}/templates/item/gear-sheet.hbs` },
   };
 
   static TABS = {
@@ -48,18 +46,22 @@ export class GearSheet extends BaseItemSheet() {
     },
   };
 
+  /** @returns {any} */
+  get item() {
+    return this.document;
+  }
+
   /** @override */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    const item = this.document;
+    const { item } = this;
     context.item = item;
     context.system = item.system;
     context.isEditable = this.isEditable;
-    context.enrichedDescription =
-      await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-        item.system?.description ?? '',
-        { relativeTo: item, secrets: item.isOwner },
-      );
+    context.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      item.system.description,
+      { relativeTo: item, secrets: item.isOwner },
+    );
     return context;
   }
 }

--- a/packages/cli/templates/system-js/templates/actor/character-sheet.hbs
+++ b/packages/cli/templates/system-js/templates/actor/character-sheet.hbs
@@ -76,7 +76,7 @@
           <div class="sh-abil">
             <div class="lbl" title="{{ability.label}}">{{ability.key}}</div>
             <input class="val" type="number"
-                   name="system.abilities.{{ability.key}}"
+                   name="system.abilities.{{ability.key}}.value"
                    value="{{ability.value}}" min="1" max="30" />
             <button type="button" class="mod sh-abil-roll"
                     data-action="rollAbility" data-ability="{{ability.key}}"

--- a/packages/cli/templates/system-ts/README.md
+++ b/packages/cli/templates/system-ts/README.md
@@ -2,55 +2,73 @@
 
 {{DESCRIPTION}}
 
-Built on [VTTForge](https://github.com/vttforge/vttforge) — typed data models, declarative sheet boilerplate, migration runner, error catalogue, and a Vite-based build pipeline.
-
-> **Note** — VTTForge is currently in pre-release and not yet published to npm. The dependencies in `package.json` (`@vttforge/core`, `@vttforge/styles`, `@vttforge/vite-plugin`) will resolve once VTTForge ships its first public release. Until then, work from a local checkout: `pnpm link --global` from each VTTForge package, then `pnpm link --global @vttforge/core @vttforge/styles @vttforge/vite-plugin` here.
+A Foundry VTT v13+ system built on [VTTForge](https://vttforge.dev): typed
+data models, sheet bases that already know their tabs and drops, a migration
+runner, and a build that produces what foundryvtt.com expects.
 
 ## Quick start
 
 ```bash
 pnpm install
-pnpm dev      # vite build --watch + auto-symlinks dist/ into Foundry's Data
-pnpm build    # one-shot build + emits {{ID}}-<version>.zip for foundryvtt.com
+pnpm dev      # build, link dist/ into Foundry's data dir, watch
+pnpm build    # dist/ plus {{ID}}-<version>.zip
 ```
 
-`pnpm dev` (`vttforge dev` under the hood) auto-detects your Foundry user-data
-directory on the first run, prompts you to confirm it, and saves the choice to
-`.vttforge/config.json` for next time. Override with `--data-dir <path>` or set
-`FOUNDRY_DATA_DIR` in your environment.
+`pnpm dev` asks where Foundry keeps its data on the first run and remembers
+the answer in `.vttforge/config.json`. Override with `--foundry-data <path>`
+or `FOUNDRY_DATA_DIR`. If Foundry runs in a container it cannot follow the
+symlink, and the command prints the compose mount to use instead.
 
-Run Foundry with `--hotReload` so saved files reload the world without a page
-refresh — `dev` watches `dist/` for changes, and Foundry's built-in dispatcher
-swaps CSS / Handlebars / JSON on the fly.
+Save a template and the open sheet redraws in place; save a stylesheet and the
+CSS swaps. Enable **VTTForge Dev** in the world once — `pnpm dev` links it in.
 
-Then launch Foundry, create a world that uses **{{TITLE}}**, and open a character — the sheet is the `CharacterSheet` shipped in `scripts/sheets/`.
+Then create a world on **{{TITLE}}** and open a character.
 
 ## What's inside
 
 | Path | Purpose |
 |---|---|
-| `system.json` | Manifest (id, compatibility, document types, manifest-side sanitization paths) |
-| `template.json` | Foundry document type declarations (Actor + Item subtypes) |
-| `scripts/main.ts` | Entry point — one call to `registerSystem` from `@vttforge/core` |
-| `scripts/data/*.ts` | Typed data models (`BaseTypeDataModel()` from `@vttforge/core`) |
-| `scripts/sheets/*.ts` | Sheet boilerplate eliminators (`BaseActorSheet()` / `BaseItemSheet()`) |
-| `scripts/migrations.ts` | `createMigrationRunner()` — versioned data migrations |
-| `templates/` | Handlebars templates for sheets |
-| `styles/main.css` | Stylesheet — imports `@vttforge/styles` as the design system base |
-| `lang/en.json` | Localization strings |
+| `system.json` | Manifest — types, `htmlFields`, hot-reload paths, migration flags |
+| `template.json` | The type names Foundry expects to see declared |
+| `scripts/main.ts` | One `registerSystem` call: models, sheets, initiative, settings, migrations |
+| `scripts/data/*.ts` | Data models. The schema is a function handed to `BaseTypeDataModel`, which is what makes `this.level` a `number` |
+| `scripts/sheets/*.ts` | Sheets on `BaseActorSheet` / `BaseItemSheet` — `static TABS`, `static DRAG_DROP`, typed `onDropItem` |
+| `scripts/migrations.ts` | `createMigrationRunner` — versioned, idempotent, GM-gated |
+| `templates/` | Handlebars, using v13's own elements (`<prose-mirror>`, `data-action`) |
+| `styles/main.css` | Imports `@vttforge/styles` and scopes your rules under `.{{ID}}` |
+| `lang/en.json` | Strings, under the `{{LOCALE_PREFIX}}` prefix |
 
-## Releasing to Foundry
+## Two things worth knowing before you edit
 
-Tag-push triggers `.github/workflows/release.yml`, which builds the system, zips `dist/`, and attaches both `{{ID}}-<version>.zip` and `dist/system.json` to a GitHub Release.
+**Sheets are registered by id, not by class name.** `registerSystem({ sheets })`
+pins each sheet under `{{ID}}.<id>`. Foundry saves that key on every actor
+whose owner picked the sheet, and derives it from the class name unless told
+otherwise — which a bundler renames between builds. Keep the ids; renaming one
+loses the sheet choice on every document already using it.
+
+**`this.document` is `unknown` on the sheet bases.** Which document a sheet is
+for is yours to know. Each sheet here narrows it once in a getter (`actor`,
+`item`) and everything below reads typed.
+
+## Checks
+
+```bash
+pnpm typecheck        # tsc against the real @vttforge/core types
+npx vttforge audit    # manifest + source against the v13 list of quiet breakages
+```
+
+## Releasing
+
+Push a tag and `.github/workflows/release.yml` builds, zips, and attaches
+`{{ID}}-<version>.zip` plus `system.json` to a GitHub Release:
 
 ```bash
 git tag v0.1.0
 git push --tags
 ```
 
-Foundry installs from the `system.json` URL on the Release — point users at the `latest/download/system.json` URL in the release notes so they auto-update on every tag.
-
-For foundryvtt.com submissions, submit the same manifest URL pattern.
+Point Foundry — and foundryvtt.com — at the release's
+`latest/download/system.json`, so installs auto-update on every tag.
 
 ## License
 

--- a/packages/cli/templates/system-ts/scripts/data/character-data.ts
+++ b/packages/cli/templates/system-ts/scripts/data/character-data.ts
@@ -1,81 +1,97 @@
 /**
- * CharacterData — typed schema for the `character` Actor type.
+ * CharacterData — the `character` Actor type.
  *
- * Quick stats are HP / AC / SPD / INIT, abilities are the six classic
- * scores (str/dex/con/int/wis/cha). Derived state (modifiers, max HP,
- * armor class, initiative) is computed in-memory in `prepareDerivedData`.
- *
- * `prepareBaseData` initialises fields that Active Effects need to mutate
- * (base max HP before any AE bonus); `prepareDerivedData` then computes
- * the AE-aware values (modifiers, percentages, totals). Never write to the
- * database in either hook — they're purely in-memory derivations.
+ * Quick stats are HP / AC / SPD / INIT; abilities are the six classic scores.
+ * Derived state (modifiers, max HP, armour class, initiative) is computed in
+ * memory in `prepareDerivedData`. Never write to the database from there.
  */
 import { BaseTypeDataModel, fields } from '@vttforge/core';
 
-export class CharacterData extends BaseTypeDataModel() {
-  static defineSchema() {
-    const f = fields();
-    // The six ability scores are written once, as a factory rather than a
-    // shared options object: a field keeps the options it was handed, and
-    // some field classes write back into them.
-    const score = () =>
-      new f.NumberField({
+/**
+ * The schema, as a function handed to the factory.
+ *
+ * Both this and a `static defineSchema()` on the class work at runtime. Only
+ * this form is typed: pass it in and `this.level` is a `number` inside
+ * `prepareDerivedData`, while the no-argument form leaves every field unknown.
+ *
+ * It has to be a function rather than an object because `fields()` reads a
+ * Foundry global that does not exist when this module is first evaluated.
+ */
+const defineCharacterSchema = () => {
+  const f = fields();
+
+  // One ability. `value` is stored and is what the sheet's input writes to
+  // (`name="system.abilities.str.value"`). `mod` is derived on every data
+  // preparation and lives in the schema only so it has a typed home — see
+  // the note on `armorClass` below for the alternative.
+  const score = () =>
+    new f.SchemaField({
+      value: new f.NumberField({
         required: true,
         nullable: false,
         integer: true,
         min: 1,
         max: 30,
         initial: 10,
-      });
-    return {
-      level: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 1,
-        max: 20,
-        initial: 1,
       }),
-      speed: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 30,
-      }),
-      abilities: new f.SchemaField({
-        str: score(),
-        dex: score(),
-        con: score(),
-        int: score(),
-        wis: score(),
-        cha: score(),
-      }),
-      health: new f.SchemaField({
-        value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
-        max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
-      }),
-      power: new f.SchemaField({
-        value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
-        max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
-      }),
-      biography: new f.HTMLField(),
-    };
-  }
+      mod: new f.NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
+    });
 
-  prepareDerivedData() {
-    // biome-ignore lint/suspicious/noExplicitAny: schema-driven types ship in a later @vttforge/types release
-    const self = this as any;
-    for (const [key, value] of Object.entries(self.abilities)) {
-      const score = typeof value === 'number' ? value : ((value as { value?: number })?.value ?? 10);
-      const mod = Math.floor((score - 10) / 2);
-      self.abilities[key] = { value: score, mod };
+  return {
+    level: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 1,
+      max: 20,
+      initial: 1,
+    }),
+    speed: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 0,
+      initial: 30,
+    }),
+    abilities: new f.SchemaField({
+      str: score(),
+      dex: score(),
+      con: score(),
+      int: score(),
+      wis: score(),
+      cha: score(),
+    }),
+    health: new f.SchemaField({
+      value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
+      max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
+    }),
+    power: new f.SchemaField({
+      value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
+      max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
+    }),
+    biography: new f.HTMLField(),
+  };
+};
+
+export class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {
+  /**
+   * Derived, so declared rather than put in the schema. `declare` tells
+   * TypeScript the property exists after `prepareDerivedData` without
+   * emitting a class field that would shadow what Foundry prepares.
+   */
+  declare armorClass: number;
+  declare initiative: number;
+
+  override prepareDerivedData(): void {
+    for (const ability of Object.values(this.abilities)) {
+      ability.mod = Math.floor((ability.value - 10) / 2);
     }
 
-    const conMod = self.abilities.con.mod;
-    self.health.max = 10 + self.level + conMod;
-
-    self.armorClass = 10 + self.abilities.dex.mod;
-    self.initiative = self.abilities.dex.mod;
+    this.health.max = 10 + this.level + this.abilities.con.mod;
+    this.armorClass = 10 + this.abilities.dex.mod;
+    this.initiative = this.abilities.dex.mod;
   }
 }
+
+/** The shape of `actor.system` for a character, derived from the schema. */
+export type CharacterSystem = CharacterData['$inferData'];

--- a/packages/cli/templates/system-ts/scripts/data/gear-data.ts
+++ b/packages/cli/templates/system-ts/scripts/data/gear-data.ts
@@ -1,37 +1,41 @@
 /**
- * GearData — typed schema for the `gear` Item type.
+ * GearData — the `gear` Item type.
  *
- * `kind` is an enum that drives the inventory pill on the character sheet:
- * `equipped` and `valued` render with the accent pill, `stowed` renders
- * muted.
+ * `kind` drives the inventory pill on the character sheet: `equipped` and
+ * `valued` render with the accent pill, `stowed` renders muted.
  */
 import { BaseTypeDataModel, fields } from '@vttforge/core';
 
-const GEAR_KINDS = ['equipped', 'valued', 'stowed'] as const;
+export const GEAR_KINDS = ['equipped', 'valued', 'stowed'] as const;
+export type GearKind = (typeof GEAR_KINDS)[number];
 
-export class GearData extends BaseTypeDataModel() {
-  static defineSchema() {
-    const f = fields();
-    return {
-      quantity: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 1,
-      }),
-      weight: new f.NumberField({
-        required: true,
-        nullable: false,
-        min: 0,
-        initial: 0,
-      }),
-      kind: new f.StringField({
-        required: true,
-        choices: GEAR_KINDS as unknown as string[],
-        initial: 'stowed',
-      }),
-      description: new f.HTMLField(),
-    };
-  }
-}
+const defineGearSchema = () => {
+  const f = fields();
+  return {
+    quantity: new f.NumberField({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 0,
+      initial: 1,
+    }),
+    weight: new f.NumberField({
+      required: true,
+      nullable: false,
+      min: 0,
+      initial: 0,
+    }),
+    kind: new f.StringField({
+      required: true,
+      nullable: false,
+      choices: GEAR_KINDS,
+      initial: 'stowed',
+    }),
+    description: new f.HTMLField(),
+  };
+};
+
+export class GearData extends BaseTypeDataModel(defineGearSchema) {}
+
+/** The shape of `item.system` for gear, derived from the schema. */
+export type GearSystem = GearData['$inferData'];

--- a/packages/cli/templates/system-ts/scripts/main.ts
+++ b/packages/cli/templates/system-ts/scripts/main.ts
@@ -1,11 +1,9 @@
 /**
  * {{TITLE}} — entry point.
  *
- * `registerSystem` from `@vttforge/core` replaces the ~60-line
- * `Hooks.once("init", ...)` block most systems copy-paste from each other:
- * data model registration, document class swap, initiative formula, sheet
- * registration, settings, and the `Hooks.once("ready", ...)` migration
- * gate are all wired by one call.
+ * One `registerSystem` call replaces the `Hooks.once("init", ...)` block most
+ * systems copy from each other: data models, initiative, sheets, settings,
+ * and the `ready`-time migration gate.
  */
 import './foundry-globals.js';
 import { registerSystem, SystemConfig, VttfError } from '@vttforge/core';
@@ -27,6 +25,39 @@ try {
     combat: {
       initiative: { formula: '1d20 + @abilities.dex.mod', decimals: 2 },
     },
+
+    // The core sheets have to go before ours can be the default. This runs
+    // before the `sheets` below are registered.
+    onBeforeInit: () => {
+      const { Actors, Items } = foundry.documents.collections;
+      Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
+      Items.unregisterSheet('core', foundry.applications.sheets.ItemSheetV2);
+    },
+
+    // Declared here rather than with `Actors.registerSheet`. Foundry keys a
+    // sheet by `${scope}.${class name}` and saves that key on every document
+    // using it; a bundler renames classes between builds, and the saved key
+    // then names a sheet that no longer exists. The `id` is written down, so
+    // the key does not move. Pick it once and keep it.
+    sheets: [
+      {
+        id: 'character',
+        document: 'Actor',
+        sheet: CharacterSheet,
+        types: ['character'],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Character.title',
+      },
+      {
+        id: 'gear',
+        document: 'Item',
+        sheet: GearSheet,
+        types: ['gear'],
+        makeDefault: true,
+        label: '{{LOCALE_PREFIX}}.Sheet.Gear.title',
+      },
+    ],
+
     onAfterInit: () => {
       settings.register('showTutorial', {
         name: '{{LOCALE_PREFIX}}.Settings.showTutorial.name',
@@ -37,24 +68,10 @@ try {
         default: true,
       });
 
-      // Register the schemaVersion setting so migrations.run() has somewhere
-      // to read and write the version flag.
+      // The schemaVersion setting `migrations.run()` reads and writes.
       migrations.register();
-
-      const { Actors, Items } = foundry.documents.collections;
-      Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
-      Actors.registerSheet(SYSTEM_ID, CharacterSheet, {
-        types: ['character'],
-        makeDefault: true,
-        label: '{{LOCALE_PREFIX}}.Sheet.Character.title',
-      });
-      Items.unregisterSheet('core', foundry.applications.sheets.ItemSheetV2);
-      Items.registerSheet(SYSTEM_ID, GearSheet, {
-        types: ['gear'],
-        makeDefault: true,
-        label: '{{LOCALE_PREFIX}}.Sheet.Gear.title',
-      });
     },
+
     onReady: async () => {
       if (!game.user?.isGM) return;
       try {

--- a/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
@@ -1,18 +1,44 @@
 /**
- * CharacterSheet — tabbed character sheet built on `BaseActorSheet()` from
- * `@vttforge/core`. Demonstrates the full boilerplate-elimination surface:
+ * CharacterSheet — tabbed character sheet on `BaseActorSheet()`.
  *
- * - `static TABS` — `context.tabs.<group>` auto-populated by BaseActorSheet
- *   (no manual `_prepareTabs` call).
- * - `static DRAG_DROP` — wires `foundry.applications.ux.DragDrop` on first
- *   render with `isEditable`-gated permissions.
- * - Typed `onDropItem(item, event)` — pre-resolves UUIDs, rejects
- *   non-`gear` items with a notification, lets `gear` flow through to
- *   Foundry's default `_onDropItem` by returning `undefined`.
+ * - `static TABS` — `context.tabs.<group>` is filled in for you.
+ * - `static DRAG_DROP` — drag-drop wired on render, gated on `isEditable`.
+ * - `onDropItem(item, event)` — the item arrives resolved, not as a UUID.
+ *   Return `false` to refuse, `undefined` to hand the drop back to Foundry.
  */
 import { BaseActorSheet } from '@vttforge/core';
+import type { CharacterData } from '../data/character-data.js';
+import type { GearData } from '../data/gear-data.js';
 
 const SYSTEM_ID = '{{ID}}';
+
+/**
+ * What this sheet reads off its actor.
+ *
+ * Foundry's own `Actor` type is not wired in — see `foundry-globals.ts` — so
+ * the sheet says what it needs. Grow this as the sheet grows; it is the one
+ * place to change when a real type package lands.
+ */
+interface CharacterActor {
+  readonly name: string;
+  readonly img: string;
+  readonly isOwner: boolean;
+  readonly system: CharacterData;
+  readonly items: {
+    filter(fn: (item: GearItem) => boolean): GearItem[];
+    get(id: string): GearItem | undefined;
+  };
+  getRollData(): Record<string, unknown>;
+}
+
+interface GearItem {
+  readonly id: string;
+  readonly name: string;
+  readonly img: string;
+  readonly type: string;
+  readonly system: GearData;
+  delete(): Promise<unknown>;
+}
 
 interface AbilityViewModel {
   key: string;
@@ -21,22 +47,18 @@ interface AbilityViewModel {
   mod: number;
 }
 
-interface GearViewModel {
-  id: string;
-  name: string;
-  img: string;
-  kind: string;
-  quantity: number;
-  weight: number;
-  description: string;
-}
+const ABILITY_LABELS: Record<string, string> = {
+  str: '{{LOCALE_PREFIX}}.Ability.str',
+  dex: '{{LOCALE_PREFIX}}.Ability.dex',
+  con: '{{LOCALE_PREFIX}}.Ability.con',
+  int: '{{LOCALE_PREFIX}}.Ability.int',
+  wis: '{{LOCALE_PREFIX}}.Ability.wis',
+  cha: '{{LOCALE_PREFIX}}.Ability.cha',
+};
 
-// biome-ignore lint/suspicious/noExplicitAny: typed sheet bases ship in a later @vttforge/types release
-const Base = BaseActorSheet() as any;
-
-export class CharacterSheet extends Base {
-  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-    Base.DEFAULT_OPTIONS,
+export class CharacterSheet extends BaseActorSheet() {
+  static override DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    super.DEFAULT_OPTIONS,
     {
       id: '{{ID}}-character',
       classes: ['{{ID}}', 'sheet', 'actor', 'character'],
@@ -55,9 +77,7 @@ export class CharacterSheet extends Base {
   );
 
   static PARTS = {
-    sheet: {
-      template: `systems/${SYSTEM_ID}/templates/actor/character-sheet.hbs`,
-    },
+    sheet: { template: `systems/${SYSTEM_ID}/templates/actor/character-sheet.hbs` },
   };
 
   static TABS = {
@@ -92,85 +112,72 @@ export class CharacterSheet extends Base {
     },
   };
 
-  static DRAG_DROP = [
-    {
-      dragSelector: '.sh-item[draggable=true]',
-      dropSelector: '.sh-body',
-    },
-  ];
+  static override DRAG_DROP = [{ dragSelector: '.sh-item[draggable=true]', dropSelector: '.sh-body' }];
 
-  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
-  async _prepareContext(options: any) {
+  /**
+   * The actor this sheet is for.
+   *
+   * `this.document` is `unknown` on the base — which document a sheet is for
+   * is the system's to know. One cast, here, and everything below is typed.
+   */
+  get actor(): CharacterActor {
+    return this.document as CharacterActor;
+  }
+
+  override async _prepareContext(options: unknown): Promise<Record<string, unknown>> {
     const context = await super._prepareContext(options);
-    const actor = (this as unknown as { document: any }).document;
-    const system = actor.system;
-    const abilityLabels: Record<string, string> = {
-      str: '{{LOCALE_PREFIX}}.Ability.str',
-      dex: '{{LOCALE_PREFIX}}.Ability.dex',
-      con: '{{LOCALE_PREFIX}}.Ability.con',
-      int: '{{LOCALE_PREFIX}}.Ability.int',
-      wis: '{{LOCALE_PREFIX}}.Ability.wis',
-      cha: '{{LOCALE_PREFIX}}.Ability.cha',
-    };
+    const { actor } = this;
+    const { system } = actor;
+
     context.actor = actor;
     context.system = system;
-    context.isEditable = (this as unknown as { isEditable: boolean }).isEditable;
-    context.abilities = Object.entries(system.abilities ?? {}).map(
-      ([key, data]): AbilityViewModel => {
-        const ability = data as { value?: number; mod?: number } | number;
-        const value = typeof ability === 'number' ? ability : (ability?.value ?? 10);
-        const mod = typeof ability === 'number' ? 0 : (ability?.mod ?? 0);
-        return {
-          key,
-          label: game.i18n.localize(abilityLabels[key] ?? key),
-          value,
-          mod,
-        };
-      },
+    context.isEditable = this.isEditable;
+    context.abilities = Object.entries(system.abilities).map(
+      ([key, ability]): AbilityViewModel => ({
+        key,
+        label: game.i18n.localize(ABILITY_LABELS[key] ?? key),
+        value: ability.value,
+        mod: ability.mod,
+      }),
     );
     context.gear = actor.items
-      .filter((item: { type: string }) => item.type === 'gear')
-      .map(
-        (item: {
-          id: string;
-          name: string;
-          img: string;
-          system?: { kind?: string; quantity?: number; weight?: number; description?: string };
-        }): GearViewModel => ({
-          id: item.id,
-          name: item.name,
-          img: item.img,
-          kind: item.system?.kind ?? 'stowed',
-          quantity: item.system?.quantity ?? 1,
-          weight: item.system?.weight ?? 0,
-          description: item.system?.description ?? '',
-        }),
-      );
+      .filter((item) => item.type === 'gear')
+      .map((item) => ({
+        id: item.id,
+        name: item.name,
+        img: item.img,
+        kind: item.system.kind,
+        quantity: item.system.quantity,
+        weight: item.system.weight,
+        description: item.system.description,
+      }));
     context.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-      system.biography ?? '',
+      system.biography,
       { relativeTo: actor, secrets: actor.isOwner },
     );
     return context;
   }
 
-  /** Reject non-gear drops with a notification; let gear fall through. */
-  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
-  async onDropItem(item: any, _event: unknown): Promise<false | undefined> {
-    if (item?.type !== 'gear') {
+  /** Only gear belongs in this inventory. Anything else is refused with a reason. */
+  override async onDropItem(item: unknown, _event: DragEvent): Promise<false | undefined> {
+    const type = (item as { type?: string } | null)?.type;
+    if (type !== 'gear') {
       ui.notifications?.warn(
-        game.i18n.format('{{LOCALE_PREFIX}}.Sheet.Drop.rejected', { type: item?.type ?? 'unknown' }),
+        game.i18n.format('{{LOCALE_PREFIX}}.Sheet.Drop.rejected', { type: type ?? 'unknown' }),
       );
       return false;
     }
     return undefined;
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
-  static async _onRollAbility(this: any, _event: Event, target: HTMLElement) {
-    const key = target?.dataset?.ability;
+  // ApplicationV2 declares action handlers static and calls them with `this`
+  // bound to the sheet instance. `this: CharacterSheet` says so to TypeScript.
+
+  static async _onRollAbility(this: CharacterSheet, _event: Event, target: HTMLElement): Promise<void> {
+    const key = target.dataset.ability;
     if (!key) return;
-    const actor = this.document;
-    const mod = actor.system.abilities?.[key]?.mod ?? 0;
+    const { actor } = this;
+    const mod = actor.system.abilities[key as keyof CharacterData['abilities']]?.mod ?? 0;
     const roll = new Roll(`1d20 + ${mod}`, actor.getRollData());
     await roll.evaluate();
     await roll.toMessage({
@@ -181,22 +188,16 @@ export class CharacterSheet extends Base {
     });
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
-  static async _onCreateGear(this: any, _event: Event, _target: HTMLElement) {
-    const cls = CONFIG.Item.documentClass;
-    const parent = this.document;
-    await cls.create(
+  static async _onCreateGear(this: CharacterSheet): Promise<void> {
+    await CONFIG.Item.documentClass.create(
       { name: game.i18n.localize('{{LOCALE_PREFIX}}.Sheet.NewGearName'), type: 'gear' },
-      { parent, renderSheet: true },
+      { parent: this.actor, renderSheet: true },
     );
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
-  static async _onDeleteItem(this: any, _event: Event, target: HTMLElement) {
-    const row = target?.closest('[data-item-id]') as HTMLElement | null;
-    const id = row?.dataset?.itemId;
+  static async _onDeleteItem(this: CharacterSheet, _event: Event, target: HTMLElement): Promise<void> {
+    const id = target.closest<HTMLElement>('[data-item-id]')?.dataset.itemId;
     if (!id) return;
-    const item = this.document.items.get(id);
-    await item?.delete();
+    await this.actor.items.get(id)?.delete();
   }
 }

--- a/packages/cli/templates/system-ts/scripts/sheets/gear-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/gear-sheet.ts
@@ -1,18 +1,24 @@
 /**
- * GearSheet — minimal Item sheet built on `BaseItemSheet()` from
- * `@vttforge/core`. Single PART, single TABS group, no DRAG_DROP — exercises
- * the mirror surface of BaseActorSheet on ItemSheetV2.
+ * GearSheet — the `gear` Item sheet on `BaseItemSheet()`.
+ *
+ * Single part, one tab group, no drag-drop: the smallest useful sheet.
  */
 import { BaseItemSheet } from '@vttforge/core';
+import type { GearData } from '../data/gear-data.js';
 
 const SYSTEM_ID = '{{ID}}';
 
-// biome-ignore lint/suspicious/noExplicitAny: typed sheet bases ship in a later @vttforge/types release
-const Base = BaseItemSheet() as any;
+/** What this sheet reads off its item. See `CharacterSheet` for the pattern. */
+interface GearItem {
+  readonly name: string;
+  readonly img: string;
+  readonly isOwner: boolean;
+  readonly system: GearData;
+}
 
-export class GearSheet extends Base {
-  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-    Base.DEFAULT_OPTIONS,
+export class GearSheet extends BaseItemSheet() {
+  static override DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    super.DEFAULT_OPTIONS,
     {
       id: '{{ID}}-gear',
       classes: ['{{ID}}', 'sheet', 'item', 'gear'],
@@ -26,9 +32,7 @@ export class GearSheet extends Base {
   );
 
   static PARTS = {
-    sheet: {
-      template: `systems/${SYSTEM_ID}/templates/item/gear-sheet.hbs`,
-    },
+    sheet: { template: `systems/${SYSTEM_ID}/templates/item/gear-sheet.hbs` },
   };
 
   static TABS = {
@@ -51,18 +55,20 @@ export class GearSheet extends Base {
     },
   };
 
-  // biome-ignore lint/suspicious/noExplicitAny: see @vttforge/types follow-up
-  async _prepareContext(options: any) {
+  get item(): GearItem {
+    return this.document as GearItem;
+  }
+
+  override async _prepareContext(options: unknown): Promise<Record<string, unknown>> {
     const context = await super._prepareContext(options);
-    const item = (this as unknown as { document: any }).document;
+    const { item } = this;
     context.item = item;
     context.system = item.system;
-    context.isEditable = (this as unknown as { isEditable: boolean }).isEditable;
-    context.enrichedDescription =
-      await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-        item.system?.description ?? '',
-        { relativeTo: item, secrets: item.isOwner },
-      );
+    context.isEditable = this.isEditable;
+    context.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      item.system.description,
+      { relativeTo: item, secrets: item.isOwner },
+    );
     return context;
   }
 }

--- a/packages/cli/templates/system-ts/templates/actor/character-sheet.hbs
+++ b/packages/cli/templates/system-ts/templates/actor/character-sheet.hbs
@@ -76,7 +76,7 @@
           <div class="sh-abil">
             <div class="lbl" title="{{ability.label}}">{{ability.key}}</div>
             <input class="val" type="number"
-                   name="system.abilities.{{ability.key}}"
+                   name="system.abilities.{{ability.key}}.value"
                    value="{{ability.value}}" min="1" max="30" />
             <button type="button" class="mod sh-abil-roll"
                     data-action="rollAbility" data-ability="{{ability.key}}"

--- a/packages/cli/templates/system-ts/tsconfig.json
+++ b/packages/cli/templates/system-ts/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noImplicitOverride": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,


### PR DESCRIPTION
## What

The four `vttforge init` templates contradicted the SDK from the first file: `as any` on the sheet bases, `Actors.registerSheet` by hand, untyped data models, and module templates that never called `registerModule`. This rewrites them.

- **system-ts / system-js** — data models on the typed `BaseTypeDataModel(defineSchema)` factory; sheets declared in `registerSystem({ sheets })` with stable ids; each sheet narrows `this.document` once in an `actor` / `item` getter; `noImplicitOverride` on in the TS tsconfig.
- **module-ts / module-js** — built on `registerModule`: a `note` Item sub-type declared under `documentTypes` and keyed with `moduleSubType`, a sheet on `BaseItemSheet`, an `@Note[id]` enricher with `onRender`, a setting, and a public API.
- READMEs no longer say the packages are unpublished.

## Audit fix

Rules VTTF-AUDIT-004 and VTTF-AUDIT-007 looked for a field's owning class by enclosing braces, so a schema in a named factory (`class X extends BaseTypeDataModel(defineSchema)`) was unowned. Rule 007 then flagged the system template for token attributes its schema declares. Both rules now treat the factory body as owned by the class.

## Test

`templates.integration.test.ts` typechecks the TS variants against the workspace `@vttforge/core` source (via `paths`), so a template that drifts from the SDK fails in CI. Verified the gate fails on an injected error.

## Checks

`pnpm typecheck`, `pnpm test` (362), `pnpm lint`, `check-template-pins`, `knip` — all green.