### PR TITLE
test(e2e): drive the SDK through a real Foundry v13

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,81 @@
+name: E2E
+
+# Foundry itself, in a container, running the example system and module.
+#
+# Not on `pull_request`, deliberately. The felddy image downloads a licensed
+# Foundry, so this job needs credentials, and GitHub does not hand secrets to
+# a workflow triggered from a fork. A job that cannot get them would fail on
+# every outside contribution and teach everyone to ignore a red check.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e
+  cancel-in-progress: false
+
+jobs:
+  foundry:
+    name: Foundry v13
+    runs-on: [self-hosted, linux, x64, gcp]
+    # A cold run downloads Foundry; a warm one reuses it from the host cache.
+    timeout-minutes: 30
+    env:
+      FOUNDRY_LICENSE_KEY: ${{ secrets.FOUNDRY_LICENSE_KEY }}
+      FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}
+      FOUNDRY_PASSWORD: ${{ secrets.FOUNDRY_PASSWORD }}
+      # Outside the workspace, so the licensed download survives between runs
+      # without going through the Actions cache, which a fork can read.
+      E2E_DATA_DIR: /opt/vttforge-e2e
+    steps:
+      - name: Check the credentials are configured
+        run: |
+          missing=""
+          for name in FOUNDRY_LICENSE_KEY FOUNDRY_USERNAME FOUNDRY_PASSWORD; do
+            [ -n "${!name}" ] || missing="$missing $name"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repository secrets:$missing"
+            echo "Set them with: gh secret set <NAME> --repo ${{ github.repository }}"
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '26'
+
+      - name: Activate pnpm
+        run: corepack enable && corepack prepare pnpm@11.25.0 --activate
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Install the browser
+        run: pnpm --filter @vttforge-e2e/foundry exec playwright install --with-deps chromium
+
+      - name: Run
+        run: pnpm --filter @vttforge-e2e/foundry test:e2e
+
+      - name: Foundry logs on failure
+        if: failure()
+        run: docker logs --tail 200 vttforge-e2e || true
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: apps/e2e/playwright-report/
+          retention-days: 7
+
+      - name: Stop Foundry
+        if: always()
+        run: docker rm -f vttforge-e2e || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,28 @@ For sheet or runtime work you want a real Foundry v13 with the example system lo
 
 `Ctrl+C` stops the container. `docker compose -f docker-compose.dev.yml down -v` wipes worlds and settings.
 
-Foundry credentials are personal and license-gated, so CI does not run Foundry. Each contributor smoke-tests locally.
+Foundry credentials are personal and licence-gated. They stay on your machine; never commit `.env`.
+
+## The end-to-end suite
+
+`apps/e2e` boots a real Foundry v13 in Docker with both examples installed and
+asserts what a mock cannot: that Foundry accepted the data models, that each
+sheet is filed under the id it was given, that a sheet actually draws, and that
+the module's sub-type is namespaced.
+
+```bash
+pnpm build
+pnpm --filter @vttforge-e2e/foundry test:e2e
+```
+
+It needs the same three credentials as the compose file above and stops with a
+clear message without them. `apps/e2e/README.md` explains how it boots without
+ever driving Foundry's setup screens.
+
+In CI it runs on every push to `main`, against the maintainer's licence. It
+never runs on a pull request from a fork, because GitHub does not hand secrets
+to those workflows, and a check that cannot pass is a check everyone learns to
+ignore.
 
 ## Changesets
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The **Forge theme**: warm-dark surfaces, an ember accent, a `{ d20 }` mark, a 4-
 - ✅ **Build pipeline.** One Vite config, a deployable `dist/`, a release zip
 - ✅ **CLI.** `init` with four templates, `dev`, `build`, `audit`
 - ✅ **Dev loop.** Templates, styles and language files reload in place, without a page refresh
+- ✅ **End-to-end.** Every push to `main` boots a real Foundry v13 in a container and drives the example system and module through it
 - ✅ **Design system.** Tokens, primitives, themes, brand
 - ✅ **Published.** Every package on npm under OIDC trusted publishing, with provenance
 - ✅ **Documentation.** [vttforge.dev/docs](https://vttforge.dev/docs/) carries the guide, the API reference, the recipes and the error catalogue

--- a/apps/e2e/.gitignore
+++ b/apps/e2e/.gitignore
@@ -1,0 +1,3 @@
+.foundry/
+playwright-report/
+test-results/

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -1,0 +1,45 @@
+# End-to-end: the SDK inside a real Foundry
+
+Boots Foundry v13 in Docker with `examples/simple-system` and
+`examples/simple-module` installed, joins the world as the Gamemaster, and
+asserts what only a running Foundry can answer.
+
+```bash
+cp .env.example .env      # at the repo root: your Foundry licence and login
+pnpm build
+pnpm test:e2e
+```
+
+## What it covers
+
+| Test | The claim |
+|---|---|
+| System registration | `registerSystem` put the data models, the initiative formula, the settings and the Active Effect flag where Foundry reads them |
+| Sheet keys | Each sheet is filed under `vttforge-example.<id>`, the key Foundry writes onto every document. This is the whole reason `sheets` takes an `id`, and a mock cannot prove it |
+| Sheet render | A character sheet draws its four tabs, six abilities and an inventory row, and `prepareDerivedData` produced the numbers on it |
+| Module sub-types | The module's `note` type is filed as `vttforge-example-module.note`, never as `note`, with its sheet, its enricher and its API |
+
+Any console error naming VTTForge fails the run.
+
+## How it boots
+
+Foundry's setup screens are never driven, because that is the part that would
+rot. Three plain steps replace them:
+
+1. The end-user licence is a real HTML form. One POST signs it.
+2. A world is a directory with a manifest. Writing `world.json` declares it.
+3. `Config/options.json` has a `world` field. Setting it launches that world
+   on the next start, which also creates the Gamemaster.
+
+The browser only joins a world that is already running.
+
+## Credentials
+
+The [felddy/foundryvtt](https://hub.docker.com/r/felddy/foundryvtt) image
+downloads a licensed Foundry, so it needs `FOUNDRY_LICENSE_KEY`,
+`FOUNDRY_USERNAME` and `FOUNDRY_PASSWORD`. Without them the run stops and says
+which are missing. They are personal, so this does not run on pull requests
+from forks, where secrets are not available by design.
+
+The downloaded Foundry is cached in `.foundry/container_cache`, so only the
+first run pays for it.

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@vttforge-e2e/foundry",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "e2e:up": "node -e \"import('./scripts/foundry.mjs').then(m => m.start()).then(r => console.log(r.baseUrl))\"",
+    "e2e:down": "node -e \"import('./scripts/foundry.mjs').then(m => m.stop())\""
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:"
+  }
+}

--- a/apps/e2e/playwright.config.mjs
+++ b/apps/e2e/playwright.config.mjs
@@ -1,0 +1,27 @@
+/**
+ * The end-to-end run.
+ *
+ * One worker and no retries on purpose: the tests share a single Foundry
+ * world, and a retry against a world another test has already written to
+ * proves nothing.
+ */
+import { defineConfig } from '@playwright/test';
+import { BASE_URL } from './scripts/foundry.mjs';
+
+export default defineConfig({
+  testDir: './tests',
+  globalSetup: './scripts/global-setup.mjs',
+  globalTeardown: './scripts/global-teardown.mjs',
+  workers: 1,
+  fullyParallel: false,
+  retries: 0,
+  // Booting a world and rendering a sheet is slower than a unit test, and a
+  // tight timeout here would only produce flakes.
+  timeout: 120_000,
+  reporter: process.env.CI ? [['list'], ['github']] : [['list']],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+});

--- a/apps/e2e/scripts/foundry.mjs
+++ b/apps/e2e/scripts/foundry.mjs
@@ -1,0 +1,208 @@
+/**
+ * Boot a real Foundry v13 in Docker, with the example system and module
+ * installed, and leave it sitting on the join screen.
+ *
+ * Everything here happens without touching Foundry's setup UI, which is the
+ * part that would rot. Three plain steps do it:
+ *
+ *   1. The end-user licence is a real HTML form. One POST signs it, and the
+ *      signature lands in `Config/license.json`.
+ *   2. A world is a directory with a manifest. Writing `world.json` is enough
+ *      for Foundry to know the world exists.
+ *   3. `Config/options.json` carries a `world` field. Setting it makes the
+ *      next start launch that world and create its Gamemaster.
+ *
+ * So the browser only has to join a world that is already running.
+ */
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+const CONTAINER = 'vttforge-e2e';
+const PORT = Number(process.env.E2E_PORT ?? 30001);
+export const BASE_URL = `http://localhost:${PORT}`;
+const WORLD_ID = 'e2e';
+
+/** Pinned rather than floating: a build the run does not choose is a build it cannot report. */
+const IMAGE = process.env.E2E_FOUNDRY_IMAGE ?? 'felddy/foundryvtt:13';
+
+/**
+ * Where Foundry keeps its data.
+ *
+ * Overridable because CI points it at a path on the runner host, outside the
+ * workspace. The licensed Foundry download is cached in here, and a build
+ * cache on a public repository is readable from a fork's workflow.
+ */
+const dataDir = process.env.E2E_DATA_DIR ?? join(repoRoot, 'apps/e2e/.foundry');
+
+/** The three the felddy image needs to fetch a licensed Foundry. */
+const REQUIRED_ENV = ['FOUNDRY_LICENSE_KEY', 'FOUNDRY_USERNAME', 'FOUNDRY_PASSWORD'];
+
+function docker(args, options = {}) {
+  return execFileSync('docker', args, { encoding: 'utf8', ...options });
+}
+
+async function waitFor(label, check, { attempts = 90, everyMs = 2000 } = {}) {
+  for (let i = 0; i < attempts; i += 1) {
+    if (await check()) return;
+    await new Promise((resolve) => setTimeout(resolve, everyMs));
+  }
+  throw new Error(`Timed out waiting for ${label} after ${(attempts * everyMs) / 1000}s`);
+}
+
+async function answers() {
+  try {
+    // `redirect: 'manual'` because every Foundry route redirects somewhere;
+    // any answer at all means the server is up.
+    await fetch(BASE_URL, { redirect: 'manual' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Where Foundry is redirecting to, which is how it reports which stage it is at. */
+async function stage() {
+  const response = await fetch(BASE_URL, { redirect: 'manual' });
+  return response.headers.get('location') ?? response.url;
+}
+
+function installPackage(kind, id, from) {
+  const to = join(dataDir, 'Data', kind, id);
+  rmSync(to, { recursive: true, force: true });
+  cpSync(from, to, { recursive: true });
+  return JSON.parse(
+    readFileSync(join(to, kind === 'systems' ? 'system.json' : 'module.json'), 'utf8'),
+  );
+}
+
+function writeWorld(system) {
+  const worldDir = join(dataDir, 'Data', 'worlds', WORLD_ID);
+  mkdirSync(worldDir, { recursive: true });
+  writeFileSync(
+    join(worldDir, 'world.json'),
+    `${JSON.stringify(
+      {
+        id: WORLD_ID,
+        title: 'VTTForge end-to-end',
+        description: 'Created by the end-to-end test. Thrown away with the run.',
+        system: system.id,
+        systemVersion: system.version,
+        coreVersion: process.env.E2E_CORE_VERSION ?? '13.351',
+        version: '1.0.0',
+        compatibility: { minimum: '13', verified: '13' },
+        authors: [],
+        packs: [],
+        relationships: {},
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function selectWorld() {
+  const file = join(dataDir, 'Config', 'options.json');
+  const options = JSON.parse(readFileSync(file, 'utf8'));
+  options.world = WORLD_ID;
+  writeFileSync(file, `${JSON.stringify(options, null, 2)}\n`);
+}
+
+export function stop() {
+  try {
+    docker(['rm', '-f', CONTAINER], { stdio: 'ignore' });
+  } catch {
+    // Not running. Nothing to stop.
+  }
+}
+
+export async function start() {
+  const missing = REQUIRED_ENV.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Cannot boot Foundry without ${missing.join(', ')}. Copy .env.example to .env, or set them in the environment.`,
+    );
+  }
+
+  stop();
+  // The data directory is disposable, but the downloaded Foundry inside it is
+  // not: keeping `container_cache` turns a two-minute download into a restart.
+  rmSync(join(dataDir, 'Data'), { recursive: true, force: true });
+  rmSync(join(dataDir, 'Config'), { recursive: true, force: true });
+  mkdirSync(dataDir, { recursive: true });
+
+  docker([
+    'run',
+    '-d',
+    '--name',
+    CONTAINER,
+    // felddy's entrypoint chowns the volume on first boot, then drops privileges.
+    '-u',
+    '0:0',
+    '-p',
+    `${PORT}:30000`,
+    '-e',
+    'FOUNDRY_LICENSE_KEY',
+    '-e',
+    'FOUNDRY_USERNAME',
+    '-e',
+    'FOUNDRY_PASSWORD',
+    '-e',
+    'FOUNDRY_ADMIN_KEY=vttforge-e2e',
+    '-e',
+    'CONTAINER_PRESERVE_CONFIG=true',
+    '-v',
+    `${dataDir}:/data`,
+    IMAGE,
+  ]);
+
+  await waitFor('Foundry to answer', answers, { attempts: 150 });
+
+  // 1. Sign the licence. Until this is done every route redirects to /license.
+  await fetch(`${BASE_URL}/license`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ agree: 'on', accept: '' }),
+    redirect: 'manual',
+  });
+  await waitFor('the licence to be signed', async () => !(await stage()).endsWith('/license'));
+
+  // 2. Install what is under test, and declare a world on it.
+  const system = installPackage(
+    'systems',
+    'vttforge-example',
+    join(repoRoot, 'examples/simple-system/dist'),
+  );
+  installPackage(
+    'modules',
+    'vttforge-example-module',
+    join(repoRoot, 'examples/simple-module/dist'),
+  );
+  writeWorld(system);
+  selectWorld();
+
+  // 3. Restart into it. Foundry refuses to start over its own lock file, and
+  // stopping the container does not always clear it.
+  docker(['stop', CONTAINER]);
+  // The lock is a directory, not a file.
+  rmSync(join(dataDir, 'Config', 'options.json.lock'), { recursive: true, force: true });
+  docker(['start', CONTAINER]);
+
+  await waitFor('Foundry to answer again', answers, { attempts: 150 });
+  await waitFor('the world to launch', async () => (await stage()).endsWith('/join'));
+
+  return { baseUrl: BASE_URL, system };
+}
+
+export function logs(tail = 40) {
+  try {
+    return docker(['logs', '--tail', String(tail), CONTAINER], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    return '(no container logs)';
+  }
+}

--- a/apps/e2e/scripts/global-setup.mjs
+++ b/apps/e2e/scripts/global-setup.mjs
@@ -1,0 +1,13 @@
+/** Boot Foundry once for the whole run. */
+import { logs, start } from './foundry.mjs';
+
+export default async function globalSetup() {
+  try {
+    const { baseUrl, system } = await start();
+    console.log(`[e2e] Foundry is up at ${baseUrl} running ${system.id}@${system.version}`);
+  } catch (error) {
+    console.error('[e2e] Foundry did not come up.');
+    console.error(logs());
+    throw error;
+  }
+}

--- a/apps/e2e/scripts/global-teardown.mjs
+++ b/apps/e2e/scripts/global-teardown.mjs
@@ -1,0 +1,10 @@
+/** Take the container down, unless someone is debugging and asked to keep it. */
+import { stop } from './foundry.mjs';
+
+export default function globalTeardown() {
+  if (process.env.E2E_KEEP_FOUNDRY === '1') {
+    console.log('[e2e] E2E_KEEP_FOUNDRY=1, leaving the container running.');
+    return;
+  }
+  stop();
+}

--- a/apps/e2e/tests/system.spec.mjs
+++ b/apps/e2e/tests/system.spec.mjs
@@ -1,0 +1,153 @@
+/**
+ * What the SDK does inside a real Foundry.
+ *
+ * Everything here is a claim the unit tests cannot make. They run against a
+ * mocked `foundry` global, so they prove the SDK calls the right things; only
+ * a real world proves Foundry accepted them.
+ *
+ * The one that matters most is the sheet key. `registerSheets` pins a class
+ * name so the key Foundry persists survives a rebuild, and until now nothing
+ * had ever read that key back out of a running Foundry.
+ */
+import { expect, test } from '@playwright/test';
+import { BASE_URL } from '../scripts/foundry.mjs';
+
+/** Foundry refuses to lay out below 1024x700 and says so in a banner. */
+test.use({ viewport: { width: 1600, height: 1000 } });
+
+/** Console errors are collected for the whole file: a stray one fails the run. */
+const consoleErrors = [];
+
+test.beforeEach(async ({ page }) => {
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  page.on('pageerror', (error) => consoleErrors.push(String(error)));
+});
+
+/** Join as the Gamemaster the world created on launch, and wait for `ready`. */
+async function joinWorld(page) {
+  await page.goto(`${BASE_URL}/join`);
+  await page.waitForSelector('select[name=userid]');
+  await page.selectOption('select[name=userid]', { label: 'Gamemaster' });
+  await page.click('button[name=join]');
+  await page.waitForURL('**/game');
+  await page.waitForFunction(() => globalThis.game?.ready === true, null, { timeout: 60_000 });
+}
+
+test('the system registers everything registerSystem was given', async ({ page }) => {
+  await joinWorld(page);
+
+  const registered = await page.evaluate(() => ({
+    system: game.system.id,
+    actorModels: Object.keys(CONFIG.Actor.dataModels ?? {}),
+    itemModels: Object.keys(CONFIG.Item.dataModels ?? {}),
+    initiative: CONFIG.Combat.initiative?.formula,
+    legacyTransferral: CONFIG.ActiveEffect.legacyTransferral,
+    settings: [...game.settings.settings.keys()].filter((key) =>
+      key.startsWith('vttforge-example.'),
+    ),
+  }));
+
+  expect(registered.system).toBe('vttforge-example');
+  expect(registered.actorModels).toContain('character');
+  expect(registered.itemModels).toContain('gear');
+  expect(registered.initiative).toBe('1d20 + @abilities.dex.mod');
+  // registerSystem turns this off by default; a system that still has it on
+  // gets Active Effects applied twice.
+  expect(registered.legacyTransferral).toBe(false);
+  expect(registered.settings).toEqual(
+    expect.arrayContaining(['vttforge-example.showTutorial', 'vttforge-example.schemaVersion']),
+  );
+});
+
+test('each sheet is filed under the id it was given, not its class name', async ({ page }) => {
+  await joinWorld(page);
+
+  const keys = await page.evaluate(() => ({
+    character: Object.keys(CONFIG.Actor.sheetClasses?.character ?? {}),
+    gear: Object.keys(CONFIG.Item.sheetClasses?.gear ?? {}),
+  }));
+
+  // This is the key Foundry writes to `flags.core.sheetClass` on every
+  // document whose owner picks the sheet. It is derived from the class name,
+  // which a minifier renames between builds, so the whole point of passing an
+  // `id` is that these two strings never move.
+  expect(keys.character).toContain('vttforge-example.character');
+  expect(keys.gear).toContain('vttforge-example.gear');
+});
+
+test('a character sheet renders its parts and its derived data', async ({ page }) => {
+  await joinWorld(page);
+
+  const sheet = await page.evaluate(async () => {
+    const actor = await Actor.create({ name: 'End-to-end Hero', type: 'character' });
+    await actor.createEmbeddedDocuments('Item', [
+      { name: 'Rope', type: 'gear', system: { quantity: 2, kind: 'stowed' } },
+    ]);
+    await actor.sheet.render(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const element = actor.sheet.element;
+    return {
+      sheetClassName: actor.sheet.constructor.name,
+      tabs: [...element.querySelectorAll('section.tab')].map((section) => section.dataset.tab),
+      abilities: element.querySelectorAll('[data-ability]').length,
+      gearRows: element.querySelectorAll('[data-item-id]').length,
+      derived: {
+        armorClass: actor.system.armorClass,
+        initiative: actor.system.initiative,
+        healthMax: actor.system.health.max,
+        strMod: actor.system.abilities.str.mod,
+      },
+    };
+  });
+
+  // The class reports the pinned name even in the bundled build.
+  expect(sheet.sheetClassName).toBe('character');
+  expect(sheet.tabs).toEqual(['abilities', 'inventory', 'spells', 'biography']);
+  expect(sheet.abilities).toBe(6);
+  expect(sheet.gearRows).toBe(1);
+  // prepareDerivedData ran: 10 + the dex modifier of a default 10.
+  expect(sheet.derived.armorClass).toBe(10);
+  expect(sheet.derived.initiative).toBe(0);
+  // 10 + level 1 + the con modifier.
+  expect(sheet.derived.healthMax).toBe(11);
+  expect(sheet.derived.strMod).toBe(0);
+});
+
+test('the module contributes a namespaced sub-type once enabled', async ({ page }) => {
+  await joinWorld(page);
+
+  // A module's sub-types are filed under `<module id>.<type>`; the bare name
+  // never appears. Enabling it needs a world reload to take effect.
+  await page.evaluate(async () => {
+    const settings = game.settings.get('core', 'moduleConfiguration');
+    await game.settings.set('core', 'moduleConfiguration', {
+      ...settings,
+      'vttforge-example-module': true,
+    });
+  });
+
+  await joinWorld(page);
+
+  const contributed = await page.evaluate(() => ({
+    itemModels: Object.keys(CONFIG.Item.dataModels ?? {}),
+    sheets: Object.keys(CONFIG.Item.sheetClasses?.['vttforge-example-module.note'] ?? {}),
+    enrichers: (CONFIG.TextEditor.enrichers ?? []).map((entry) => entry.id).filter(Boolean),
+    api: typeof game.modules.get('vttforge-example-module')?.api?.createNote,
+  }));
+
+  expect(contributed.itemModels).toContain('vttforge-example-module.note');
+  expect(contributed.itemModels).not.toContain('note');
+  expect(contributed.sheets).toContain('vttforge-example-module.note');
+  expect(contributed.enrichers).toContain('vttforge-example-module.note');
+  expect(contributed.api).toBe('function');
+});
+
+test.afterAll(() => {
+  // Foundry logs a few of its own errors that have nothing to do with us
+  // (a missing favicon, an audio context the browser blocks). Only ours fail.
+  const ours = consoleErrors.filter((line) => /vttforge|VTTF-\d{4}/i.test(line));
+  expect(ours, `console errors naming VTTForge:\n${ours.join('\n')}`).toEqual([]);
+});

--- a/biome.json
+++ b/biome.json
@@ -61,7 +61,7 @@
   },
   "overrides": [
     {
-      "includes": ["scripts/**", "**/scripts/**"],
+      "includes": ["scripts/**", "apps/*/scripts/**"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/biome.json
+++ b/biome.json
@@ -61,7 +61,7 @@
   },
   "overrides": [
     {
-      "includes": ["scripts/**"],
+      "includes": ["scripts/**", "**/scripts/**"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/knip.json
+++ b/knip.json
@@ -33,6 +33,9 @@
         "typedoc-vitepress-theme",
         "@vttforge/styles"
       ]
+    },
+    "apps/e2e": {
+      "entry": ["tests/*.spec.mjs"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@clack/prompts':
       specifier: ^1.7.0
       version: 1.7.0
+    '@playwright/test':
+      specifier: ^1.62.1
+      version: 1.62.1
     '@types/archiver':
       specifier: ^8.0.0
       version: 8.0.0
@@ -132,6 +135,12 @@ importers:
       vitepress:
         specifier: 'catalog:'
         version: 1.6.4(@algolia/client-search@5.57.0)(@types/node@26.4.0)(change-case@5.4.4)(jiti@2.7.0)(lightningcss@1.33.0)(postcss@8.5.26)(search-insights@2.17.3)(typescript@6.0.3)(yaml@2.9.0)
+
+  apps/e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.62.1
 
   apps/web:
     dependencies:
@@ -1255,6 +1264,11 @@ packages:
     resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@pnpm/deps.graph-sequencer@1100.0.1':
     resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
@@ -2449,6 +2463,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3015,6 +3034,16 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4614,6 +4643,10 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@pnpm/deps.graph-sequencer@1100.0.1': {}
 
   '@publint/pack@0.1.7':
@@ -5594,6 +5627,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6175,6 +6211,14 @@ snapshots:
   picomatch@4.0.7: {}
 
   pify@4.0.1: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'apps/*'
 
 catalog:
+  '@playwright/test': ^1.62.1
   vitepress: ^1.6.4
   '@arethetypeswrong/cli': ^0.18.5
   '@biomejs/biome': ^2.5.11


### PR DESCRIPTION
## Why

The unit suite runs against a mocked `foundry` global. It proves the SDK calls the right things; only a running Foundry proves Foundry accepted them. One claim in particular had never been checked anywhere: `registerSheets` pins a class name so the key Foundry persists survives a rebuild, and nothing had ever read that key back out of a real world.

## What it asserts

| Test | The claim |
|---|---|
| System registration | Foundry has the data models, the initiative formula, the settings, and `legacyTransferral` off |
| Sheet keys | Each sheet is filed under `vttforge-example.<id>`, the string Foundry writes onto every document that uses it |
| Sheet render | A character sheet draws its four tabs, six abilities and an inventory row, and `prepareDerivedData` produced the numbers on it |
| Module sub-types | The module's type is filed as `vttforge-example-module.note` and never as `note`, with its sheet, its enricher and its API |

Any console error naming VTTForge fails the run.

## How it boots

Foundry's setup screens are never driven, because that is the part that would rot. Three plain steps replace them:

1. The end-user licence is a real HTML form. One POST signs it.
2. A world is a directory with a manifest. Writing `world.json` declares it.
3. `Config/options.json` carries a `world` field. Setting it launches that world on the next start, which also creates the Gamemaster.

The browser only joins a world that is already running. One wrinkle worth knowing: Foundry refuses to start over its own lock, and stopping the container does not always clear it, so the harness removes it between the two starts.

## CI

`on: push: branches: [main]` and `workflow_dispatch`. Deliberately **not** on `pull_request`: the felddy image downloads a licensed Foundry, so the job needs credentials, and GitHub does not hand secrets to a workflow triggered from a fork. A job that cannot pass on outside contributions is a red check everyone learns to ignore.

The licensed download is cached at `/opt/vttforge-e2e` on the runner host rather than in the Actions cache, which a fork's workflow can read.

The job fails with a clear message until three repository secrets exist: `FOUNDRY_LICENSE_KEY`, `FOUNDRY_USERNAME`, `FOUNDRY_PASSWORD`.

## Verified

Ran locally against Foundry 13.351: four tests pass in 35s after boot. Also verified the suite is not vacuous, by asserting the wrong sheet key and watching it fail with the real one (`vttforge-example.character`) in the diff.

`pnpm lint`, `pnpm typecheck`, `pnpm test`, `knip` green.