### PR TITLE
chore: read the VTTFORGE_*_VERSION constants from package.json

### DIFF
--- a/.changeset/version-from-package-json.md
+++ b/.changeset/version-from-package-json.md
@@ -1,0 +1,8 @@
+---
+"@vttforge/cli": patch
+"@vttforge/core": patch
+"@vttforge/vite-plugin": patch
+"@vttforge/types": patch
+---
+
+Read the exported `VTTFORGE_*_VERSION` constants from `package.json` at build time. They were hardcoded and had fallen behind — `vttforge --version` printed `0.1.0` on the 0.5 line.

--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import cliPackage from '../../package.json' with { type: 'json' };
 import {
   detectPackageManager,
   detectProjectPackageManager,
@@ -51,6 +52,6 @@ describe('@vttforge/cli public surface', () => {
   });
 
   it('exports the version constant', () => {
-    expect(VTTFORGE_CLI_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+    expect(VTTFORGE_CLI_VERSION).toBe(cliPackage.version);
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,8 @@
  * scaffolder (e.g. from another CLI, a test harness, or a custom tool).
  */
 
+import { version } from '../package.json' with { type: 'json' };
+
 export { runAudit } from './audit/index.js';
 export { runManifestRules } from './audit/manifest-rules.js';
 export type { ReportFormat } from './audit/reporter.js';
@@ -53,4 +55,4 @@ export {
 export type { EmitZipOptions, EmitZipResult } from './zip.js';
 export { emitZip } from './zip.js';
 
-export const VTTFORGE_CLI_VERSION = '0.1.0';
+export const VTTFORGE_CLI_VERSION: string = version;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,9 @@
  * `@vttforge/types` in v1.0.
  */
 
-export const VTTFORGE_CORE_VERSION = '0.2.0';
+import { version } from '../package.json' with { type: 'json' };
+
+export const VTTFORGE_CORE_VERSION: string = version;
 
 export {
   BaseActorSheet,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,6 @@
 /**
  * @vttforge/types — placeholder. Real type surface lands in v1.0.0.
  */
-export const VTTFORGE_TYPES_VERSION = '0.0.1';
+import { version } from '../package.json' with { type: 'json' };
+
+export const VTTFORGE_TYPES_VERSION: string = version;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import pluginPackage from '../../package.json' with { type: 'json' };
 import vttforge, { VTTFORGE_VITE_PLUGIN_VERSION, type VttforgeOptions } from '../index';
 
 const FIXTURE_SRC = fileURLToPath(new URL('./fixtures/example-system', import.meta.url));
@@ -67,7 +68,7 @@ describe('@vttforge/vite-plugin', () => {
   });
 
   it('exports a version constant', () => {
-    expect(VTTFORGE_VITE_PLUGIN_VERSION).toBeTypeOf('string');
+    expect(VTTFORGE_VITE_PLUGIN_VERSION).toBe(pluginPackage.version);
   });
 
   it('returns a Vite plugin with the right shape', () => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -22,6 +22,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { cp, mkdir, readdir, stat } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 import type { Plugin, UserConfig } from 'vite';
+import { version } from '../package.json' with { type: 'json' };
 
 export interface VttforgeOptions {
   /**
@@ -362,4 +363,4 @@ export default function vttforge(options: VttforgeOptions): Plugin {
   };
 }
 
-export const VTTFORGE_VITE_PLUGIN_VERSION = '0.1.0';
+export const VTTFORGE_VITE_PLUGIN_VERSION: string = version;

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "types": ["node"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## What

`@vttforge/cli`, `core`, `vite-plugin` and `types` each exported a hardcoded `VTTFORGE_*_VERSION`. None matched the published version — `vttforge --version` printed `0.1.0` on the 0.5 line.

Each now imports `version` from its own `package.json`. The bundler inlines the single field (`var version = "0.5.2"` in dist, nothing else from the manifest). `rootDir` is dropped from the four tsconfigs so the import typechecks; they are `noEmit` anyway.

The cli and vite-plugin tests now assert equality with `package.json` instead of a semver regex.

## Checks

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm publint`, `knip` — green. `node packages/cli/dist/bin.mjs --version` → `0.5.2`.