### PR TITLE
docs: a transparency page

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -94,6 +94,7 @@ export default defineConfig({
       { text: 'API', link: '/reference/' },
       { text: 'Errors', link: '/errors/' },
       { text: 'Stability', link: '/stability' },
+      { text: 'Transparency', link: '/transparency' },
       // Absolute, because a root-relative link would be prefixed with the
       // `/docs/` base and point back into the docs.
       { text: 'Design System', link: 'https://vttforge.dev/design-system' },

--- a/apps/docs/stability.md
+++ b/apps/docs/stability.md
@@ -70,6 +70,11 @@ Every package targets **Foundry v13+**. v12 is an explicit non-goal: the v13
 application and data-model APIs are what the SDK is built on, and supporting
 both would mean shipping the older shape forever.
 
+## How this is checked
+
+What every change passes before it ships, and what the SDK does and does not
+do on your machine, is on the [transparency page](/transparency).
+
 ## Peer dependencies
 
 `@vttforge/vite-plugin` peers on `vite`. Nothing else declares a peer, and

--- a/apps/docs/transparency.md
+++ b/apps/docs/transparency.md
@@ -1,0 +1,95 @@
+---
+title: Transparency
+---
+
+# Transparency
+
+VTTForge is two halves. One runs inside Foundry, in your players' browsers. The
+other runs on your own machine, in your terminal. They deserve different
+answers.
+
+## What runs inside Foundry
+
+`@vttforge/core`, `@vttforge/styles` and `@vttforge/dev-module` are what a
+system or module built on VTTForge ships to a world.
+
+**No network calls.** None of these packages calls out. There is no telemetry,
+no analytics, no version check, no phone-home, because there is no code in them
+that can make a request. The one exception is deliberate and local: while
+`vttforge dev` is running, the companion module opens a WebSocket to
+`localhost` (or `host.docker.internal` when Foundry is in a container) to hear
+that a file changed. It is never installed in a world you publish.
+
+**No third-party runtime dependencies.** `styles`, `testing`, `types`,
+`vite-plugin` and `dev-module` have none at all. `core` has one,
+`@vttforge/types`, which is types only and disappears at build time.
+
+**Nothing about your world is read or sent.** The SDK registers your data
+models, your sheets and your settings with Foundry and then gets out of the
+way. It does not inspect your actors, your players, or your compendia.
+
+## What runs on your machine
+
+`@vttforge/cli` is a different kind of trust. It is a program you run in your
+terminal, so here is everything it touches.
+
+| It does | Where |
+|---|---|
+| Writes the project it scaffolds | The directory you named |
+| Remembers where Foundry keeps its data | `<project>/.vttforge/config.json` |
+| Creates a symlink to your build | `<Foundry data>/Data/systems/<id>` or `modules/<id>` |
+| Runs Vite | Your project |
+| Serves the hot-reload bridge | `localhost:31313`, while `dev` is running |
+| Writes a release zip | Your project root |
+
+It makes no network requests of its own. The one time anything is downloaded is
+when `init` installs dependencies, and that is your own package manager,
+running the command you approved.
+
+## How it is published
+
+Every package goes to npm through OIDC trusted publishing, with a provenance
+attestation tying the tarball to the commit and the workflow that built it.
+Nothing is published from a laptop, and no long-lived npm token exists to leak.
+You can check any version yourself:
+
+```bash
+npm audit signatures
+```
+
+## How it is built
+
+I write VTTForge with the help of AI coding agents. That is worth saying
+plainly rather than leaving for someone to notice.
+
+What decides whether a change ships is not who typed it. Every change, mine or
+an agent's, goes through a pull request and has to pass the same gates:
+
+| Gate | What it does |
+|---|---|
+| Typecheck | TypeScript strict across every package |
+| Tests | 664 of them |
+| Lint | Biome, plus a dependency-version check and a check that the scaffolding templates pin versions that exist |
+| Dead code | Unused exports and dependencies fail the build |
+| Package quality | `publint` and `attw`, so the published shape is correct |
+| A real Foundry | Every push to `main` boots Foundry v13 in a container, installs the example system and module, joins a world, and drives them. Any console error naming VTTForge fails it |
+
+That last one is the one I care about most. The unit tests run against a mocked
+Foundry, so they prove the SDK calls the right things. Only a running Foundry
+proves Foundry accepted them.
+
+I read what ships and I merge it. No agent merges its own work or publishes a
+release.
+
+Being honest about the gaps, since a list of gates is only worth what it leaves
+out: there are no staged release channels, no visual regression captures, and
+the end-to-end run covers v13 only. Every package is below 1.0, and a minor may
+break you. The [stability policy](/stability) says exactly how much.
+
+## If you would rather not
+
+Some people prefer not to build on AI-assisted software, and that is a
+reasonable line to draw. Nothing here is hidden: the repository is public,
+every change went through a pull request you can read, and the packages carry
+provenance back to the commit that built them. Pin a version and stay on it, or
+read the code before you install it.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -415,6 +415,7 @@
               <li><a href="/docs/reference/">API reference</a></li>
               <li><a href="/docs/errors/">Error codes</a></li>
               <li><a href="/docs/recipes/">Recipes</a></li>
+              <li><a href="/docs/transparency">Transparency</a></li>
               <li><a href="/design-system">Design System</a></li>
             </ul>
           </div>


### PR DESCRIPTION
## What

A `/docs/transparency` page answering two questions on their own page rather than in a footnote.

**What the SDK does on your machine and in your world.** This is the half with real value, and an SDK deserves a different answer from a module. What runs inside Foundry makes no outbound request at all, and everything except `core` has zero third-party runtime dependencies. What runs in your terminal is a program you invoke, so the page lists everything the CLI touches: the scaffolded project, `.vttforge/config.json`, the symlink into your Foundry data directory, Vite, `localhost:31313` while `dev` runs, and the release zip. The only download is your own package manager during `init`.

Every claim was checked against the source before writing it, including the dev module's WebSocket target and the runtime dependency of each package.

**That it is written with AI coding agents.** Said plainly, with the gates that actually exist: typecheck, 664 tests, Biome plus the version and template-pin checks, knip, publint, attw, and the real Foundry v13 run on every push to `main`. And the gaps, because a list of gates is worth what it leaves out: no staged release channels, no visual regression captures, v13 only.

The page is in the first person. It says "I read what ships and I merge it", which is a claim only the maintainer can make, and it was reviewed before writing.

## Wiring

Docs nav next to Stability, the landing page's footer Documentation column, and a pointer from the stability page.

## Checks

`vitepress build` green with no dead links, `pnpm lint` green, no em dashes.