### PR TITLE
feat(examples): make simple-module a real module

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,11 +14,11 @@ services:
       CONTAINER_PRESERVE_CONFIG: "true"
     volumes:
       - foundry-dev-data:/data
-      # Mount the built dist/ — produced by `pnpm -F @vttforge-examples/simple-system build`
+      # Mount the built dist/ of each example — `pnpm -F @vttforge-examples/<name> build`
       # via @vttforge/vite-plugin. The plugin emits a fully Foundry-loadable
       # tree (system.json + bundled main.mjs + bundled styles/ + lang/ + templates/).
       - ./examples/simple-system/dist:/data/Data/systems/vttforge-example:ro
-      - ./examples/simple-module:/data/Data/modules/vttforge-example-module:ro
+      - ./examples/simple-module/dist:/data/Data/modules/vttforge-example-module:ro
       # The hot reload companion. A container cannot follow the symlink
       # `vttforge dev` drops on the host, so it is mounted instead.
       - ./packages/dev-module:/data/Data/modules/vttforge-dev:ro

--- a/examples/simple-module/README.md
+++ b/examples/simple-module/README.md
@@ -1,5 +1,44 @@
 # @vttforge-examples/simple-module
 
-Minimal reference Foundry VTT **module** built against `@vttforge/core` + `@vttforge/vite-plugin`. Doubles as the smoke-test for HMR and manifest sync.
+Reference Foundry v13 module built on `@vttforge/core` and `@vttforge/vite-plugin`. It is the `module-js` template from `vttforge init`, rendered with the id `vttforge-example-module`, plus a boot test.
 
-> **Status:** v0.0.0 placeholder. Real Foundry manifest + HMR proof-of-life land in v0.2.0 alongside `@vttforge/vite-plugin`.
+## What this exercises
+
+| Feature | Where |
+|---|---|
+| `registerModule` — sub-type, sheet, enricher, settings, API in one call | `scripts/main.mjs` |
+| `moduleSubType` — the `<module id>.<type>` key Foundry files a module's sub-type under | `scripts/constants.mjs` |
+| `BaseTypeDataModel(defineSchema)` | `scripts/data/note-data.mjs` |
+| `BaseItemSheet()` with one part and one action | `scripts/sheets/note-sheet.mjs` |
+| An enricher declared as data, with `onRender` | `scripts/enricher.mjs` |
+| `documentTypes` in a module manifest | `module.json` |
+
+## Run inside Foundry
+
+From the repo root:
+
+```bash
+cp .env.example .env                                  # FOUNDRY_LICENSE_KEY + foundryvtt.com credentials
+pnpm -F @vttforge-examples/simple-module build        # → examples/simple-module/dist/
+docker compose -f docker-compose.dev.yml up           # → http://localhost:30000
+```
+
+Enable **VTTForge Example Module** in any world. Create a Note from the Items sidebar, copy the `@Note[id]` reference from its sheet, and paste it into any text field.
+
+`pnpm -F @vttforge-examples/simple-module dev` rebuilds on every edit.
+
+## Layout
+
+```
+scripts/
+├── constants.mjs                 ← MODULE_ID, NOTE_TYPE
+├── data/note-data.mjs            ← TypeDataModel for `note`
+├── sheets/note-sheet.mjs         ← BaseItemSheet subclass
+├── enricher.mjs                  ← @Note[id]
+└── main.mjs                      ← registerModule entry
+templates/item/note-sheet.hbs
+tests/boot.test.mjs               ← happy-dom smoke: mocks Foundry, boots main.mjs
+styles/main.css
+lang/en.json
+module.json
+```

--- a/examples/simple-module/lang/en.json
+++ b/examples/simple-module/lang/en.json
@@ -1,0 +1,29 @@
+{
+  "TYPES": {
+    "Item": {
+      "vttforge-example-module": {
+        "note": "Note"
+      }
+    }
+  },
+  "VTTFORGE_EXAMPLE_MODULE": {
+    "Settings": {
+      "showWelcome": {
+        "name": "Show welcome notification",
+        "hint": "Display a one-shot toast when VTTForge Example Module loads in a world."
+      }
+    },
+    "Welcome": "VTTForge Example Module loaded — create a Note from the Items sidebar, or try `game.modules.get(\"vttforge-example-module\").api.createNote(\"Hello\")` in the console.",
+    "Sheet": {
+      "NamePlaceholder": "Name",
+      "Note": {
+        "title": "Note"
+      }
+    },
+    "Note": {
+      "NewName": "New Note",
+      "Pinned": "Pinned",
+      "ReferenceHint": "Paste this in any text field to link here."
+    }
+  }
+}

--- a/examples/simple-module/module.json
+++ b/examples/simple-module/module.json
@@ -1,0 +1,25 @@
+{
+  "id": "vttforge-example-module",
+  "title": "VTTForge Example Module",
+  "description": "Reference Foundry VTT module built on @vttforge/core: a note item type, its sheet, and an enricher.",
+  "version": "0.1.0",
+  "compatibility": {
+    "minimum": "13",
+    "verified": "13"
+  },
+  "authors": [{ "name": "VTTForge Contributors" }],
+  "esmodules": ["main.mjs"],
+  "styles": [{ "src": "styles/main.css" }],
+  "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
+  "documentTypes": {
+    "Item": {
+      "note": { "htmlFields": ["body"] }
+    }
+  },
+  "flags": {
+    "hotReload": {
+      "extensions": ["css", "hbs", "json"],
+      "paths": ["styles", "templates", "lang"]
+    }
+  }
+}

--- a/examples/simple-module/package.json
+++ b/examples/simple-module/package.json
@@ -1,12 +1,23 @@
 {
   "name": "@vttforge-examples/simple-module",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Reference Foundry VTT module built on @vttforge/core + @vttforge/vite-plugin.",
   "type": "module",
   "scripts": {
-    "build": "echo 'simple-module: scaffolding lands in v0.2.0'",
-    "typecheck": "echo 'simple-module: typecheck lands in v0.2.0'",
-    "test": "echo 'simple-module: no tests yet'"
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@vttforge/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@vttforge/vite-plugin": "workspace:*",
+    "happy-dom": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/examples/simple-module/scripts/constants.mjs
+++ b/examples/simple-module/scripts/constants.mjs
@@ -1,0 +1,12 @@
+import { moduleSubType } from '@vttforge/core';
+
+export const MODULE_ID = 'vttforge-example-module';
+
+/**
+ * The key Foundry files the `note` sub-type under: `vttforge-example-module.note`.
+ *
+ * A module's sub-types are namespaced by Foundry. Use this constant wherever
+ * the type is named — `item.type === NOTE_TYPE`, `types: [NOTE_TYPE]` — and
+ * the prefix cannot be forgotten.
+ */
+export const NOTE_TYPE = moduleSubType(MODULE_ID, 'note');

--- a/examples/simple-module/scripts/data/note-data.mjs
+++ b/examples/simple-module/scripts/data/note-data.mjs
@@ -1,0 +1,18 @@
+/**
+ * NoteData — the `note` Item sub-type this module adds to any system.
+ *
+ * The schema is a function handed to the factory. It has to be a function
+ * because `fields()` reads a Foundry global that does not exist when this
+ * module is first evaluated.
+ */
+import { BaseTypeDataModel, fields } from '@vttforge/core';
+
+const defineNoteSchema = () => {
+  const f = fields();
+  return {
+    body: new f.HTMLField(),
+    pinned: new f.BooleanField({ required: true, nullable: false, initial: false }),
+  };
+};
+
+export class NoteData extends BaseTypeDataModel(defineNoteSchema) {}

--- a/examples/simple-module/scripts/enricher.mjs
+++ b/examples/simple-module/scripts/enricher.mjs
@@ -1,0 +1,56 @@
+/**
+ * `@Note[id]` — a link to a note from any enriched text field.
+ *
+ * Declared as data and handed to `registerModule({ enrichers })`, which
+ * registers it as `vttforge-example-module.note`. The pattern carries the `g` flag because
+ * enrichment runs it through `matchAll`, and `onRender` binds the click
+ * where the markup is declared rather than in a separate hook.
+ */
+import { NOTE_TYPE } from './constants.mjs';
+
+/**
+ * @param {string} id
+ * @returns {any}
+ */
+function findNote(id) {
+  const item = game.items.get(id);
+  return item?.type === NOTE_TYPE ? item : undefined;
+}
+
+/** @type {import('@vttforge/core').EnricherRegistration} */
+export const noteEnricher = {
+  id: 'note',
+  pattern: /@Note\[([^\]]+)\]/g,
+
+  /** @param {RegExpMatchArray} match */
+  enricher(match) {
+    const id = match[1];
+    const note = id === undefined ? undefined : findNote(id);
+    // Leave the text alone when the note is gone: a dead link is worse than
+    // the raw reference, which at least says what was meant.
+    if (note === undefined) return null;
+
+    const link = document.createElement('a');
+    link.className = 'vttforge-example-module-note-link';
+    link.dataset.noteId = id;
+    link.draggable = false;
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid fa-note-sticky';
+    link.append(icon, note.name);
+    return link;
+  },
+
+  /** @param {HTMLElement} element */
+  onRender(element) {
+    const links = /** @type {NodeListOf<HTMLElement>} */ (
+      element.querySelectorAll('a.vttforge-example-module-note-link')
+    );
+    for (const link of links) {
+      link.addEventListener('click', (event) => {
+        event.preventDefault();
+        const { noteId } = link.dataset;
+        if (noteId) findNote(noteId)?.sheet.render(true);
+      });
+    }
+  },
+};

--- a/examples/simple-module/scripts/foundry-globals.d.ts
+++ b/examples/simple-module/scripts/foundry-globals.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Minimal Foundry runtime globals for the example.
+ *
+ * `checkJs` is on here, which is the point: it compiles the example the way a
+ * consumer's own JavaScript gets compiled, so the SDK's inferred types are
+ * exercised against real code rather than only against type tests.
+ *
+ * These stubs are deliberately `any`. Typing the Foundry runtime is
+ * `@vttforge/types`' job; what this file exists to do is stop "Cannot find
+ * name 'game'" from drowning out the errors that actually matter.
+ */
+declare global {
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const game: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const CONFIG: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const Hooks: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const ui: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const ChatMessage: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const Roll: any;
+  // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
+  const foundry: any;
+}
+
+export {};

--- a/examples/simple-module/scripts/main.mjs
+++ b/examples/simple-module/scripts/main.mjs
@@ -1,0 +1,87 @@
+/**
+ * VTTForge Example Module — entry point.
+ *
+ * One `registerModule` call replaces the `Hooks.once("init", ...)` block most
+ * modules copy from each other: the sub-type, its sheet, the enricher, the
+ * settings, and the public API.
+ */
+import { registerModule, SystemConfig, VttfError } from '@vttforge/core';
+import { MODULE_ID, NOTE_TYPE } from './constants.mjs';
+import { NoteData } from './data/note-data.mjs';
+import { noteEnricher } from './enricher.mjs';
+import { NoteSheet } from './sheets/note-sheet.mjs';
+
+const settings = new SystemConfig(MODULE_ID);
+
+/** What `game.modules.get("vttforge-example-module").api` offers other modules and macros. */
+const api = {
+  /** The prefixed type key, for `item.type === api.noteType` checks. */
+  noteType: NOTE_TYPE,
+  /**
+   * @param {string} name
+   * @param {string} [body]
+   */
+  createNote(name, body = '') {
+    return CONFIG.Item.documentClass.create(
+      { name, type: NOTE_TYPE, system: { body } },
+      { renderSheet: true },
+    );
+  },
+};
+
+try {
+  registerModule({
+    id: MODULE_ID,
+
+    // Registered as `vttforge-example-module.note` — the prefix is added for you, and the
+    // manifest declares the same key under `documentTypes.Item`.
+    itemDataModels: { note: NoteData },
+
+    // Declared here rather than with `Items.registerSheet`. Foundry keys a
+    // sheet by `${scope}.${class name}` and saves that key on every document
+    // using it; a bundler renames classes between builds, and the saved key
+    // then names a sheet that no longer exists. The `id` is written down, so
+    // the key does not move. Pick it once and keep it.
+    sheets: [
+      {
+        id: 'note',
+        document: 'Item',
+        sheet: NoteSheet,
+        types: [NOTE_TYPE],
+        makeDefault: true,
+        label: 'VTTFORGE_EXAMPLE_MODULE.Sheet.Note.title',
+      },
+    ],
+
+    enrichers: [noteEnricher],
+
+    // Runs first inside `init` — the usual home for the module API, so it is
+    // there before anything that might hook `init` after us asks for it.
+    onBeforeInit: () => {
+      const handle = game.modules.get(MODULE_ID);
+      if (handle) handle.api = api;
+    },
+
+    onAfterInit: () => {
+      settings.register('showWelcome', {
+        name: 'VTTFORGE_EXAMPLE_MODULE.Settings.showWelcome.name',
+        hint: 'VTTFORGE_EXAMPLE_MODULE.Settings.showWelcome.hint',
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: true,
+      });
+    },
+
+    onReady: () => {
+      if (settings.get('showWelcome')) {
+        ui.notifications?.info(game.i18n.localize('VTTFORGE_EXAMPLE_MODULE.Welcome'));
+      }
+    },
+  });
+} catch (err) {
+  if (err instanceof VttfError) {
+    console.error(`[${err.code}] ${err.message} — see ${err.docsUrl}`);
+  }
+  throw err;
+}

--- a/examples/simple-module/scripts/sheets/note-sheet.mjs
+++ b/examples/simple-module/scripts/sheets/note-sheet.mjs
@@ -1,0 +1,69 @@
+/**
+ * NoteSheet — the `note` Item sheet on `BaseItemSheet()`.
+ *
+ * One part, no tabs, one action. The smallest sheet a module can ship.
+ */
+import { BaseItemSheet } from '@vttforge/core';
+import { MODULE_ID } from '../constants.mjs';
+
+export class NoteSheet extends BaseItemSheet() {
+  /** @override */
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    super.DEFAULT_OPTIONS,
+    {
+      id: 'vttforge-example-module-note',
+      classes: ['vttforge-example-module', 'sheet', 'item', 'note'],
+      window: {
+        title: 'VTTFORGE_EXAMPLE_MODULE.Sheet.Note.title',
+        icon: 'fa-solid fa-note-sticky',
+      },
+      position: { width: 480, height: 480 },
+      actions: {
+        togglePinned: NoteSheet._onTogglePinned,
+      },
+    },
+    { inplace: false },
+  );
+
+  static PARTS = {
+    sheet: { template: `modules/${MODULE_ID}/templates/item/note-sheet.hbs` },
+  };
+
+  /**
+   * The item this sheet is for. One place to read `this.document` from, so
+   * the rest of the sheet says `this.item` and means it.
+   * @returns {any}
+   */
+  get item() {
+    return this.document;
+  }
+
+  /**
+   * @override
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<Record<string, unknown>>}
+   */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const { item } = this;
+    context.item = item;
+    context.system = item.system;
+    context.isEditable = this.isEditable;
+    context.reference = `@Note[${item.id}]`;
+    context.enrichedBody = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      item.system.body,
+      { relativeTo: item, secrets: item.isOwner },
+    );
+    return context;
+  }
+
+  /**
+   * @this {NoteSheet} ApplicationV2 declares action handlers static but calls
+   *   them with `this` bound to the sheet instance.
+   */
+  static async _onTogglePinned() {
+    // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
+    const { item } = this;
+    await item.update({ 'system.pinned': !item.system.pinned });
+  }
+}

--- a/examples/simple-module/styles/main.css
+++ b/examples/simple-module/styles/main.css
@@ -1,0 +1,77 @@
+/**
+ * VTTForge Example Module stylesheet.
+ *
+ * Every rule is scoped under `.vttforge-example-module` so nothing leaks into the host system's
+ * sheets. Colours come from Foundry's own variables so the sheet follows the
+ * light and dark themes.
+ */
+.vttforge-example-module.sheet .sheet-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.vttforge-example-module.sheet .sheet-header .portrait {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border: 1px solid var(--color-border-dark, #7a7971);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.vttforge-example-module.sheet .sheet-header input[name="name"] {
+  flex: 1;
+  font-size: var(--font-size-20, 1.25rem);
+}
+
+.vttforge-example-module.sheet .sheet-header .pin {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  opacity: 0.5;
+}
+
+.vttforge-example-module.sheet .sheet-header .pin.active {
+  opacity: 1;
+  color: var(--color-warm-2, #c9593f);
+}
+
+.vttforge-example-module.sheet .sheet-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  height: 100%;
+}
+
+.vttforge-example-module.sheet prose-mirror,
+.vttforge-example-module.sheet .body-readonly {
+  flex: 1;
+  min-height: 12rem;
+}
+
+.vttforge-example-module.sheet .reference {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  color: var(--color-text-secondary, #4b4a44);
+  font-size: var(--font-size-12, 0.75rem);
+}
+
+/* Rendered by the `note` enricher wherever `@Note[id]` appears. */
+a.vttforge-example-module-note-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  padding: 0 0.35em;
+  border: 1px dotted var(--color-border-dark, #7a7971);
+  border-radius: 3px;
+  background: var(--color-bg-tertiary, rgba(0, 0, 0, 0.06));
+  text-decoration: none;
+}
+
+a.vttforge-example-module-note-link:hover {
+  border-style: solid;
+  text-shadow: none;
+}

--- a/examples/simple-module/templates/item/note-sheet.hbs
+++ b/examples/simple-module/templates/item/note-sheet.hbs
@@ -1,0 +1,34 @@
+{{!-- Note sheet — one part, no tabs. --}}
+<form autocomplete="off">
+
+  <header class="sheet-header">
+    <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
+    <input type="text" name="name" value="{{item.name}}"
+           placeholder="{{localize 'VTTFORGE_EXAMPLE_MODULE.Sheet.NamePlaceholder'}}" />
+    <button type="button" class="pin {{#if system.pinned}}active{{/if}}"
+            data-action="togglePinned"
+            title="{{localize 'VTTFORGE_EXAMPLE_MODULE.Note.Pinned'}}">
+      <i class="fa-solid fa-thumbtack"></i>
+    </button>
+  </header>
+
+  <section class="sheet-body">
+    {{#if isEditable}}
+      <prose-mirror name="system.body"
+                    button="true"
+                    editable="{{isEditable}}"
+                    toggled="false"
+                    value="{{system.body}}">
+        {{{enrichedBody}}}
+      </prose-mirror>
+    {{else}}
+      <div class="body-readonly">{{{enrichedBody}}}</div>
+    {{/if}}
+
+    <footer class="reference">
+      <code>{{reference}}</code>
+      <small>{{localize 'VTTFORGE_EXAMPLE_MODULE.Note.ReferenceHint'}}</small>
+    </footer>
+  </section>
+
+</form>

--- a/examples/simple-module/tests/boot.test.mjs
+++ b/examples/simple-module/tests/boot.test.mjs
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+/**
+ * Boot smoke — loads scripts/main.mjs against mocked Foundry globals and
+ * checks that `registerModule({...})` lands the sub-type, the sheet and the
+ * enricher under the keys Foundry will look them up by.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function installFoundryGlobals() {
+  const settings = new Map();
+  const hooks = new Map();
+  const registerSheet = vi.fn();
+
+  globalThis.Hooks = {
+    once(name, fn) {
+      hooks.set(name, fn);
+      return 0;
+    },
+    on() {
+      return 0;
+    },
+  };
+
+  globalThis.CONFIG = {
+    Actor: { dataModels: {}, documentClass: class {} },
+    Item: { dataModels: {}, documentClass: class {} },
+    TextEditor: { enrichers: [] },
+  };
+
+  const moduleHandle = { id: 'vttforge-example-module' };
+  globalThis.game = {
+    user: { isGM: true },
+    modules: { get: (id) => (id === moduleHandle.id ? moduleHandle : undefined) },
+    settings: {
+      register(namespace, key, config) {
+        settings.set(`${namespace}.${key}`, config);
+      },
+      get(namespace, key) {
+        const entry = settings.get(`${namespace}.${key}`);
+        return entry?.value ?? entry?.default;
+      },
+    },
+    i18n: { localize: (key) => key },
+    items: { get: () => undefined },
+  };
+
+  globalThis.ui = { notifications: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } };
+
+  globalThis.foundry = {
+    abstract: { TypeDataModel: class {} },
+    applications: {
+      apps: { DocumentSheetConfig: { registerSheet } },
+      api: {
+        HandlebarsApplicationMixin: (base) => class extends base {},
+      },
+      sheets: { ActorSheetV2: class {}, ItemSheetV2: class {} },
+      ux: { DragDrop: class {} },
+    },
+    data: { fields: {} },
+    utils: {
+      mergeObject(a, b) {
+        return { ...a, ...b };
+      },
+    },
+  };
+
+  return { hooks, settings, registerSheet, moduleHandle };
+}
+
+let env;
+
+beforeEach(() => {
+  env = installFoundryGlobals();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete globalThis.Hooks;
+  delete globalThis.CONFIG;
+  delete globalThis.game;
+  delete globalThis.ui;
+  delete globalThis.foundry;
+});
+
+describe('vttforge-example-module — boot', () => {
+  it('loads main.mjs and registers init and ready', async () => {
+    await import('../scripts/main.mjs?bootA');
+    expect(env.hooks.has('init')).toBe(true);
+    expect(env.hooks.has('ready')).toBe(true);
+  });
+
+  it('files the note sub-type under the module-prefixed key', async () => {
+    await import('../scripts/main.mjs?bootB');
+    env.hooks.get('init')();
+    // A module's sub-types are namespaced; `note` alone would never appear.
+    expect(CONFIG.Item.dataModels['vttforge-example-module.note']).toBeDefined();
+    expect(CONFIG.Item.dataModels.note).toBeUndefined();
+  });
+
+  it('registers the note sheet under a key a rebuild cannot move', async () => {
+    await import('../scripts/main.mjs?bootC');
+    env.hooks.get('init')();
+    expect(env.registerSheet).toHaveBeenCalledTimes(1);
+    const [, scope, sheetClass, options] = env.registerSheet.mock.calls[0];
+    expect(`${scope}.${sheetClass.name}`).toBe('vttforge-example-module.note');
+    expect(options).toMatchObject({ types: ['vttforge-example-module.note'], makeDefault: true });
+  });
+
+  it('registers the enricher under the module namespace, with a global pattern', async () => {
+    await import('../scripts/main.mjs?bootD');
+    env.hooks.get('init')();
+    const [enricher] = CONFIG.TextEditor.enrichers;
+    expect(enricher.id).toBe('vttforge-example-module.note');
+    expect(enricher.pattern.global).toBe(true);
+    expect(typeof enricher.onRender).toBe('function');
+  });
+
+  it('exposes the API on the module handle and registers the setting', async () => {
+    await import('../scripts/main.mjs?bootE');
+    env.hooks.get('init')();
+    expect(env.moduleHandle.api.noteType).toBe('vttforge-example-module.note');
+    expect(typeof env.moduleHandle.api.createNote).toBe('function');
+    expect(env.settings.has('vttforge-example-module.showWelcome')).toBe(true);
+  });
+});

--- a/examples/simple-module/tsconfig.json
+++ b/examples/simple-module/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": ["scripts/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/examples/simple-module/vite.config.mjs
+++ b/examples/simple-module/vite.config.mjs
@@ -1,0 +1,13 @@
+import vttforge from '@vttforge/vite-plugin';
+import { defineConfig } from 'vite';
+
+/**
+ * Vite config for VTTForge Example Module.
+ *
+ * `@vttforge/vite-plugin` owns the build contract for both systems and
+ * modules — `kind: 'module'` tells the plugin to write `dist/module.json`
+ * (instead of `system.json`) and to base chunk URLs at `/modules/vttforge-example-module/`.
+ */
+export default defineConfig({
+  plugins: [vttforge({ id: 'vttforge-example-module', kind: 'module' })],
+});

--- a/knip.json
+++ b/knip.json
@@ -19,6 +19,10 @@
       "project": ["scripts/**/*.mjs"],
       "ignoreDependencies": ["@vttforge/styles"]
     },
+    "examples/simple-module": {
+      "entry": ["scripts/main.mjs"],
+      "project": ["scripts/**/*.mjs"]
+    },
     "apps/web": {
       "entry": ["index.html"],
       "ignoreDependencies": ["@vttforge/styles"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,27 @@ importers:
         specifier: 'catalog:'
         version: 8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0)
 
-  examples/simple-module: {}
+  examples/simple-module:
+    dependencies:
+      '@vttforge/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      '@vttforge/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin
+      happy-dom:
+        specifier: 'catalog:'
+        version: 20.12.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@types/node@26.4.0)(happy-dom@20.12.0)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0))
 
   examples/simple-system:
     dependencies:


### PR DESCRIPTION
## What

`examples/simple-module` was a placeholder — `package.json` scripts that echoed "lands in v0.2.0" — while `docker-compose.dev.yml` already mounted it into the container.

It is now the `module-js` template from `vttforge init`, rendered as `vttforge-example-module`: a `note` Item sub-type on `registerModule`, its sheet on `BaseItemSheet`, an `@Note[id]` enricher, a setting and a public API. Same shape as `simple-system`: `vite build` through the plugin, `checkJs` with the stub globals, and a boot test that asserts the prefixed data-model key, the pinned sheet key, the namespaced enricher id and the API on the module handle.

- Compose mounts `examples/simple-module/dist` (the built tree), matching the system.
- `knip.json` gains the entry.

Rendered from the template as it stands in #123, so the two stay the same code; that PR carries the JSDoc annotations `checkJs` needed.

## Checks

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `knip` — green. `pnpm -F @vttforge-examples/simple-module build` emits `dist/module.json` + `main.mjs`.