### PR TITLE
feat(cli): audit the two failures that ship silently

### DIFF
--- a/.changeset/audit-the-two-silent-ones.md
+++ b/.changeset/audit-the-two-silent-ones.md
@@ -1,0 +1,9 @@
+---
+"@vttforge/cli": minor
+---
+
+`vttforge audit` gains two rules, both for failures a real module shipped.
+
+`VTTF-AUDIT-008` (HIGH) flags a sheet template that opens its own `<form>`. `BaseActorSheet` and `BaseItemSheet` set `tag: 'form'`, so the application element already is one, and a nested form owns the fields inside it: the submit reads the outer element, finds nothing, and every edit is dropped when the window closes. No error, no warning. It only looks at templates those two bases name in their `PARTS`, so a `BaseApplication` that legitimately builds a form is left alone.
+
+`VTTF-AUDIT-009` (MEDIUM) flags a subtype declared in `documentTypes` with no `TYPES` label. Foundry prints the raw key instead, so the sheet is titled `TYPES.Item.my-module.note` and the Create dialog offers the same string in its type dropdown. A label written nested or flattened both count, because Foundry reads both.

--- a/.changeset/sheets-that-actually-save.md
+++ b/.changeset/sheets-that-actually-save.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/cli": patch
+---
+
+The scaffolding sheet templates no longer open a `<form>` the sheet already is. `BaseActorSheet` and `BaseItemSheet` set `tag: 'form'`, so the application element is the form; the nested one owned every field inside it, and the submit read the outer element and found nothing. A scaffolded project's sheets accepted every edit and dropped it when the window closed, with no error. Found by the new `VTTF-AUDIT-008`, which reported it against all four templates the first time it ran.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -68,10 +68,15 @@ quietly: nothing in the console, a feature that just does not work.
 | `VTTF-AUDIT-005` | MEDIUM | A `TypeDataModel` without `prepareBaseData`; Active Effects apply between it and `prepareDerivedData` |
 | `VTTF-AUDIT-006` | LOW | An `_addDataFieldMigrations` override; the signature is not what it looks like |
 | `VTTF-AUDIT-007` | MEDIUM | `primaryTokenAttribute` / `secondaryTokenAttribute` not pointing at a `{ value, max }` field; the token bar degrades with no error |
+| `VTTF-AUDIT-008` | HIGH | A sheet template that opens its own `<form>` when the sheet base already is one; the fields belong to the inner form and every edit is dropped on close |
+| `VTTF-AUDIT-009` | MEDIUM | A subtype declared in `documentTypes` with no `TYPES` label; Foundry prints the raw key as the type's name |
 
 Rules 004 and 007 read the schema whether it is a `static defineSchema()` or
 a function handed to `BaseTypeDataModel`, and scope it to the class
-registered for that document.
+registered for that document. Rule 008 only looks at templates a
+`BaseActorSheet` or `BaseItemSheet` names in its `PARTS`, since those are the
+bases that set `tag: 'form'`. Rule 009 accepts a label written either nested
+or flattened, because Foundry reads both.
 
 The exit code is non-zero on a HIGH finding. `--strict` makes any finding
 fail, for CI. `--json` prints the report as data.

--- a/examples/simple-module/templates/item/note-sheet.hbs
+++ b/examples/simple-module/templates/item/note-sheet.hbs
@@ -1,5 +1,11 @@
 {{!-- Note sheet — one part, no tabs. --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   <header class="sheet-header">
     <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
@@ -31,4 +37,4 @@
     </footer>
   </section>
 
-</form>
+</div>

--- a/examples/simple-system/templates/actor/character-sheet.hbs
+++ b/examples/simple-system/templates/actor/character-sheet.hbs
@@ -9,7 +9,13 @@
   `<img data-edit="img">` is handled by DocumentSheetV2's built-in editImage
   action. `<prose-mirror>` is the v13 rich text element for biography.
 --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   {{!-- ════════ HEAD (.sh-head) ════════ --}}
   <div class="sh-head">
@@ -165,4 +171,4 @@
     <span>@vttforge/styles · v0.2</span>
   </footer>
 
-</form>
+</div>

--- a/examples/simple-system/templates/item/gear-sheet.hbs
+++ b/examples/simple-system/templates/item/gear-sheet.hbs
@@ -1,5 +1,11 @@
 {{!-- Gear sheet — minimal demo of BaseItemSheet on ItemSheetV2. --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   <header class="sheet-header">
     <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
@@ -51,4 +57,4 @@
     </section>
   </section>
 
-</form>
+</div>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,7 +22,7 @@ vttforge audit [dir] [--json] [--strict]
 
 **`build`** runs the production build and writes `<id>-<version>.zip` at the project root with the manifest at the top level, which is what foundryvtt.com expects. `LICENSE`, `README.md` and `CHANGELOG.md` go in when present.
 
-**`audit`** checks the manifest and source against seven v13 breakages that fail quietly: the `flags.hotReload` shape, deprecated grid fields, the v12 `styles` shape, `HTMLField`/`FilePathField` paths missing from `documentTypes`, `TypeDataModel` without `prepareBaseData`, a bad `_addDataFieldMigrations` override, and token attributes that do not point at a `{ value, max }` field. `--json` for machines; `--strict` exits non-zero on any finding rather than only on HIGH.
+**`audit`** checks the manifest, the source and the templates against nine v13 breakages that fail quietly: the `flags.hotReload` shape, deprecated grid fields, the v12 `styles` shape, `HTMLField`/`FilePathField` paths missing from `documentTypes`, `TypeDataModel` without `prepareBaseData`, a bad `_addDataFieldMigrations` override, token attributes that do not point at a `{ value, max }` field, a sheet template that opens a `<form>` the sheet already is, and a declared subtype with no name in any language file. `--json` for machines; `--strict` exits non-zero on any finding rather than only on HIGH.
 
 ## As a library
 

--- a/packages/cli/src/__tests__/audit/manifest-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/manifest-rules.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -283,5 +283,86 @@ describe('runManifestRules', () => {
       );
       expect(await runManifestRules(cwd)).toEqual([]);
     });
+  });
+});
+
+describe('VTTF-AUDIT-009 — a declared subtype with no name', () => {
+  /** A module with one subtype, and whatever language file the test wants. */
+  async function project(languages: Record<string, unknown> | null): Promise<string> {
+    const dir = mkdtempSync(join(tmpdir(), 'vttforge-audit-types-'));
+    await writeFile(
+      join(dir, 'module.json'),
+      JSON.stringify({
+        id: 'my-module',
+        version: '1.0.0',
+        documentTypes: { Item: { note: { htmlFields: ['body'] } } },
+        languages: [{ lang: 'en', name: 'English', path: 'lang/en.json' }],
+      }),
+      'utf8',
+    );
+    if (languages !== null) {
+      await mkdir(join(dir, 'lang'), { recursive: true });
+      await writeFile(join(dir, 'lang', 'en.json'), JSON.stringify(languages), 'utf8');
+    }
+    return dir;
+  }
+
+  it('flags a subtype no language file names', async () => {
+    const dir = await project({ MY_MODULE: { Hello: 'Hi' } });
+    const found = (await runManifestRules(dir)).filter((r) => r.ruleId === 'VTTF-AUDIT-009');
+    expect(found).toHaveLength(1);
+    expect(found[0]?.severity).toBe('MEDIUM');
+    // The key carries the module id, which is the part people get wrong.
+    expect(found[0]?.message).toContain('TYPES.Item.my-module.note');
+    expect(found[0]?.remediation).toContain('"my-module"');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('accepts the nested form', async () => {
+    const dir = await project({ TYPES: { Item: { 'my-module': { note: 'Note' } } } });
+    expect((await runManifestRules(dir)).filter((r) => r.ruleId === 'VTTF-AUDIT-009')).toEqual([]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('accepts the flattened form, which Foundry also reads', async () => {
+    const dir = await project({ 'TYPES.Item.my-module.note': 'Note' });
+    expect((await runManifestRules(dir)).filter((r) => r.ruleId === 'VTTF-AUDIT-009')).toEqual([]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('accepts a half-flattened form', async () => {
+    const dir = await project({ TYPES: { 'Item.my-module.note': 'Note' } });
+    expect((await runManifestRules(dir)).filter((r) => r.ruleId === 'VTTF-AUDIT-009')).toEqual([]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('says nothing when there is no language file to check against', async () => {
+    // A package with no strings at all is a different finding to make.
+    const dir = await project(null);
+    expect((await runManifestRules(dir)).filter((r) => r.ruleId === 'VTTF-AUDIT-009')).toEqual([]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('expects a system subtype without the id in the key', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vttforge-audit-types-'));
+    await writeFile(
+      join(dir, 'system.json'),
+      JSON.stringify({
+        id: 'my-system',
+        version: '1.0.0',
+        documentTypes: { Actor: { character: {} } },
+        languages: [{ lang: 'en', name: 'English', path: 'lang/en.json' }],
+      }),
+      'utf8',
+    );
+    await mkdir(join(dir, 'lang'), { recursive: true });
+    // A system owns its type names; no module id in the path.
+    await writeFile(
+      join(dir, 'lang', 'en.json'),
+      JSON.stringify({ TYPES: { Actor: { character: 'Character' } } }),
+      'utf8',
+    );
+    expect((await runManifestRules(dir)).filter((r) => r.ruleId === 'VTTF-AUDIT-009')).toEqual([]);
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/cli/src/__tests__/audit/template-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/template-rules.test.ts
@@ -1,0 +1,115 @@
+/**
+ * VTTF-AUDIT-008, the sheet template that opens a form the sheet already is.
+ *
+ * The bug this exists for shipped in a real module and cost a release: the
+ * sheet accepted every edit and dropped it on close, with nothing in the
+ * console. The rule reads the Handlebars, because that is where it lives.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runTemplateRules } from '../../audit/template-rules.js';
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'vttforge-audit-template-'));
+});
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+/** Write a sheet class and the template its `PARTS` names. */
+async function project(options: {
+  base: string;
+  template: string;
+  served?: string;
+  file?: string;
+}): Promise<void> {
+  const served = options.served ?? 'modules/my-module/templates/item/sheet.hbs';
+  const file = options.file ?? 'templates/item/sheet.hbs';
+  await mkdir(join(cwd, 'scripts'), { recursive: true });
+  await writeFile(
+    join(cwd, 'scripts', 'sheet.ts'),
+    `import { ${options.base} } from '@vttforge/core';
+export class MySheet extends ${options.base}() {
+  static PARTS = { sheet: { template: '${served}' } };
+}`,
+    'utf8',
+  );
+  await mkdir(join(cwd, file.split('/').slice(0, -1).join('/')), { recursive: true });
+  await writeFile(join(cwd, file), options.template, 'utf8');
+}
+
+describe('VTTF-AUDIT-008', () => {
+  it('flags a form inside an item sheet template', async () => {
+    await project({
+      base: 'BaseItemSheet',
+      template: '<form>\n  <input name="system.code" />\n</form>',
+    });
+    const found = await runTemplateRules(cwd);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.ruleId).toBe('VTTF-AUDIT-008');
+    expect(found[0]?.severity).toBe('HIGH');
+    expect(found[0]?.filePath).toBe('templates/item/sheet.hbs');
+    expect(found[0]?.line).toBe(1);
+  });
+
+  it('flags one inside an actor sheet template too', async () => {
+    await project({
+      base: 'BaseActorSheet',
+      served: 'systems/my-system/templates/actor/sheet.hbs',
+      file: 'templates/actor/sheet.hbs',
+      template: '<div>\n</div>\n<form class="wrapper"></form>',
+    });
+    const found = await runTemplateRules(cwd);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.line).toBe(3);
+  });
+
+  it('leaves a template alone when it opens no form', async () => {
+    await project({
+      base: 'BaseItemSheet',
+      template: '<div>\n  <input name="system.code" />\n</div>',
+    });
+    expect(await runTemplateRules(cwd)).toEqual([]);
+  });
+
+  it('does not read a Handlebars comment as markup', async () => {
+    // The fix for this bug leaves a comment saying why there is no form.
+    // A rule that flagged its own remediation would be worse than useless.
+    await project({
+      base: 'BaseItemSheet',
+      template: '{{!--\n  No <form> here: the application already is one.\n--}}\n<div></div>',
+    });
+    expect(await runTemplateRules(cwd)).toEqual([]);
+  });
+
+  it('leaves a plain application alone, which is not a form', async () => {
+    // BaseApplication and BaseDocumentSheet do not set `tag: "form"`, so a
+    // template of theirs may open one quite correctly.
+    await project({ base: 'BaseApplication', template: '<form><input name="q" /></form>' });
+    expect(await runTemplateRules(cwd)).toEqual([]);
+  });
+
+  it('says nothing about a template no sheet names', async () => {
+    await mkdir(join(cwd, 'templates'), { recursive: true });
+    await writeFile(join(cwd, 'templates', 'orphan.hbs'), '<form></form>', 'utf8');
+    expect(await runTemplateRules(cwd)).toEqual([]);
+  });
+
+  it('survives a PARTS entry pointing at a file that is not there', async () => {
+    await mkdir(join(cwd, 'scripts'), { recursive: true });
+    await writeFile(
+      join(cwd, 'scripts', 'sheet.ts'),
+      `export class MySheet extends BaseItemSheet() {
+  static PARTS = { sheet: { template: 'modules/my-module/templates/gone.hbs' } };
+}`,
+      'utf8',
+    );
+    expect(await runTemplateRules(cwd)).toEqual([]);
+  });
+});

--- a/packages/cli/src/audit/index.ts
+++ b/packages/cli/src/audit/index.ts
@@ -6,6 +6,8 @@
  *   - manifest-rules.ts → VTTF-AUDIT-001, 002, 003 (manifest-only)
  *   - source-rules.ts   → VTTF-AUDIT-004, 005, 006, 007 (source walker
  *                         + cross-check with manifest where needed)
+ *   - template-rules.ts → VTTF-AUDIT-008 (the Handlebars, cross-checked
+ *                         against which base each sheet is built on)
  *
  * The orchestrator stays minimal. It knows which rule sets exist, but
  * the rules themselves are responsible for their own file IO. This keeps
@@ -16,6 +18,7 @@ import { existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { runManifestRules } from './manifest-rules.js';
 import { runSourceRules } from './source-rules.js';
+import { runTemplateRules } from './template-rules.js';
 import { type AuditReport, type RuleResult, SEVERITY_RANK } from './types.js';
 
 export interface RunAuditOptions {
@@ -43,12 +46,15 @@ export async function runAudit(options: RunAuditOptions): Promise<AuditReport> {
   }
   const startedAt = new Date().toISOString();
 
-  const [manifestFindings, sourceFindings] = await Promise.all([
+  const [manifestFindings, sourceFindings, templateFindings] = await Promise.all([
     runManifestRules(cwd),
     runSourceRules(cwd),
+    runTemplateRules(cwd),
   ]);
 
-  const findings: RuleResult[] = [...manifestFindings, ...sourceFindings].sort(compareFindings);
+  const findings: RuleResult[] = [...manifestFindings, ...sourceFindings, ...templateFindings].sort(
+    compareFindings,
+  );
 
   return {
     cwd,

--- a/packages/cli/src/audit/manifest-rules.ts
+++ b/packages/cli/src/audit/manifest-rules.ts
@@ -8,6 +8,7 @@
  *   VTTF-AUDIT-001 (HIGH)  : flags.hotReload shape
  *   VTTF-AUDIT-002 (MEDIUM): deprecated gridDistance/gridUnits
  *   VTTF-AUDIT-003 (LOW)   : styles array of strings (v12 shape)
+ *   VTTF-AUDIT-009 (MEDIUM): a documentTypes subtype with no TYPES label
  *
  * Each rule emits zero or more `RuleResult`s. Line numbers are looked up
  * cheaply by scanning the raw JSON for the offending key. Accurate
@@ -207,6 +208,104 @@ function ruleStylesShape(manifest: LoadedManifest): RuleResult[] {
 }
 
 /**
+ * VTTF-AUDIT-009 (MEDIUM) — a declared subtype with no name.
+ *
+ * Foundry looks a subtype's label up under `TYPES.<Document>.<key>`, where a
+ * module's key carries its id: `TYPES.Item.my-module.note`. With the label
+ * missing it prints that path, so the sheet is titled
+ * `TYPES.Item.my-module.note: Rope` and the Create dialog offers
+ * `my-module.note` in its type dropdown.
+ *
+ * Nothing errors. The type works; it just has no name anywhere a reader
+ * looks, which is the sort of thing that ships and stays.
+ */
+async function ruleTypeLabels(cwd: string, manifest: LoadedManifest): Promise<RuleResult[]> {
+  const documentTypes = manifest.parsed.documentTypes;
+  if (documentTypes === null || typeof documentTypes !== 'object') return [];
+
+  const id = typeof manifest.parsed.id === 'string' ? manifest.parsed.id : null;
+  if (id === null) return [];
+  // A module namespaces its subtypes under its own id; a system does not.
+  const isModule = manifest.path.endsWith('module.json');
+
+  const languages = await loadLanguages(cwd, manifest);
+  // Nothing to check against. Missing language files are their own problem.
+  if (languages.length === 0) return [];
+
+  const missing: string[] = [];
+  for (const [document, subtypes] of Object.entries(documentTypes as Record<string, unknown>)) {
+    if (subtypes === null || typeof subtypes !== 'object') continue;
+    for (const subtype of Object.keys(subtypes as Record<string, unknown>)) {
+      const path = isModule ? ['TYPES', document, id, subtype] : ['TYPES', document, subtype];
+      const named = languages.some((catalogue) => readPath(catalogue, path) !== undefined);
+      if (!named) missing.push(path.join('.'));
+    }
+  }
+  if (missing.length === 0) return [];
+
+  return [
+    {
+      ruleId: 'VTTF-AUDIT-009',
+      title: 'Declared subtype has no name in any language file',
+      severity: 'MEDIUM',
+      filePath: manifest.path,
+      line: findKeyLine(manifest.raw, 'documentTypes'),
+      message: `No language file names ${missing.join(', ')}. Foundry falls back to printing the key, so the sheet title and the type dropdown read the raw path instead of a name.`,
+      remediation: `Add the label to a language file, nested: ${nestedExample(missing[0] ?? '')}`,
+    },
+  ];
+}
+
+/** Every language catalogue the manifest declares, parsed. Unreadable ones are skipped. */
+async function loadLanguages(
+  cwd: string,
+  manifest: LoadedManifest,
+): Promise<Record<string, unknown>[]> {
+  const declared = manifest.parsed.languages;
+  if (!Array.isArray(declared)) return [];
+  const out: Record<string, unknown>[] = [];
+  for (const entry of declared) {
+    if (entry === null || typeof entry !== 'object') continue;
+    const path = (entry as { path?: unknown }).path;
+    if (typeof path !== 'string') continue;
+    try {
+      out.push(JSON.parse(await readFile(join(cwd, path), 'utf8')));
+    } catch {
+      // Missing or malformed. Not this rule's finding to make.
+    }
+  }
+  return out;
+}
+
+/**
+ * Read a dotted path, allowing for either nesting.
+ *
+ * Foundry flattens its catalogues, so `{"TYPES.Item.x": "X"}` and the fully
+ * nested form both work. A rule that only understood one shape would report
+ * a label that is really there.
+ */
+function readPath(catalogue: Record<string, unknown>, path: readonly string[]): unknown {
+  for (let split = path.length; split > 0; split -= 1) {
+    const head = path.slice(0, split).join('.');
+    const value = catalogue[head];
+    if (value === undefined) continue;
+    if (split === path.length) return value;
+    if (value === null || typeof value !== 'object') continue;
+    const rest = readPath(value as Record<string, unknown>, path.slice(split));
+    if (rest !== undefined) return rest;
+  }
+  return undefined;
+}
+
+/** The JSON a reader should paste, for the first missing label. */
+function nestedExample(dotted: string): string {
+  const parts = dotted.split('.');
+  let json = '"Some Name"';
+  for (const key of parts.reverse()) json = `{ ${JSON.stringify(key)}: ${json} }`;
+  return json;
+}
+
+/**
  * Entry point: run every manifest rule against every manifest at the
  * project root.
  */
@@ -217,6 +316,7 @@ export async function runManifestRules(cwd: string): Promise<RuleResult[]> {
     results.push(...ruleHotReload(manifest));
     results.push(...ruleGridShape(manifest));
     results.push(...ruleStylesShape(manifest));
+    results.push(...(await ruleTypeLabels(cwd, manifest)));
   }
   return results;
 }

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -986,5 +986,8 @@ export const _internal = {
   walkSourceFiles,
   isSourceFile,
   lastSegment,
+  // Shared with template-rules.ts, which has to know which class a `PARTS`
+  // entry belongs to before it can say whether its template is wrong.
+  findClassRanges,
   EXCLUDED_DIRS,
 };

--- a/packages/cli/src/audit/template-rules.ts
+++ b/packages/cli/src/audit/template-rules.ts
@@ -1,0 +1,111 @@
+/**
+ * Template-scope audit rules.
+ *
+ *   VTTF-AUDIT-008 (HIGH): a sheet template that opens its own `<form>`
+ *
+ * The two rules before this read the manifest and the source. This one reads
+ * the Handlebars, because that is where the mistake lives and nothing else
+ * looks there.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { _internal } from './source-rules.js';
+import type { RuleResult } from './types.js';
+
+/**
+ * The bases that make the application element a form.
+ *
+ * `BaseActorSheet` and `BaseItemSheet` set `tag: 'form'`, which is what makes
+ * `submitOnChange` work at all. `BaseApplication` and `BaseDocumentSheet` do
+ * not, and a template of theirs may open a form of its own quite correctly.
+ */
+const FORM_TAGGED_BASES = /extends\s+(?:[\w.]+\.)?(?:BaseActorSheet|BaseItemSheet)\s*\(/;
+
+/** `template: '.../foo.hbs'`, in a `static PARTS` block or anywhere near one. */
+const TEMPLATE_RE = /template:\s*[`'"]([^`'"]*\.hbs)[`'"]/g;
+
+/** A `<form>` start tag, ignoring what a Handlebars comment says about one. */
+const FORM_TAG_RE = /<form[\s>]/i;
+const HANDLEBARS_COMMENT_RE = /\{\{!--[\s\S]*?--\}\}|\{\{![^}]*\}\}/g;
+
+/**
+ * The templates a form-tagged sheet declares, as paths inside the project.
+ *
+ * A `PARTS` entry names the path Foundry serves it from, like
+ * `systems/my-system/templates/actor/sheet.hbs`. On disk the package root is
+ * the project root, so the first two segments come off.
+ */
+function templatesOfFormSheets(source: string): string[] {
+  const classes = _internal.findClassRanges(source);
+  const out: string[] = [];
+  for (const match of source.matchAll(TEMPLATE_RE)) {
+    if (match.index === undefined) continue;
+    const owner = classes.find((c) => match.index > c.openIdx && match.index < c.endIdx);
+    if (!owner) continue;
+    // Look at the class header, which is where `extends` is.
+    const header = source.slice(Math.max(0, owner.openIdx - 240), owner.openIdx);
+    if (!FORM_TAGGED_BASES.test(header)) continue;
+    const served = match[1];
+    if (served === undefined) continue;
+    const parts = served.split('/');
+    // `systems/<id>/…` and `modules/<id>/…` both map to the project root.
+    const local = parts[0] === 'systems' || parts[0] === 'modules' ? parts.slice(2) : parts;
+    if (local.length > 0) out.push(local.join('/'));
+  }
+  return [...new Set(out)];
+}
+
+/**
+ * VTTF-AUDIT-008 (HIGH) — a sheet template that opens its own `<form>`.
+ *
+ * `BaseActorSheet` and `BaseItemSheet` set `tag: 'form'`, so the application
+ * element already is one. A `<form>` inside it owns every field inside it,
+ * and the submit reads the outer element: `new FormData` on it comes back
+ * empty and nothing is written.
+ *
+ * HIGH because of how it fails. There is no error and no warning. The sheet
+ * looks right, accepts what you type, and drops it when the window closes.
+ */
+export async function runTemplateRules(cwd: string): Promise<RuleResult[]> {
+  const templates = new Set<string>();
+  for await (const file of _internal.walkSourceFiles(cwd)) {
+    let content: string;
+    try {
+      content = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const template of templatesOfFormSheets(content)) templates.add(template);
+  }
+
+  const results: RuleResult[] = [];
+  for (const template of [...templates].sort()) {
+    const path = join(cwd, template);
+    let source: string;
+    try {
+      source = await readFile(path, 'utf8');
+    } catch {
+      // A `PARTS` entry naming a file that is not there is a different
+      // problem, and Foundry reports that one itself.
+      continue;
+    }
+    const markup = source.replace(HANDLEBARS_COMMENT_RE, '');
+    if (!FORM_TAG_RE.test(markup)) continue;
+
+    const lines = markup.split('\n');
+    const line = lines.findIndex((text) => FORM_TAG_RE.test(text)) + 1;
+    results.push({
+      ruleId: 'VTTF-AUDIT-008',
+      title: 'Sheet template opens a form the sheet already is',
+      severity: 'HIGH',
+      filePath: relative(cwd, path) || template,
+      line: line > 0 ? line : 1,
+      message:
+        'This template is rendered by a sheet built on BaseActorSheet or BaseItemSheet, which set `tag: "form"`, so the application element already is a form. A nested form owns the fields inside it, so the submit reads the outer element and finds nothing. Every edit is dropped when the window closes, with no error.',
+      remediation:
+        'Replace the `<form>` wrapper with a `<div>`, or drop it entirely. The fields belong to the application element, and `submitOnChange` saves them as they change.',
+    });
+  }
+  return results;
+}

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -14,7 +14,7 @@
     "@vttforge/core": "^0.11.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.5.0",
+    "@vttforge/cli": "^0.6.0",
     "@vttforge/vite-plugin": "^0.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-js/templates/item/note-sheet.hbs
+++ b/packages/cli/templates/module-js/templates/item/note-sheet.hbs
@@ -1,5 +1,11 @@
 {{!-- Note sheet — one part, no tabs. --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   <header class="sheet-header">
     <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
@@ -31,4 +37,4 @@
     </footer>
   </section>
 
-</form>
+</div>

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -15,7 +15,7 @@
     "@vttforge/core": "^0.11.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.5.0",
+    "@vttforge/cli": "^0.6.0",
     "@vttforge/vite-plugin": "^0.4.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/module-ts/templates/item/note-sheet.hbs
+++ b/packages/cli/templates/module-ts/templates/item/note-sheet.hbs
@@ -1,5 +1,11 @@
 {{!-- Note sheet — one part, no tabs. --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   <header class="sheet-header">
     <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
@@ -31,4 +37,4 @@
     </footer>
   </section>
 
-</form>
+</div>

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -15,7 +15,7 @@
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.5.0",
+    "@vttforge/cli": "^0.6.0",
     "@vttforge/vite-plugin": "^0.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-js/templates/actor/character-sheet.hbs
+++ b/packages/cli/templates/system-js/templates/actor/character-sheet.hbs
@@ -9,7 +9,13 @@
   `<img data-edit="img">` is handled by DocumentSheetV2's built-in editImage
   action. `<prose-mirror>` is the v13 rich text element for biography.
 --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   {{!-- ════════ HEAD (.sh-head) ════════ --}}
   <div class="sh-head">
@@ -165,4 +171,4 @@
     <span>@vttforge/styles · v0.2</span>
   </footer>
 
-</form>
+</div>

--- a/packages/cli/templates/system-js/templates/item/gear-sheet.hbs
+++ b/packages/cli/templates/system-js/templates/item/gear-sheet.hbs
@@ -1,5 +1,11 @@
 {{!-- Gear sheet — minimal demo of BaseItemSheet on ItemSheetV2. --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   <header class="sheet-header">
     <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
@@ -51,4 +57,4 @@
     </section>
   </section>
 
-</form>
+</div>

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -16,7 +16,7 @@
     "@vttforge/styles": "^0.3.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.5.0",
+    "@vttforge/cli": "^0.6.0",
     "@vttforge/vite-plugin": "^0.4.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-ts/templates/actor/character-sheet.hbs
+++ b/packages/cli/templates/system-ts/templates/actor/character-sheet.hbs
@@ -9,7 +9,13 @@
   `<img data-edit="img">` is handled by DocumentSheetV2's built-in editImage
   action. `<prose-mirror>` is the v13 rich text element for biography.
 --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   {{!-- ════════ HEAD (.sh-head) ════════ --}}
   <div class="sh-head">
@@ -165,4 +171,4 @@
     <span>@vttforge/styles · v0.2</span>
   </footer>
 
-</form>
+</div>

--- a/packages/cli/templates/system-ts/templates/item/gear-sheet.hbs
+++ b/packages/cli/templates/system-ts/templates/item/gear-sheet.hbs
@@ -1,5 +1,11 @@
 {{!-- Gear sheet — minimal demo of BaseItemSheet on ItemSheetV2. --}}
-<form autocomplete="off">
+{{!--
+  No <form> here. The sheet bases set `tag: 'form'`, so the application
+  element already is one, and a nested form owns the fields inside it: the
+  submit would read the outer element, find nothing, and drop every edit when
+  the window closes. `vttforge audit` reports this as VTTF-AUDIT-008.
+--}}
+<div class="sheet-body-root">
 
   <header class="sheet-header">
     <img class="portrait" src="{{item.img}}" alt="{{item.name}}" data-edit="img" />
@@ -51,4 +57,4 @@
     </section>
   </section>
 
-</form>
+</div>


### PR DESCRIPTION
## Two rules, both from a module that shipped the bug

### `VTTF-AUDIT-008` (HIGH) — a sheet template that opens its own `<form>`

`BaseActorSheet` and `BaseItemSheet` set `tag: 'form'`, so the application element already is one. A `<form>` inside it owns every field inside it, and the submit reads the outer element: `new FormData` on it comes back empty and nothing is written. The sheet looks right, accepts what you type, and drops it when the window closes.

It only considers templates those two bases name in their `PARTS`. `BaseApplication` and `BaseDocumentSheet` do not set `tag: 'form'`, and a template of theirs may open one quite correctly.

### `VTTF-AUDIT-009` (MEDIUM) — a declared subtype with no name

Foundry reads a subtype's label from `TYPES.<Document>.<key>`, where a module's key carries its id. Without it, it prints the path: the sheet is titled `TYPES.Item.my-module.note: Rope`, and the Create dialog offers `my-module.note` in its type dropdown. A label written nested or flattened both count, because Foundry reads both, and a system's key has no module id in it.

## What running 008 found immediately

All four scaffolding templates and both examples had the bug. **A project created with `pnpm create vttforge` had sheets that silently lost everything typed into them.** That is fixed here as well, which is the larger half of this change: nine templates move their wrapper from `<form>` to `<div>`, each with a comment saying why.

The template pin guard then caught its own case, since the changeset takes the CLI to a minor: the four templates asked for `@vttforge/cli@^0.5.0`, which this release supersedes. Bumped.

## Tests

Thirteen new ones. For 008: an item sheet and an actor sheet flagged, a clean template left alone, a Handlebars comment not read as markup (the fix leaves one behind, and a rule that flagged its own remediation would be worse than useless), a `BaseApplication` left alone, an unreferenced template ignored, and a `PARTS` entry pointing at a missing file surviving. For 009: flagged when absent, accepted nested, flattened and half-flattened, quiet with no language file at all, and a system subtype checked without the module id.

Verified end to end by rebuilding both bugs into a copy of the real module and running the CLI against it: two findings, right file, right line, with the JSON to paste in the remediation.

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `knip`, `pnpm build` green.