### PR TITLE
fix(testing): declare the Foundry globals with var, so consumers can too

### DIFF
--- a/.changeset/globals-that-can-coexist.md
+++ b/.changeset/globals-that-can-coexist.md
@@ -1,0 +1,6 @@
+---
+"@vttforge/testing": patch
+"@vttforge/cli": patch
+---
+
+Declare the Foundry globals with `var` so a consumer's own declarations can coexist. A package that adds `@vttforge/testing` to a typechecked project already declares `foundry`, `game`, `CONFIG`, `Hooks` and `ui` for its own source, and two `declare global` blocks only merge when both use `var`. With `const` on either side `tsc` stopped with `TS2451: Cannot redeclare block-scoped variable`, which is what a real consumer hit the first time it tried to typecheck its tests. The scaffolding templates are corrected the same way.

--- a/examples/simple-module/scripts/foundry-globals.d.ts
+++ b/examples/simple-module/scripts/foundry-globals.d.ts
@@ -9,21 +9,26 @@
  * `@vttforge/types`' job; what this file exists to do is stop "Cannot find
  * name 'game'" from drowning out the errors that actually matter.
  */
+/**
+ * `var`, not `const`. Two `declare global` blocks naming the same global have
+ * to merge, and only `var` merges. A `const` here collides with the identical
+ * declaration `@vttforge/testing` ships, and `tsc` stops with TS2451.
+ */
 declare global {
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const game: any;
+  var game: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const CONFIG: any;
+  var CONFIG: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const Hooks: any;
+  var Hooks: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const ui: any;
+  var ui: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const ChatMessage: any;
+  var ChatMessage: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const Roll: any;
+  var Roll: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const foundry: any;
+  var foundry: any;
 }
 
 export {};

--- a/examples/simple-system/scripts/foundry-globals.d.ts
+++ b/examples/simple-system/scripts/foundry-globals.d.ts
@@ -9,21 +9,26 @@
  * `@vttforge/types`' job; what this file exists to do is stop "Cannot find
  * name 'game'" from drowning out the errors that actually matter.
  */
+/**
+ * `var`, not `const`. Two `declare global` blocks naming the same global have
+ * to merge, and only `var` merges. A `const` here collides with the identical
+ * declaration `@vttforge/testing` ships, and `tsc` stops with TS2451.
+ */
 declare global {
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const game: any;
+  var game: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const CONFIG: any;
+  var CONFIG: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const Hooks: any;
+  var Hooks: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const ui: any;
+  var ui: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const ChatMessage: any;
+  var ChatMessage: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const Roll: any;
+  var Roll: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const foundry: any;
+  var foundry: any;
 }
 
 export {};

--- a/packages/cli/templates/module-ts/scripts/foundry-globals.ts
+++ b/packages/cli/templates/module-ts/scripts/foundry-globals.ts
@@ -7,17 +7,22 @@
  * VTTForge release) for full type coverage.
  */
 
+/**
+ * `var`, not `const`. Two `declare global` blocks naming the same global have
+ * to merge, and only `var` merges. A `const` here collides with the identical
+ * declaration `@vttforge/testing` ships, and `tsc` stops with TS2451.
+ */
 declare global {
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const game: any;
+  var game: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const CONFIG: any;
+  var CONFIG: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const Hooks: any;
+  var Hooks: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const ui: any;
+  var ui: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const foundry: any;
+  var foundry: any;
 }
 
 export {};

--- a/packages/cli/templates/system-ts/scripts/foundry-globals.ts
+++ b/packages/cli/templates/system-ts/scripts/foundry-globals.ts
@@ -13,21 +13,26 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+/**
+ * `var`, not `const`. Two `declare global` blocks naming the same global have
+ * to merge, and only `var` merges. A `const` here collides with the identical
+ * declaration `@vttforge/testing` ships, and `tsc` stops with TS2451.
+ */
 declare global {
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const game: any;
+  var game: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const CONFIG: any;
+  var CONFIG: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const Hooks: any;
+  var Hooks: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const ui: any;
+  var ui: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const ChatMessage: any;
+  var ChatMessage: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const Roll: any;
+  var Roll: any;
   // biome-ignore lint/suspicious/noExplicitAny: stub declarations only
-  const foundry: any;
+  var foundry: any;
 }
 
 export {};

--- a/packages/testing/src/vitest/index.ts
+++ b/packages/testing/src/vitest/index.ts
@@ -26,17 +26,28 @@ export {
   withMockFoundry,
 } from './with-mock-foundry.js';
 
+/**
+ * `var`, not `const`, and that is the whole point.
+ *
+ * A package that consumes this already declares these globals for its own
+ * source, because the SDK does not ship a Foundry runtime type. Two
+ * `declare global` blocks naming the same thing have to merge, and only
+ * `var` merges: `const` is block-scoped, so a second one is a redeclaration
+ * and `tsc` stops with TS2451. Consumers hit that the moment they add the
+ * test helpers to a typechecked project, which is the moment they most want
+ * them.
+ */
 declare global {
   // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
-  const foundry: any;
+  var foundry: any;
   // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
-  const game: any;
+  var game: any;
   // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
-  const CONFIG: any;
+  var CONFIG: any;
   // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
-  const Hooks: any;
+  var Hooks: any;
   // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
-  const ui: any;
+  var ui: any;
   // biome-ignore lint/suspicious/noExplicitAny: the Foundry surface is typed elsewhere
-  const CONST: any;
+  var CONST: any;
 }


### PR DESCRIPTION
## What broke

Adding `@vttforge/testing` to a project that typechecks its tests fails:

```
scripts/foundry-globals.ts(12,9): error TS2451: Cannot redeclare block-scoped variable 'game'.
scripts/foundry-globals.ts(14,9): error TS2451: Cannot redeclare block-scoped variable 'CONFIG'.
```

`@vttforge/testing/vitest` declares `foundry`, `game`, `CONFIG`, `Hooks`, `ui` and `CONST` so a test can name them. A consumer already declares the same globals for its own source, because the SDK ships no Foundry runtime type and the scaffolding templates hand them a `foundry-globals.ts` that does exactly this. Two `declare global` blocks naming the same thing have to merge, and `const` is block-scoped: the second one is a redeclaration.

Found by the first consumer that tried, which is the module this SDK was built against. It had to leave its tests out of `pnpm typecheck`.

## The fix

`var`, which is the idiom for a global declaration precisely because it merges. Applied to the testing package, both TypeScript templates, and both examples, since a scaffolded project inherits the same file.

## Verified

Checked the TypeScript behaviour directly rather than assuming, with two files declaring the same global:

| Combination | Result |
|---|---|
| `var` + `var` | merges, `tsc` clean |
| `var` + `const` | `TS2451` on both |

Then against the real consumer: built this branch's `@vttforge/testing`, installed it in the module, added its tests to `tsconfig.json`. Typecheck clean. Flipping only the module's own file back to `const` brings the five errors straight back, so the test is not vacuous.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm build`, `knip` green.