### PR TITLE
docs: link the docs from the landing and the README, and dress them in Forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![FoundryVTT](https://img.shields.io/badge/FoundryVTT-v13%2B-orange?style=flat-square)](https://foundryvtt.com)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org)
 
-[📖 Documentation](https://vttforge.dev/docs/) · [🗺️ Roadmap](#roadmap) · [🐛 Report bug](https://github.com/vttforge/vttforge/issues)
+[Documentation](https://vttforge.dev/docs/) · [Getting started](https://vttforge.dev/docs/guide/getting-started) · [API reference](https://vttforge.dev/docs/reference/) · [Roadmap](#roadmap) · [Report a bug](https://github.com/vttforge/vttforge/issues)
 
 </div>
 
@@ -36,6 +36,21 @@ pnpm dev
 ```
 
 This builds, symlinks `dist/` into your Foundry data directory, and watches. Save a template and the open sheet redraws in place, with no page reload. The first run asks where Foundry keeps its data and remembers the answer; if Foundry runs in a container and cannot follow a symlink, it prints the compose mount to use instead.
+
+## Docs
+
+The whole guide is at **[vttforge.dev/docs](https://vttforge.dev/docs/)**.
+
+- **[Getting started](https://vttforge.dev/docs/guide/getting-started).** Scaffold a project, point Foundry at it, build a release zip.
+- **[Data models](https://vttforge.dev/docs/guide/data-models).** One schema that types itself, and what each field class quietly defaults to.
+- **[Sheets](https://vttforge.dev/docs/guide/sheets).** The bases, the drop hooks, and why every sheet needs an id.
+- **[Modules](https://vttforge.dev/docs/guide/modules).** Namespaced sub-types, enrichers, and what a module may not touch.
+- **[Settings and migrations](https://vttforge.dev/docs/guide/settings-and-migrations).** `SystemConfig` and the migration runner.
+- **[The dev loop](https://vttforge.dev/docs/guide/dev-loop).** What reloads in place and what does not.
+- **[Testing](https://vttforge.dev/docs/guide/testing).** `withMockFoundry` in Vitest, Quench for what a mock cannot answer.
+- **[CLI reference](https://vttforge.dev/docs/guide/cli).** Every command, and every rule `vttforge audit` checks.
+
+Also on the site: the [API reference](https://vttforge.dev/docs/reference/) generated from the sources, the [error catalogue](https://vttforge.dev/docs/errors/), the [recipes](https://vttforge.dev/docs/recipes/), and the [stability policy](https://vttforge.dev/docs/stability).
 
 ## Why
 
@@ -143,7 +158,7 @@ The **Forge theme**: warm-dark surfaces, an ember accent, a `{ d20 }` mark, a 4-
 - ✅ **Dev loop.** Templates, styles and language files reload in place, without a page refresh
 - ✅ **Design system.** Tokens, primitives, themes, brand
 - ✅ **Published.** Every package on npm under OIDC trusted publishing, with provenance
-- ✅ **Documentation.** [vttforge.dev](https://vttforge.dev) carries the guide, the recipes, the error catalogue and the design system
+- ✅ **Documentation.** [vttforge.dev/docs](https://vttforge.dev/docs/) carries the guide, the API reference, the recipes and the error catalogue
 - 🛠️ **Now.** Widening the Foundry surface in `@vttforge/types` as adopters hit gaps
 - 🚀 **v1.0.** A stable API, decorators once the toolchain allows them, and enough adopters to know which of the remaining gaps are real
 

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -42,6 +42,32 @@ export default defineConfig({
   // in one Pages artifact.
   base: '/docs/',
   description: 'An SDK and CLI for building Foundry VTT v13+ systems and modules.',
+
+  head: [
+    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    [
+      'link',
+      {
+        rel: 'stylesheet',
+        href: 'https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,600;12..96,700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap',
+      },
+    ],
+    // VitePress selects dark with a class on <html>; the Forge tokens read
+    // `[data-theme]`. Mirror one onto the other, here in the head so it is
+    // set before first paint, and again on every toggle.
+    [
+      'script',
+      {},
+      `(() => {
+        const el = document.documentElement;
+        const sync = () =>
+          el.setAttribute('data-theme', el.classList.contains('dark') ? 'dark' : 'light');
+        sync();
+        new MutationObserver(sync).observe(el, { attributes: true, attributeFilter: ['class'] });
+      })();`,
+    ],
+  ],
   cleanUrls: true,
   lastUpdated: true,
 
@@ -59,6 +85,10 @@ export default defineConfig({
       { text: 'API', link: '/reference/' },
       { text: 'Errors', link: '/errors/' },
       { text: 'Stability', link: '/stability' },
+      // Absolute, because a root-relative link would be prefixed with the
+      // `/docs/` base and point back into the docs.
+      { text: 'Design System', link: 'https://vttforge.dev/design-system' },
+      { text: 'vttforge.dev', link: 'https://vttforge.dev/' },
     ],
 
     sidebar: {

--- a/apps/docs/.vitepress/theme/forge.css
+++ b/apps/docs/.vitepress/theme/forge.css
@@ -1,0 +1,104 @@
+/*!
+ * Forge, applied to VitePress.
+ *
+ * The docs sit under the same domain as the landing page, so they should
+ * not look like a different product. This file maps VitePress's own theme
+ * variables onto the `--vttf-*` tokens `@vttforge/styles` publishes, which
+ * is the same set the landing page and the design-system page read.
+ *
+ * The two themes disagree about how light and dark are selected: VitePress
+ * puts a `dark` class on `<html>`, Forge reads `[data-theme]`. A small
+ * script in the site head mirrors one onto the other before first paint, so
+ * every mapping below can be written once and still follow the toggle.
+ */
+@import '@vttforge/styles/tokens.css';
+
+:root,
+:root.dark {
+  --vp-c-bg: var(--vttf-bg);
+  --vp-c-bg-alt: var(--vttf-bg-sunken);
+  --vp-c-bg-elv: var(--vttf-bg-elevated);
+  --vp-c-bg-soft: var(--vttf-surface);
+
+  --vp-c-text-1: var(--vttf-text);
+  --vp-c-text-2: var(--vttf-text-muted);
+  --vp-c-text-3: var(--vttf-text-faint);
+
+  --vp-c-divider: var(--vttf-border);
+  --vp-c-border: var(--vttf-border);
+  --vp-c-gutter: var(--vttf-border);
+
+  --vp-c-brand-1: var(--vttf-ember);
+  --vp-c-brand-2: var(--vttf-ember-glow);
+  --vp-c-brand-3: var(--vttf-ember-deep);
+  --vp-c-brand-soft: color-mix(in oklch, var(--vttf-ember) 14%, transparent);
+
+  --vp-c-default-1: var(--vttf-text);
+  --vp-c-default-2: var(--vttf-text-muted);
+  --vp-c-default-3: var(--vttf-border-strong);
+  --vp-c-default-soft: var(--vttf-surface);
+
+  --vp-c-tip-1: var(--vttf-ember);
+  --vp-c-tip-2: var(--vttf-ember-glow);
+  --vp-c-tip-3: var(--vttf-ember-deep);
+  --vp-c-tip-soft: color-mix(in oklch, var(--vttf-ember) 12%, transparent);
+
+  --vp-c-warning-1: var(--vttf-gold);
+  --vp-c-warning-soft: color-mix(in oklch, var(--vttf-gold) 12%, transparent);
+  --vp-c-danger-1: var(--vttf-rose);
+  --vp-c-danger-soft: color-mix(in oklch, var(--vttf-rose) 12%, transparent);
+
+  --vp-font-family-base: var(--vttf-font-body);
+  --vp-font-family-mono: var(--vttf-font-mono);
+
+  --vp-button-brand-bg: var(--vttf-ember);
+  --vp-button-brand-hover-bg: var(--vttf-ember-glow);
+  --vp-button-brand-active-bg: var(--vttf-ember-deep);
+  --vp-button-brand-text: var(--vttf-text-inverse);
+  --vp-button-brand-hover-text: var(--vttf-text-inverse);
+  --vp-button-alt-bg: var(--vttf-surface);
+  --vp-button-alt-hover-bg: var(--vttf-surface-2);
+  --vp-button-alt-border: var(--vttf-border-strong);
+  --vp-button-alt-text: var(--vttf-text);
+
+  --vp-code-bg: var(--vttf-surface);
+  --vp-code-color: var(--vttf-ember-glow);
+  --vp-code-block-bg: var(--vttf-bg-sunken);
+  --vp-code-copy-code-bg: var(--vttf-surface);
+  --vp-code-copy-code-hover-bg: var(--vttf-surface-2);
+
+  --vp-home-hero-name-color: var(--vttf-ember);
+  --vp-home-hero-image-background-image: none;
+
+  --vp-nav-bg-color: color-mix(in oklch, var(--vttf-bg) 88%, transparent);
+  --vp-sidebar-bg-color: var(--vttf-bg);
+  --vp-local-search-bg: var(--vttf-bg-elevated);
+}
+
+/* Headings carry the display face, the way they do on the landing page. */
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3,
+.vp-doc h4,
+.VPHero .name,
+.VPHero .text,
+.VPFeature .title,
+.VPNavBarTitle .title {
+  font-family: var(--vttf-font-display);
+  letter-spacing: -0.01em;
+}
+
+/* The section rules read as dividers, not as boxes. */
+.vp-doc h2 {
+  border-top-color: var(--vttf-border);
+}
+
+/* Inline code inherits the ember accent; kill the default brand-tinted box. */
+.vp-doc :not(pre) > code {
+  border-radius: var(--vttf-radius-sm);
+}
+
+/* The ember, dimmed, behind the nav on scroll. */
+.VPNavBar.has-sidebar .curtain {
+  background: var(--vttf-bg);
+}

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -1,0 +1,10 @@
+/**
+ * The docs theme: VitePress's default, wearing Forge.
+ *
+ * Nothing is replaced, only re-coloured. `forge.css` is imported after the
+ * default theme's own styles so its variable mapping wins the cascade.
+ */
+import DefaultTheme from 'vitepress/theme';
+import './forge.css';
+
+export default DefaultTheme;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,6 +9,9 @@
     "build": "node scripts/typedoc.mjs && vitepress build .",
     "preview": "vitepress preview ."
   },
+  "dependencies": {
+    "@vttforge/styles": "workspace:*"
+  },
   "devDependencies": {
     "typedoc": "^0.28.20",
     "typedoc-plugin-markdown": "^4.13.0",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -39,6 +39,7 @@
           <a href="#packages">Packages</a>
           <a href="#try">Try it</a>
           <a href="#roadmap">Roadmap</a>
+          <a href="/docs/">Docs</a>
           <a href="/design-system">Design System</a>
         </nav>
         <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle theme">
@@ -76,7 +77,8 @@
                 <span class="lbl">copy</span>
               </button>
             </div>
-            <a class="btn-secondary" href="/design-system">Design System <span aria-hidden="true">→</span></a>
+            <a class="btn-secondary" href="/docs/guide/getting-started">Read the docs <span aria-hidden="true">→</span></a>
+            <a class="btn-secondary" href="/design-system">Design System</a>
           </div>
 
           <dl class="hero-meta">
@@ -323,7 +325,7 @@
 
             <div class="try-card">
               <h3>Scaffold one in a minute</h3>
-              <p>One command writes a system or a module you can open in Foundry: typed data models, a sheet with tabs and drag-drop, a migration runner, a release workflow. Then <span class="mono">vttforge dev</span> reloads templates and styles in place.</p>
+              <p>One command writes a system or a module you can open in Foundry: typed data models, a sheet with tabs and drag-drop, a migration runner, a release workflow. Then <span class="mono">vttforge dev</span> reloads templates and styles in place. The walkthrough is in <a href="/docs/guide/getting-started">getting started</a>.</p>
               <div class="vttf-codeblock">
                 <div class="vttf-codeblock__head">
                   <div class="vttf-codeblock__dots"><span></span><span></span><span></span></div>
@@ -374,9 +376,10 @@
         <div class="shell">
           <div class="cta-strip">
             <h2>Built one Foundry system the hard way?<br />Try building the next one with VTTForge.</h2>
-            <p>Every package is on npm. Scaffold one, file an issue with the boilerplate you keep writing by hand, or open the design system to see what ships with it.</p>
+            <p>Every package is on npm. Scaffold one, read the guide, or file an issue with the boilerplate you keep writing by hand.</p>
             <div class="row">
               <a href="https://github.com/vttforge/vttforge" class="top-cta">Star on GitHub →</a>
+              <a href="/docs/" class="btn-secondary">Read the docs</a>
               <a href="/design-system" class="btn-secondary">View design system</a>
             </div>
           </div>
@@ -394,10 +397,12 @@
           <div>
             <h4>Documentation</h4>
             <ul>
+              <li><a href="/docs/guide/getting-started">Getting started</a></li>
+              <li><a href="/docs/guide/cli">CLI reference</a></li>
+              <li><a href="/docs/reference/">API reference</a></li>
+              <li><a href="/docs/errors/">Error codes</a></li>
+              <li><a href="/docs/recipes/">Recipes</a></li>
               <li><a href="/design-system">Design System</a></li>
-              <li><a href="/docs/recipes/theme-v2">Theme Recipes</a></li>
-              <li><a href="#packages">Packages</a></li>
-              <li><a href="#roadmap">Roadmap</a></li>
             </ul>
           </div>
           <div>

--- a/knip.json
+++ b/knip.json
@@ -28,7 +28,11 @@
       "ignoreDependencies": ["@vttforge/styles"]
     },
     "apps/docs": {
-      "ignoreDependencies": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"]
+      "ignoreDependencies": [
+        "typedoc-plugin-markdown",
+        "typedoc-vitepress-theme",
+        "@vttforge/styles"
+      ]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,10 @@ importers:
         version: 7.0.2
 
   apps/docs:
+    dependencies:
+      '@vttforge/styles':
+        specifier: workspace:*
+        version: link:../../packages/styles
     devDependencies:
       typedoc:
         specifier: ^0.28.20


### PR DESCRIPTION
## What

Two things the site got wrong.

**Nothing linked to the docs.** The landing page had no link to `/docs/` at all. Its only off-page links were four to `/design-system` and one deep link to a single recipe in the footer. The top nav is `display: none` on mobile, so a phone had no route there either. The guide, the API reference and the error catalogue were reachable only by typing the URL.

- Nav gains **Docs**.
- The hero's secondary button becomes **Read the docs →**, with Design System beside it.
- The closing CTA gains **Read the docs**.
- The footer's "Documentation" column stops listing in-page anchors and lists getting started, the CLI reference, the API reference, error codes, recipes and the design system.
- The scaffold card points at the getting-started walkthrough.
- README: the link row under the badges names getting started and the API reference, and a new **Docs** section lists all eight guide pages plus the reference, errors, recipes and stability.

**The docs looked like a different product.** They shipped in VitePress's default theme: its blue, its fonts, its surfaces.

`apps/docs/.vitepress/theme/forge.css` maps VitePress's own variables onto the `--vttf-*` tokens `@vttforge/styles` publishes, the same set the landing page and the design-system page read. Headings take the display face, the three Google faces load in the head, and the nav links back to the landing and the design system.

The two themes disagree about how appearance is selected: VitePress puts a `dark` class on `<html>`, Forge reads `[data-theme]`. A head script mirrors one onto the other before first paint, so the mapping is written once and still follows the toggle. Verified in both directions locally: the toggle flips `data-theme` and the whole page swaps, code blocks included.

No published package changed, so no changeset.

## Checks

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `knip` green. Site assembled locally and both pages screenshotted in light and dark.