### PR TITLE
fix(styles): take component CSS out of its cascade layer

### DIFF
--- a/.changeset/hungry-pans-shave.md
+++ b/.changeset/hungry-pans-shave.md
@@ -1,0 +1,19 @@
+---
+'@vttforge/styles': minor
+---
+
+Take the component styles out of their cascade layer, so plain CSS from another package cannot restyle your sheet.
+
+Base, components and the theme used to sit in `@layer vttforge.*`. That was a mistake. An unlayered rule beats every layered one, whatever the specificity, and layer order is settled before specificity is ever consulted. Foundry loads a system or module stylesheet unlayered unless the manifest asks otherwise, so most packages on the page write plain CSS. One of them shipping this:
+
+```css
+button { border-radius: 99px; }
+```
+
+used to win against `.vttf-btn`, and nothing you could write would win it back.
+
+Tokens and the reset stay layered, and lose on purpose. Tokens are custom properties you must be able to override with one plain declaration, and a reset that outranks real rules is a bug waiting to happen.
+
+The `styles.layer.css` entry still wraps everything in one `@layer vttforge` for consumers who order these styles against layers of their own. It gives up the cascade position by design.
+
+If you were relying on `@layer vttforge.base`, `vttforge.components` or `vttforge.themes` to keep these styles below your own unlayered CSS, that no longer holds. Raise the specificity of your override, or import `styles.layer.css` instead.

--- a/.changeset/tidy-bats-marry.md
+++ b/.changeset/tidy-bats-marry.md
@@ -1,0 +1,7 @@
+---
+'@vttforge/cli': patch
+---
+
+Follow the `@vttforge/styles` minor in the scaffold's pin.
+
+On a `0.x` version a caret pins the minor, so `^0.3.0` would have kept new projects on the old styles. The templates ship inside this package, so the corrected pin only reaches anyone when the CLI is published too.

--- a/apps/e2e/tests/system.spec.mjs
+++ b/apps/e2e/tests/system.spec.mjs
@@ -116,6 +116,95 @@ test('a character sheet renders its parts and its derived data', async ({ page }
   expect(sheet.derived.strMod).toBe(0);
 });
 
+test('another package\'s plain CSS cannot restyle the sheet', async ({ page }) => {
+  await joinWorld(page);
+
+  // An unlayered author rule beats every layered one, whatever the
+  // specificity, and layer order is settled before specificity is consulted.
+  // Foundry loads a system or module stylesheet unlayered unless the manifest
+  // asks otherwise, so most packages on the page write plain CSS. Put the
+  // components in a layer and a bare element selector from an unrelated
+  // module wins.
+  //
+  // Two of ours stay layered on purpose. Tokens are custom properties a
+  // consumer overrides with one plain declaration, and the reset touches bare
+  // elements, so neither should outrank a real rule from the system around it.
+  const ALLOWED = ['vttforge.tokens', 'vttforge.reset'];
+
+  const cascade = await page.evaluate(async (allowed) => {
+    const actor = await Actor.create({ name: 'Cascade Check', type: 'character' });
+    await actor.sheet.render(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // The example system styles its sheet with its own classes, so nothing on
+    // screen carries a `.vttf-` class. The element is planted; the stylesheet,
+    // the page and the rival rule below are all real.
+    const button = document.createElement('button');
+    button.className = 'vttf-btn';
+    actor.sheet.element.querySelector('.window-content').append(button);
+    const before = getComputedStyle(button).borderRadius;
+
+    // Stand in for a second module, loaded after ours, styling elements the
+    // way modules commonly do: no layer, barely any specificity.
+    const rival = document.createElement('style');
+    rival.textContent = 'button { border-radius: 99px; }';
+    document.head.append(rival);
+    const after = getComputedStyle(button).borderRadius;
+
+    // Walk every stylesheet and note which layer, if any, each of our rules
+    // sits in. A cross-origin sheet throws on `cssRules`, so the count of
+    // those is carried out for the failure message: it explains an empty
+    // result that would otherwise look like a pass.
+    const offenders = [];
+    let unlayeredCount = 0;
+    let unreadable = 0;
+
+    const visit = (rules, layerName) => {
+      for (const rule of rules) {
+        if (rule instanceof CSSImportRule) {
+          if (rule.styleSheet) visit(rule.styleSheet.cssRules, rule.layerName ?? layerName);
+        } else if (rule instanceof CSSLayerBlockRule) {
+          visit(rule.cssRules, rule.name || '(anonymous)');
+        } else if (rule instanceof CSSGroupingRule) {
+          visit(rule.cssRules, layerName);
+        } else if (rule instanceof CSSStyleRule && rule.selectorText.includes('vttf-')) {
+          if (layerName === null) unlayeredCount += 1;
+          else if (!allowed.includes(layerName)) {
+            offenders.push(`@layer ${layerName} { ${rule.selectorText} }`);
+          }
+        }
+      }
+    };
+
+    for (const sheet of document.styleSheets) {
+      try {
+        visit(sheet.cssRules, null);
+      } catch {
+        unreadable += 1;
+      }
+    }
+
+    rival.remove();
+    button.remove();
+    return { unreadable, unlayeredCount, offenders: offenders.slice(0, 10), before, after };
+  }, ALLOWED);
+
+  // Proves the walk actually read our stylesheet, so an empty `offenders` is
+  // a real result and not a sheet it could not open.
+  expect(
+    cascade.unlayeredCount,
+    `no unlayered VTTForge rules found; ${cascade.unreadable} stylesheets were unreadable`,
+  ).toBeGreaterThan(50);
+  expect(
+    cascade.offenders,
+    'these rules paint the sheet from inside a cascade layer, so plain CSS from any other module beats them',
+  ).toEqual([]);
+
+  // --vttf-radius-md, and it holds while the rival rule is on the page.
+  expect(cascade.before).toBe('6px');
+  expect(cascade.after).toBe('6px');
+});
+
 test('the module contributes a namespaced sub-type once enabled', async ({ page }) => {
   await joinWorld(page);
 

--- a/apps/e2e/tests/system.spec.mjs
+++ b/apps/e2e/tests/system.spec.mjs
@@ -116,7 +116,7 @@ test('a character sheet renders its parts and its derived data', async ({ page }
   expect(sheet.derived.strMod).toBe(0);
 });
 
-test('another package\'s plain CSS cannot restyle the sheet', async ({ page }) => {
+test("another package's plain CSS cannot restyle the sheet", async ({ page }) => {
   await joinWorld(page);
 
   // An unlayered author rule beats every layered one, whatever the

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@vttforge/core": "^0.11.0",
-    "@vttforge/styles": "^0.3.0"
+    "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.6.0",

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@vttforge/core": "^0.11.0",
-    "@vttforge/styles": "^0.3.0"
+    "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.6.0",

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -1,6 +1,6 @@
 # @vttforge/styles
 
-CSS-only package: design tokens, scoped reset, base styles, sheet primitives, and opt-in themes. Built on [CSS Cascade Layers](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) for predictable composition with Foundry v13's own layer order.
+CSS-only package: design tokens, scoped reset, base styles, sheet primitives, and opt-in themes.
 
 ```bash
 pnpm add @vttforge/styles
@@ -8,17 +8,20 @@ pnpm add @vttforge/styles
 
 ## Usage
 
-Default, one import, sub-layered:
+Default, one import:
 
 ```css
 @import '@vttforge/styles';
 ```
 
-Or wrap everything in a single `@layer vttforge`:
+Or wrap everything in a single `@layer vttforge` you order yourself:
 
 ```css
+@layer reset, vttforge, my-system;
 @import '@vttforge/styles/styles.layer.css';
 ```
+
+Read the next section before you pick the second one.
 
 Cherry-pick:
 
@@ -35,9 +38,22 @@ Opt-in theme:
 
 The tokens are also published as data, `@vttforge/styles/tokens.json`, for anything that is not CSS.
 
-## Layer names
+## Cascade layers
 
-VTTForge uses a vendored prefix: `vttforge.tokens`, `vttforge.reset`, `vttforge.base`, `vttforge.components`. Foundry v13 owns the top-level layer names (`reset, variables, elements, blocks, applications, …, system, modules`) and auto-wraps system manifest CSS in its `system` layer.
+Only two pieces sit in a layer, `vttforge.tokens` and `vttforge.reset`. Base, components and the theme are unlayered on purpose.
+
+The cascade puts every unlayered author rule above every layered one, whatever the specificity. Foundry loads a system or module stylesheet unlayered unless the manifest asks otherwise, so most packages on the page write plain CSS. Put these components in a layer and a bare element selector from an unrelated module wins:
+
+```css
+/* some other module, no layer, almost no specificity */
+button { border-radius: 99px; }
+```
+
+That rule used to beat `.vttf-btn`. Now it does not. Nothing you do with specificity would have won it back, because layer order is decided before specificity is ever consulted.
+
+Tokens and the reset lose that fight on purpose. Tokens are custom properties you must be able to override with one plain declaration. The reset touches bare elements inside `.vttf-app`, and a reset that outranks real rules from the system around it is a bug waiting to happen.
+
+The `styles.layer.css` entry gives up that position by design: inside a layer, VTTForge loses to anything unlayered on the page. Use it only when you need to order these styles against layers of your own.
 
 ## See it
 

--- a/packages/styles/base.css
+++ b/packages/styles/base.css
@@ -2,68 +2,70 @@
  * @vttforge/styles — base.css
  *
  * Element baselines and shared utilities on top of `tokens` + `reset`.
- * Owns `--vttf-focus-ring` rendering; component layers MUST NOT override `:focus-visible`.
+ *
+ * Unlayered, so a plain rule from another package cannot outrank these
+ * baselines. See `index.css` for why.
+ *
+ * Owns `--vttf-focus-ring` rendering; components MUST NOT override `:focus-visible`.
  */
 
-@layer vttforge.base {
-  .vttf-app,
-  .vttf-sheet {
-    font-family: var(--vttf-font-body);
-    font-size: var(--vttf-text-size-body);
-    line-height: 1.5;
-    color: var(--vttf-text);
-    background: var(--vttf-bg);
-  }
+.vttf-app,
+.vttf-sheet {
+  font-family: var(--vttf-font-body);
+  font-size: var(--vttf-text-size-body);
+  line-height: 1.5;
+  color: var(--vttf-text);
+  background: var(--vttf-bg);
+}
 
-  .vttf-app :focus-visible,
-  .vttf-sheet :focus-visible,
-  form[data-vttf] :focus-visible {
-    outline: none;
-    box-shadow: var(--vttf-focus-ring);
-  }
+.vttf-app :focus-visible,
+.vttf-sheet :focus-visible,
+form[data-vttf] :focus-visible {
+  outline: none;
+  box-shadow: var(--vttf-focus-ring);
+}
 
-  .vttf-app a,
-  .vttf-sheet a {
-    color: var(--vttf-ember);
-    text-decoration: none;
-    transition: color var(--vttf-duration-fast) var(--vttf-ease-out);
-  }
+.vttf-app a,
+.vttf-sheet a {
+  color: var(--vttf-ember);
+  text-decoration: none;
+  transition: color var(--vttf-duration-fast) var(--vttf-ease-out);
+}
 
-  .vttf-app a:hover,
-  .vttf-sheet a:hover {
-    color: var(--vttf-ember-glow);
-    text-decoration: underline;
-  }
+.vttf-app a:hover,
+.vttf-sheet a:hover {
+  color: var(--vttf-ember-glow);
+  text-decoration: underline;
+}
 
-  .vttf-app h1,
-  .vttf-app h2,
-  .vttf-app h3,
-  .vttf-sheet h1,
-  .vttf-sheet h2,
-  .vttf-sheet h3 {
-    font-family: var(--vttf-font-display);
-    font-weight: var(--vttf-text-weight-semibold);
-    letter-spacing: -0.02em;
-    margin: 0;
-  }
+.vttf-app h1,
+.vttf-app h2,
+.vttf-app h3,
+.vttf-sheet h1,
+.vttf-sheet h2,
+.vttf-sheet h3 {
+  font-family: var(--vttf-font-display);
+  font-weight: var(--vttf-text-weight-semibold);
+  letter-spacing: -0.02em;
+  margin: 0;
+}
 
-  .vttf-app code,
-  .vttf-app pre,
-  .vttf-sheet code,
-  .vttf-sheet pre {
-    font-family: var(--vttf-font-mono);
-  }
+.vttf-app code,
+.vttf-app pre,
+.vttf-sheet code,
+.vttf-sheet pre {
+  font-family: var(--vttf-font-mono);
+}
 
-  /* Utility: visually hidden but accessible to screen readers */
-  .vttf-sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
+/* Utility: visually hidden but accessible to screen readers */
+.vttf-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/packages/styles/components.css
+++ b/packages/styles/components.css
@@ -10,737 +10,735 @@
  * classes as legacy fallbacks.
  */
 
-@layer vttforge.components {
-  /* ════════ BUTTONS ════════ */
-
-  .vttf-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--vttf-space-2);
-    padding: 10px 16px;
-    border-radius: var(--vttf-radius-md);
-    font-family: var(--vttf-font-body);
-    font-weight: var(--vttf-text-weight-semibold);
-    font-size: 14px;
-    border: 1px solid transparent;
-    cursor: pointer;
-    transition:
-      transform var(--vttf-duration-fast) var(--vttf-ease-out),
-      box-shadow var(--vttf-duration-fast) var(--vttf-ease-out),
-      background var(--vttf-duration-fast) var(--vttf-ease-out),
-      border-color var(--vttf-duration-fast) var(--vttf-ease-out);
-  }
-
-  .vttf-btn:active {
-    transform: translateY(1px);
-  }
-
-  .vttf-btn[disabled],
-  .vttf-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    pointer-events: none;
-  }
-
-  .vttf-btn--primary {
-    background: var(--vttf-ember);
-    color: var(--vttf-text-inverse);
-    box-shadow:
-      0 1px 0 rgb(255 255 255 / 0.2) inset,
-      var(--vttf-shadow-sm);
-  }
-  .vttf-btn--primary:hover {
-    background: var(--vttf-ember-glow);
-  }
-
-  .vttf-btn--secondary {
-    background: var(--vttf-surface);
-    color: var(--vttf-text);
-    border-color: var(--vttf-border-strong);
-  }
-  .vttf-btn--secondary:hover {
-    background: var(--vttf-surface-2);
-    border-color: var(--vttf-text-faint);
-  }
-
-  .vttf-btn--ghost {
-    background: transparent;
-    color: var(--vttf-text-muted);
-  }
-  .vttf-btn--ghost:hover {
-    color: var(--vttf-text);
-    background: var(--vttf-surface);
-  }
-
-  .vttf-btn--danger {
-    background: transparent;
-    color: var(--vttf-rose);
-    border-color: color-mix(in oklch, var(--vttf-rose) 40%, transparent);
-  }
-  .vttf-btn--danger:hover {
-    background: color-mix(in oklch, var(--vttf-rose) 10%, transparent);
-  }
-
-  .vttf-btn .vttf-kbd {
-    font-family: var(--vttf-font-mono);
-    font-size: 11px;
-    padding: 1px 5px;
-    border-radius: var(--vttf-radius-sm);
-    background: rgb(0 0 0 / 0.25);
-    color: inherit;
-    opacity: 0.7;
-  }
-
-  /* ════════ BADGES ════════ */
-
-  .vttf-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 2px 8px;
-    border-radius: var(--vttf-radius-full);
-    font-family: var(--vttf-font-mono);
-    font-size: 11px;
-    font-weight: 500;
-    border: 1px solid;
-    line-height: 1.5;
-  }
-
-  .vttf-badge__blip {
-    width: 6px;
-    height: 6px;
-    border-radius: var(--vttf-radius-full);
-    background: currentColor;
-  }
-
-  .vttf-badge--ember {
-    color: var(--vttf-ember);
-    border-color: color-mix(in oklch, var(--vttf-ember) 40%, transparent);
-    background: color-mix(in oklch, var(--vttf-ember) 8%, transparent);
-  }
-  .vttf-badge--steel {
-    color: var(--vttf-steel);
-    border-color: color-mix(in oklch, var(--vttf-steel) 40%, transparent);
-    background: color-mix(in oklch, var(--vttf-steel) 8%, transparent);
-  }
-  .vttf-badge--mint {
-    color: var(--vttf-mint);
-    border-color: color-mix(in oklch, var(--vttf-mint) 40%, transparent);
-    background: color-mix(in oklch, var(--vttf-mint) 8%, transparent);
-  }
-  .vttf-badge--gold {
-    color: var(--vttf-gold);
-    border-color: color-mix(in oklch, var(--vttf-gold) 40%, transparent);
-    background: color-mix(in oklch, var(--vttf-gold) 8%, transparent);
-  }
-  .vttf-badge--rose {
-    color: var(--vttf-rose);
-    border-color: color-mix(in oklch, var(--vttf-rose) 40%, transparent);
-    background: color-mix(in oklch, var(--vttf-rose) 8%, transparent);
-  }
-  .vttf-badge--violet {
-    color: var(--vttf-violet);
-    border-color: color-mix(in oklch, var(--vttf-violet) 40%, transparent);
-    background: color-mix(in oklch, var(--vttf-violet) 8%, transparent);
-  }
-  .vttf-badge--muted {
-    color: var(--vttf-text-muted);
-    border-color: var(--vttf-border);
-    background: var(--vttf-surface);
-  }
-
-  /* ════════ CODE BLOCK + SYNTAX TOKENS ════════ */
-
-  .vttf-codeblock {
-    background: var(--vttf-bg-sunken);
-    border: 1px solid var(--vttf-border);
-    border-radius: var(--vttf-radius-lg);
-    overflow: hidden;
-    font-family: var(--vttf-font-mono);
-  }
-
-  .vttf-codeblock__head {
-    display: flex;
-    align-items: center;
-    gap: var(--vttf-space-3);
-    padding: 10px 14px;
-    border-bottom: 1px solid var(--vttf-border);
-    background: color-mix(in oklch, var(--vttf-bg-elevated) 70%, transparent);
-    font-size: 12px;
-    color: var(--vttf-text-muted);
-  }
-
-  .vttf-codeblock__dots {
-    display: flex;
-    gap: 6px;
-  }
-  .vttf-codeblock__dots span {
-    width: 10px;
-    height: 10px;
-    border-radius: var(--vttf-radius-full);
-    background: var(--vttf-border-strong);
-  }
-
-  .vttf-codeblock__file {
-    color: var(--vttf-text);
-    background: var(--vttf-surface);
-    padding: 4px 10px;
-    border-radius: var(--vttf-radius-sm);
-    border: 1px solid var(--vttf-border);
-  }
-
-  .vttf-codeblock__lang {
-    margin-left: auto;
-    font-size: 11px;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--vttf-text-faint);
-  }
-
-  .vttf-codeblock pre {
-    margin: 0;
-    padding: var(--vttf-space-5);
-    font-size: 13.5px;
-    line-height: 1.6;
-    color: var(--vttf-text);
-    overflow-x: auto;
-  }
-
-  .vttf-tk-com {
-    color: var(--vttf-text-faint);
-    font-style: italic;
-  }
-  .vttf-tk-kw {
-    color: var(--vttf-violet);
-  }
-  .vttf-tk-fn {
-    color: var(--vttf-ember-glow);
-  }
-  .vttf-tk-str {
-    color: var(--vttf-mint);
-  }
-  .vttf-tk-num {
-    color: var(--vttf-gold);
-  }
-  .vttf-tk-ty {
-    color: var(--vttf-steel);
-  }
-  .vttf-tk-pun {
-    color: var(--vttf-text-muted);
-  }
-  .vttf-tk-prop {
-    color: var(--vttf-text);
-  }
-
-  /* ════════ FORM GRID + FIELD ════════ */
-
-  .vttf-form-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--vttf-space-6);
-  }
-
-  .vttf-form-field {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-
-  .vttf-form-field > label {
-    font-family: var(--vttf-font-mono);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--vttf-text-faint);
-  }
-
-  .vttf-form-field .vttf-hint {
-    font-size: 12px;
-    color: var(--vttf-text-muted);
-  }
-
-  /* ════════ TEXT INPUTS ════════ */
-
-  .vttf-input,
-  .vttf-textarea,
-  .vttf-select {
-    background: var(--vttf-bg-sunken);
-    border: 1px solid var(--vttf-border);
-    color: var(--vttf-text);
-    padding: 9px 12px;
-    border-radius: var(--vttf-radius-sm);
-    font-family: var(--vttf-font-body);
-    font-size: 14px;
-    width: 100%;
-    transition:
-      border-color var(--vttf-duration-fast) var(--vttf-ease-out),
-      box-shadow var(--vttf-duration-fast) var(--vttf-ease-out);
-  }
-
-  .vttf-input:focus-visible,
-  .vttf-textarea:focus-visible,
-  .vttf-select:focus-visible {
-    border-color: var(--vttf-ember);
-  }
-
-  .vttf-input[aria-invalid="true"],
-  .vttf-input.is-invalid,
-  .vttf-textarea[aria-invalid="true"],
-  .vttf-textarea.is-invalid,
-  .vttf-select[aria-invalid="true"],
-  .vttf-select.is-invalid {
-    border-color: var(--vttf-rose);
-    box-shadow: 0 0 0 3px color-mix(in oklch, var(--vttf-rose) 18%, transparent);
-  }
-
-  .vttf-textarea {
-    min-height: 96px;
-    resize: vertical;
-    font-family: var(--vttf-font-mono);
-    font-size: 13px;
-  }
-
-  .vttf-select {
-    appearance: none;
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M3 5l3 3 3-3' stroke='%23999' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-    background-repeat: no-repeat;
-    background-position: right 10px center;
-    padding-right: 32px;
-  }
-
-  /* ════════ CHECKBOXES + RADIOS ════════ */
-
-  .vttf-check,
-  .vttf-radio {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--vttf-space-2);
-    cursor: pointer;
-    font-size: 14px;
-  }
-
-  .vttf-check input,
-  .vttf-radio input {
-    position: absolute;
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  .vttf-check__box,
-  .vttf-radio__box {
-    width: 16px;
-    height: 16px;
-    background: var(--vttf-bg-sunken);
-    border: 1.5px solid var(--vttf-border-strong);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex: 0 0 auto;
-    transition:
-      background var(--vttf-duration-fast) var(--vttf-ease-out),
-      border-color var(--vttf-duration-fast) var(--vttf-ease-out);
-  }
-
-  .vttf-check__box {
-    border-radius: var(--vttf-radius-sm);
-  }
-  .vttf-radio__box {
-    border-radius: var(--vttf-radius-full);
-  }
-
-  .vttf-check input:checked + .vttf-check__box {
-    background: var(--vttf-ember);
-    border-color: var(--vttf-ember);
-  }
-  .vttf-check input:checked + .vttf-check__box::after {
-    content: "";
-    width: 9px;
-    height: 5px;
-    border-left: 2px solid var(--vttf-text-inverse);
-    border-bottom: 2px solid var(--vttf-text-inverse);
-    transform: rotate(-45deg) translate(1px, -1px);
-  }
-
-  .vttf-radio input:checked + .vttf-radio__box {
-    border-color: var(--vttf-ember);
-  }
-  .vttf-radio input:checked + .vttf-radio__box::after {
-    content: "";
-    width: 8px;
-    height: 8px;
-    border-radius: var(--vttf-radius-full);
-    background: var(--vttf-ember);
-  }
-
-  .vttf-check input:focus-visible + .vttf-check__box,
-  .vttf-radio input:focus-visible + .vttf-radio__box {
-    box-shadow: var(--vttf-focus-ring);
-  }
-
-  /* ════════ SWITCH ════════ */
-
-  .vttf-switch {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--vttf-space-3);
-    cursor: pointer;
-    font-size: 14px;
-  }
-
-  .vttf-switch input {
-    position: absolute;
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  .vttf-switch__track {
-    width: 36px;
-    height: 20px;
-    border-radius: var(--vttf-radius-full);
-    background: var(--vttf-surface-2);
-    border: 1px solid var(--vttf-border-strong);
-    position: relative;
-    transition:
-      background var(--vttf-duration-base) var(--vttf-ease-out),
-      border-color var(--vttf-duration-base) var(--vttf-ease-out);
-  }
-
-  .vttf-switch__track::after {
-    content: "";
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    top: 2px;
-    left: 2px;
-    background: var(--vttf-text-muted);
-    border-radius: var(--vttf-radius-full);
-    transition:
-      transform var(--vttf-duration-base) var(--vttf-ease-out),
-      background var(--vttf-duration-base) var(--vttf-ease-out);
-  }
-
-  .vttf-switch input:checked + .vttf-switch__track {
-    background: var(--vttf-ember);
-    border-color: var(--vttf-ember);
-  }
-
-  .vttf-switch input:checked + .vttf-switch__track::after {
-    transform: translateX(16px);
-    background: var(--vttf-text-inverse);
-  }
-
-  .vttf-switch input:focus-visible + .vttf-switch__track {
-    box-shadow: var(--vttf-focus-ring);
-  }
-
-  /* ════════ RANGE ════════ */
-
-  .vttf-range {
-    appearance: none;
-    -webkit-appearance: none;
-    width: 100%;
-    height: 4px;
-    background: var(--vttf-surface-2);
-    border-radius: var(--vttf-radius-full);
-    outline: none;
-  }
-
-  .vttf-range::-webkit-slider-thumb {
-    appearance: none;
-    -webkit-appearance: none;
-    width: 16px;
-    height: 16px;
-    border-radius: var(--vttf-radius-full);
-    background: var(--vttf-ember);
-    border: 2px solid var(--vttf-bg);
-    box-shadow: var(--vttf-shadow-sm);
-    cursor: pointer;
-  }
-
-  .vttf-range::-moz-range-thumb {
-    width: 14px;
-    height: 14px;
-    border-radius: var(--vttf-radius-full);
-    background: var(--vttf-ember);
-    border: 2px solid var(--vttf-bg);
-    cursor: pointer;
-  }
-
-  /* ════════ SEGMENTED CONTROL ════════ */
-
-  .vttf-segment {
-    display: inline-flex;
-    padding: 3px;
-    background: var(--vttf-surface);
-    border: 1px solid var(--vttf-border);
-    border-radius: var(--vttf-radius-md);
-  }
-
-  .vttf-segment button {
-    border: none;
-    background: transparent;
-    color: var(--vttf-text-muted);
-    font-family: var(--vttf-font-body);
-    font-size: 13px;
-    font-weight: 500;
-    padding: 6px 12px;
-    border-radius: var(--vttf-radius-sm);
-    cursor: pointer;
-    transition:
-      background var(--vttf-duration-fast) var(--vttf-ease-out),
-      color var(--vttf-duration-fast) var(--vttf-ease-out),
-      box-shadow var(--vttf-duration-fast) var(--vttf-ease-out);
-  }
-
-  .vttf-segment button:hover {
-    color: var(--vttf-text);
-  }
-
-  .vttf-segment button[aria-pressed="true"],
-  .vttf-segment button[aria-selected="true"],
-  .vttf-segment button.is-active {
-    background: var(--vttf-bg-sunken);
-    color: var(--vttf-text);
-    box-shadow: var(--vttf-shadow-sm);
-  }
-
-  /* ════════ TABS ════════ */
-
-  .vttf-tabs {
-    display: flex;
-    gap: 4px;
-    padding: 0 var(--vttf-space-4);
-    border-bottom: 1px solid var(--vttf-border);
-    background: var(--vttf-bg-elevated);
-  }
-
-  .vttf-tab {
-    padding: 10px 14px;
-    font-family: var(--vttf-font-body);
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--vttf-text-muted);
-    border-bottom: 2px solid transparent;
-    margin-bottom: -1px;
-    cursor: pointer;
-    transition:
-      color var(--vttf-duration-fast) var(--vttf-ease-out),
-      border-color var(--vttf-duration-fast) var(--vttf-ease-out);
-  }
-
-  .vttf-tab:hover {
-    color: var(--vttf-text);
-  }
-
-  .vttf-tab[aria-selected="true"],
-  .vttf-tab.is-active {
-    color: var(--vttf-text);
-    border-bottom-color: var(--vttf-ember);
-  }
-
-  .vttf-tab__count {
-    font-family: var(--vttf-font-mono);
-    font-size: 10px;
-    margin-left: 6px;
-    color: var(--vttf-text-faint);
-  }
-
-  /* ════════ SHEET CONTAINER ════════ */
-
-  .vttf-sheet {
-    background: var(--vttf-bg-elevated);
-    border: 1px solid var(--vttf-border);
-    border-radius: var(--vttf-radius-lg);
-    overflow: hidden;
-  }
-
-  .vttf-sheet__head {
-    padding: var(--vttf-space-4);
-    display: flex;
-    align-items: center;
-    gap: var(--vttf-space-4);
-    border-bottom: 1px solid var(--vttf-border);
-    background: var(--vttf-surface);
-  }
-
-  .vttf-sheet__title {
-    font-family: var(--vttf-font-display);
-    font-size: 22px;
-    font-weight: var(--vttf-text-weight-semibold);
-    letter-spacing: -0.02em;
-  }
-
-  .vttf-sheet__sub {
-    font-family: var(--vttf-font-mono);
-    font-size: 11px;
-    color: var(--vttf-text-faint);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-  }
-
-  .vttf-sheet__body {
-    padding: var(--vttf-space-5);
-    display: grid;
-    gap: var(--vttf-space-3);
-  }
-
-  .vttf-portrait {
-    width: 56px;
-    height: 56px;
-    border-radius: var(--vttf-radius-md);
-    background:
-      repeating-linear-gradient(
-        45deg,
-        color-mix(in oklch, var(--vttf-ember-deep) 18%, transparent) 0 6px,
-        color-mix(in oklch, var(--vttf-ember-deep) 8%, transparent) 6px 12px
-      ),
-      var(--vttf-surface-2);
-    border: 1px dashed var(--vttf-border-strong);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: var(--vttf-font-mono);
-    font-size: 10px;
-    color: var(--vttf-text-faint);
-  }
-
-  .vttf-field-row {
-    display: grid;
-    grid-template-columns: 120px 1fr;
-    gap: var(--vttf-space-4);
-    align-items: center;
-  }
-
-  .vttf-field-label {
-    font-family: var(--vttf-font-mono);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--vttf-text-faint);
-  }
-
-  /* ════════ STAT PILL ════════ */
-
-  .vttf-stat-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--vttf-space-2);
-    padding: 4px 10px 4px 4px;
-    background: var(--vttf-surface);
-    border-radius: var(--vttf-radius-full);
-    border: 1px solid var(--vttf-border);
-  }
-
-  .vttf-stat-pill__n {
-    width: 28px;
-    height: 28px;
-    border-radius: var(--vttf-radius-full);
-    background: var(--vttf-ember);
-    color: var(--vttf-text-inverse);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: var(--vttf-font-mono);
-    font-weight: var(--vttf-text-weight-bold);
-    font-size: 13px;
-  }
-
-  .vttf-stat-pill__label {
-    font-size: 12px;
-    color: var(--vttf-text-muted);
-    font-family: var(--vttf-font-mono);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-  }
-
-  /* ════════ DROPZONE ════════ */
-
-  .vttf-dropzone {
-    border: 1.5px dashed var(--vttf-border-strong);
-    border-radius: var(--vttf-radius-md);
-    padding: var(--vttf-space-6);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--vttf-space-2);
-    color: var(--vttf-text-muted);
-    background: color-mix(in oklch, var(--vttf-bg) 40%, transparent);
-    transition:
-      background var(--vttf-duration-fast) var(--vttf-ease-out),
-      border-color var(--vttf-duration-fast) var(--vttf-ease-out);
-  }
-
-  .vttf-dropzone.is-active,
-  .vttf-dropzone[data-drop-effect] {
-    border-color: var(--vttf-ember);
-    color: var(--vttf-ember);
-    background: color-mix(in oklch, var(--vttf-ember) 6%, transparent);
-    box-shadow: var(--vttf-glow-ember);
-  }
-
-  .vttf-dropzone__icon {
-    font-family: var(--vttf-font-mono);
-    font-size: 24px;
-  }
-
-  .vttf-dropzone__title {
-    font-family: var(--vttf-font-body);
-    font-weight: var(--vttf-text-weight-semibold);
-    font-size: 14px;
-    color: var(--vttf-text);
-  }
-
-  .vttf-dropzone__sub {
-    font-family: var(--vttf-font-mono);
-    font-size: 11px;
-  }
-
-  /* ════════ ITEM ROW ════════ */
-
-  .vttf-item-row {
-    display: grid;
-    grid-template-columns: 24px 32px 1fr auto auto;
-    align-items: center;
-    gap: var(--vttf-space-3);
-    padding: 8px 10px;
-    border: 1px solid var(--vttf-border);
-    border-radius: var(--vttf-radius-sm);
-    background: var(--vttf-surface);
-  }
-
-  .vttf-item-row + .vttf-item-row {
-    margin-top: -1px;
-  }
-
-  .vttf-item-row__grip {
-    color: var(--vttf-text-faint);
-    cursor: grab;
-    font-family: var(--vttf-font-mono);
-    font-size: 14px;
-  }
-
-  .vttf-item-row__thumb {
-    width: 32px;
-    height: 32px;
-    border-radius: var(--vttf-radius-sm);
-    background: var(--vttf-surface-2);
-    border: 1px solid var(--vttf-border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: var(--vttf-font-mono);
-    font-size: 12px;
-    color: var(--vttf-text-faint);
-  }
-
-  .vttf-item-row__name {
-    font-size: 14px;
-    font-weight: 500;
-  }
-
-  .vttf-item-row__meta {
-    font-family: var(--vttf-font-mono);
-    font-size: 11px;
-    color: var(--vttf-text-faint);
-  }
+/* ════════ BUTTONS ════════ */
+
+.vttf-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vttf-space-2);
+  padding: 10px 16px;
+  border-radius: var(--vttf-radius-md);
+  font-family: var(--vttf-font-body);
+  font-weight: var(--vttf-text-weight-semibold);
+  font-size: 14px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition:
+    transform var(--vttf-duration-fast) var(--vttf-ease-out),
+    box-shadow var(--vttf-duration-fast) var(--vttf-ease-out),
+    background var(--vttf-duration-fast) var(--vttf-ease-out),
+    border-color var(--vttf-duration-fast) var(--vttf-ease-out);
+}
+
+.vttf-btn:active {
+  transform: translateY(1px);
+}
+
+.vttf-btn[disabled],
+.vttf-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.vttf-btn--primary {
+  background: var(--vttf-ember);
+  color: var(--vttf-text-inverse);
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 0.2) inset,
+    var(--vttf-shadow-sm);
+}
+.vttf-btn--primary:hover {
+  background: var(--vttf-ember-glow);
+}
+
+.vttf-btn--secondary {
+  background: var(--vttf-surface);
+  color: var(--vttf-text);
+  border-color: var(--vttf-border-strong);
+}
+.vttf-btn--secondary:hover {
+  background: var(--vttf-surface-2);
+  border-color: var(--vttf-text-faint);
+}
+
+.vttf-btn--ghost {
+  background: transparent;
+  color: var(--vttf-text-muted);
+}
+.vttf-btn--ghost:hover {
+  color: var(--vttf-text);
+  background: var(--vttf-surface);
+}
+
+.vttf-btn--danger {
+  background: transparent;
+  color: var(--vttf-rose);
+  border-color: color-mix(in oklch, var(--vttf-rose) 40%, transparent);
+}
+.vttf-btn--danger:hover {
+  background: color-mix(in oklch, var(--vttf-rose) 10%, transparent);
+}
+
+.vttf-btn .vttf-kbd {
+  font-family: var(--vttf-font-mono);
+  font-size: 11px;
+  padding: 1px 5px;
+  border-radius: var(--vttf-radius-sm);
+  background: rgb(0 0 0 / 0.25);
+  color: inherit;
+  opacity: 0.7;
+}
+
+/* ════════ BADGES ════════ */
+
+.vttf-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: var(--vttf-radius-full);
+  font-family: var(--vttf-font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid;
+  line-height: 1.5;
+}
+
+.vttf-badge__blip {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--vttf-radius-full);
+  background: currentColor;
+}
+
+.vttf-badge--ember {
+  color: var(--vttf-ember);
+  border-color: color-mix(in oklch, var(--vttf-ember) 40%, transparent);
+  background: color-mix(in oklch, var(--vttf-ember) 8%, transparent);
+}
+.vttf-badge--steel {
+  color: var(--vttf-steel);
+  border-color: color-mix(in oklch, var(--vttf-steel) 40%, transparent);
+  background: color-mix(in oklch, var(--vttf-steel) 8%, transparent);
+}
+.vttf-badge--mint {
+  color: var(--vttf-mint);
+  border-color: color-mix(in oklch, var(--vttf-mint) 40%, transparent);
+  background: color-mix(in oklch, var(--vttf-mint) 8%, transparent);
+}
+.vttf-badge--gold {
+  color: var(--vttf-gold);
+  border-color: color-mix(in oklch, var(--vttf-gold) 40%, transparent);
+  background: color-mix(in oklch, var(--vttf-gold) 8%, transparent);
+}
+.vttf-badge--rose {
+  color: var(--vttf-rose);
+  border-color: color-mix(in oklch, var(--vttf-rose) 40%, transparent);
+  background: color-mix(in oklch, var(--vttf-rose) 8%, transparent);
+}
+.vttf-badge--violet {
+  color: var(--vttf-violet);
+  border-color: color-mix(in oklch, var(--vttf-violet) 40%, transparent);
+  background: color-mix(in oklch, var(--vttf-violet) 8%, transparent);
+}
+.vttf-badge--muted {
+  color: var(--vttf-text-muted);
+  border-color: var(--vttf-border);
+  background: var(--vttf-surface);
+}
+
+/* ════════ CODE BLOCK + SYNTAX TOKENS ════════ */
+
+.vttf-codeblock {
+  background: var(--vttf-bg-sunken);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-lg);
+  overflow: hidden;
+  font-family: var(--vttf-font-mono);
+}
+
+.vttf-codeblock__head {
+  display: flex;
+  align-items: center;
+  gap: var(--vttf-space-3);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--vttf-border);
+  background: color-mix(in oklch, var(--vttf-bg-elevated) 70%, transparent);
+  font-size: 12px;
+  color: var(--vttf-text-muted);
+}
+
+.vttf-codeblock__dots {
+  display: flex;
+  gap: 6px;
+}
+.vttf-codeblock__dots span {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--vttf-radius-full);
+  background: var(--vttf-border-strong);
+}
+
+.vttf-codeblock__file {
+  color: var(--vttf-text);
+  background: var(--vttf-surface);
+  padding: 4px 10px;
+  border-radius: var(--vttf-radius-sm);
+  border: 1px solid var(--vttf-border);
+}
+
+.vttf-codeblock__lang {
+  margin-left: auto;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vttf-text-faint);
+}
+
+.vttf-codeblock pre {
+  margin: 0;
+  padding: var(--vttf-space-5);
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--vttf-text);
+  overflow-x: auto;
+}
+
+.vttf-tk-com {
+  color: var(--vttf-text-faint);
+  font-style: italic;
+}
+.vttf-tk-kw {
+  color: var(--vttf-violet);
+}
+.vttf-tk-fn {
+  color: var(--vttf-ember-glow);
+}
+.vttf-tk-str {
+  color: var(--vttf-mint);
+}
+.vttf-tk-num {
+  color: var(--vttf-gold);
+}
+.vttf-tk-ty {
+  color: var(--vttf-steel);
+}
+.vttf-tk-pun {
+  color: var(--vttf-text-muted);
+}
+.vttf-tk-prop {
+  color: var(--vttf-text);
+}
+
+/* ════════ FORM GRID + FIELD ════════ */
+
+.vttf-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--vttf-space-6);
+}
+
+.vttf-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.vttf-form-field > label {
+  font-family: var(--vttf-font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--vttf-text-faint);
+}
+
+.vttf-form-field .vttf-hint {
+  font-size: 12px;
+  color: var(--vttf-text-muted);
+}
+
+/* ════════ TEXT INPUTS ════════ */
+
+.vttf-input,
+.vttf-textarea,
+.vttf-select {
+  background: var(--vttf-bg-sunken);
+  border: 1px solid var(--vttf-border);
+  color: var(--vttf-text);
+  padding: 9px 12px;
+  border-radius: var(--vttf-radius-sm);
+  font-family: var(--vttf-font-body);
+  font-size: 14px;
+  width: 100%;
+  transition:
+    border-color var(--vttf-duration-fast) var(--vttf-ease-out),
+    box-shadow var(--vttf-duration-fast) var(--vttf-ease-out);
+}
+
+.vttf-input:focus-visible,
+.vttf-textarea:focus-visible,
+.vttf-select:focus-visible {
+  border-color: var(--vttf-ember);
+}
+
+.vttf-input[aria-invalid="true"],
+.vttf-input.is-invalid,
+.vttf-textarea[aria-invalid="true"],
+.vttf-textarea.is-invalid,
+.vttf-select[aria-invalid="true"],
+.vttf-select.is-invalid {
+  border-color: var(--vttf-rose);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--vttf-rose) 18%, transparent);
+}
+
+.vttf-textarea {
+  min-height: 96px;
+  resize: vertical;
+  font-family: var(--vttf-font-mono);
+  font-size: 13px;
+}
+
+.vttf-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M3 5l3 3 3-3' stroke='%23999' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 32px;
+}
+
+/* ════════ CHECKBOXES + RADIOS ════════ */
+
+.vttf-check,
+.vttf-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vttf-space-2);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.vttf-check input,
+.vttf-radio input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.vttf-check__box,
+.vttf-radio__box {
+  width: 16px;
+  height: 16px;
+  background: var(--vttf-bg-sunken);
+  border: 1.5px solid var(--vttf-border-strong);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  transition:
+    background var(--vttf-duration-fast) var(--vttf-ease-out),
+    border-color var(--vttf-duration-fast) var(--vttf-ease-out);
+}
+
+.vttf-check__box {
+  border-radius: var(--vttf-radius-sm);
+}
+.vttf-radio__box {
+  border-radius: var(--vttf-radius-full);
+}
+
+.vttf-check input:checked + .vttf-check__box {
+  background: var(--vttf-ember);
+  border-color: var(--vttf-ember);
+}
+.vttf-check input:checked + .vttf-check__box::after {
+  content: "";
+  width: 9px;
+  height: 5px;
+  border-left: 2px solid var(--vttf-text-inverse);
+  border-bottom: 2px solid var(--vttf-text-inverse);
+  transform: rotate(-45deg) translate(1px, -1px);
+}
+
+.vttf-radio input:checked + .vttf-radio__box {
+  border-color: var(--vttf-ember);
+}
+.vttf-radio input:checked + .vttf-radio__box::after {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: var(--vttf-radius-full);
+  background: var(--vttf-ember);
+}
+
+.vttf-check input:focus-visible + .vttf-check__box,
+.vttf-radio input:focus-visible + .vttf-radio__box {
+  box-shadow: var(--vttf-focus-ring);
+}
+
+/* ════════ SWITCH ════════ */
+
+.vttf-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vttf-space-3);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.vttf-switch input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.vttf-switch__track {
+  width: 36px;
+  height: 20px;
+  border-radius: var(--vttf-radius-full);
+  background: var(--vttf-surface-2);
+  border: 1px solid var(--vttf-border-strong);
+  position: relative;
+  transition:
+    background var(--vttf-duration-base) var(--vttf-ease-out),
+    border-color var(--vttf-duration-base) var(--vttf-ease-out);
+}
+
+.vttf-switch__track::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  top: 2px;
+  left: 2px;
+  background: var(--vttf-text-muted);
+  border-radius: var(--vttf-radius-full);
+  transition:
+    transform var(--vttf-duration-base) var(--vttf-ease-out),
+    background var(--vttf-duration-base) var(--vttf-ease-out);
+}
+
+.vttf-switch input:checked + .vttf-switch__track {
+  background: var(--vttf-ember);
+  border-color: var(--vttf-ember);
+}
+
+.vttf-switch input:checked + .vttf-switch__track::after {
+  transform: translateX(16px);
+  background: var(--vttf-text-inverse);
+}
+
+.vttf-switch input:focus-visible + .vttf-switch__track {
+  box-shadow: var(--vttf-focus-ring);
+}
+
+/* ════════ RANGE ════════ */
+
+.vttf-range {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 4px;
+  background: var(--vttf-surface-2);
+  border-radius: var(--vttf-radius-full);
+  outline: none;
+}
+
+.vttf-range::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--vttf-radius-full);
+  background: var(--vttf-ember);
+  border: 2px solid var(--vttf-bg);
+  box-shadow: var(--vttf-shadow-sm);
+  cursor: pointer;
+}
+
+.vttf-range::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: var(--vttf-radius-full);
+  background: var(--vttf-ember);
+  border: 2px solid var(--vttf-bg);
+  cursor: pointer;
+}
+
+/* ════════ SEGMENTED CONTROL ════════ */
+
+.vttf-segment {
+  display: inline-flex;
+  padding: 3px;
+  background: var(--vttf-surface);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-md);
+}
+
+.vttf-segment button {
+  border: none;
+  background: transparent;
+  color: var(--vttf-text-muted);
+  font-family: var(--vttf-font-body);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: var(--vttf-radius-sm);
+  cursor: pointer;
+  transition:
+    background var(--vttf-duration-fast) var(--vttf-ease-out),
+    color var(--vttf-duration-fast) var(--vttf-ease-out),
+    box-shadow var(--vttf-duration-fast) var(--vttf-ease-out);
+}
+
+.vttf-segment button:hover {
+  color: var(--vttf-text);
+}
+
+.vttf-segment button[aria-pressed="true"],
+.vttf-segment button[aria-selected="true"],
+.vttf-segment button.is-active {
+  background: var(--vttf-bg-sunken);
+  color: var(--vttf-text);
+  box-shadow: var(--vttf-shadow-sm);
+}
+
+/* ════════ TABS ════════ */
+
+.vttf-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 var(--vttf-space-4);
+  border-bottom: 1px solid var(--vttf-border);
+  background: var(--vttf-bg-elevated);
+}
+
+.vttf-tab {
+  padding: 10px 14px;
+  font-family: var(--vttf-font-body);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--vttf-text-muted);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition:
+    color var(--vttf-duration-fast) var(--vttf-ease-out),
+    border-color var(--vttf-duration-fast) var(--vttf-ease-out);
+}
+
+.vttf-tab:hover {
+  color: var(--vttf-text);
+}
+
+.vttf-tab[aria-selected="true"],
+.vttf-tab.is-active {
+  color: var(--vttf-text);
+  border-bottom-color: var(--vttf-ember);
+}
+
+.vttf-tab__count {
+  font-family: var(--vttf-font-mono);
+  font-size: 10px;
+  margin-left: 6px;
+  color: var(--vttf-text-faint);
+}
+
+/* ════════ SHEET CONTAINER ════════ */
+
+.vttf-sheet {
+  background: var(--vttf-bg-elevated);
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-lg);
+  overflow: hidden;
+}
+
+.vttf-sheet__head {
+  padding: var(--vttf-space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--vttf-space-4);
+  border-bottom: 1px solid var(--vttf-border);
+  background: var(--vttf-surface);
+}
+
+.vttf-sheet__title {
+  font-family: var(--vttf-font-display);
+  font-size: 22px;
+  font-weight: var(--vttf-text-weight-semibold);
+  letter-spacing: -0.02em;
+}
+
+.vttf-sheet__sub {
+  font-family: var(--vttf-font-mono);
+  font-size: 11px;
+  color: var(--vttf-text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.vttf-sheet__body {
+  padding: var(--vttf-space-5);
+  display: grid;
+  gap: var(--vttf-space-3);
+}
+
+.vttf-portrait {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--vttf-radius-md);
+  background:
+    repeating-linear-gradient(
+      45deg,
+      color-mix(in oklch, var(--vttf-ember-deep) 18%, transparent) 0 6px,
+      color-mix(in oklch, var(--vttf-ember-deep) 8%, transparent) 6px 12px
+    ),
+    var(--vttf-surface-2);
+  border: 1px dashed var(--vttf-border-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--vttf-font-mono);
+  font-size: 10px;
+  color: var(--vttf-text-faint);
+}
+
+.vttf-field-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: var(--vttf-space-4);
+  align-items: center;
+}
+
+.vttf-field-label {
+  font-family: var(--vttf-font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vttf-text-faint);
+}
+
+/* ════════ STAT PILL ════════ */
+
+.vttf-stat-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vttf-space-2);
+  padding: 4px 10px 4px 4px;
+  background: var(--vttf-surface);
+  border-radius: var(--vttf-radius-full);
+  border: 1px solid var(--vttf-border);
+}
+
+.vttf-stat-pill__n {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--vttf-radius-full);
+  background: var(--vttf-ember);
+  color: var(--vttf-text-inverse);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--vttf-font-mono);
+  font-weight: var(--vttf-text-weight-bold);
+  font-size: 13px;
+}
+
+.vttf-stat-pill__label {
+  font-size: 12px;
+  color: var(--vttf-text-muted);
+  font-family: var(--vttf-font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ════════ DROPZONE ════════ */
+
+.vttf-dropzone {
+  border: 1.5px dashed var(--vttf-border-strong);
+  border-radius: var(--vttf-radius-md);
+  padding: var(--vttf-space-6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--vttf-space-2);
+  color: var(--vttf-text-muted);
+  background: color-mix(in oklch, var(--vttf-bg) 40%, transparent);
+  transition:
+    background var(--vttf-duration-fast) var(--vttf-ease-out),
+    border-color var(--vttf-duration-fast) var(--vttf-ease-out);
+}
+
+.vttf-dropzone.is-active,
+.vttf-dropzone[data-drop-effect] {
+  border-color: var(--vttf-ember);
+  color: var(--vttf-ember);
+  background: color-mix(in oklch, var(--vttf-ember) 6%, transparent);
+  box-shadow: var(--vttf-glow-ember);
+}
+
+.vttf-dropzone__icon {
+  font-family: var(--vttf-font-mono);
+  font-size: 24px;
+}
+
+.vttf-dropzone__title {
+  font-family: var(--vttf-font-body);
+  font-weight: var(--vttf-text-weight-semibold);
+  font-size: 14px;
+  color: var(--vttf-text);
+}
+
+.vttf-dropzone__sub {
+  font-family: var(--vttf-font-mono);
+  font-size: 11px;
+}
+
+/* ════════ ITEM ROW ════════ */
+
+.vttf-item-row {
+  display: grid;
+  grid-template-columns: 24px 32px 1fr auto auto;
+  align-items: center;
+  gap: var(--vttf-space-3);
+  padding: 8px 10px;
+  border: 1px solid var(--vttf-border);
+  border-radius: var(--vttf-radius-sm);
+  background: var(--vttf-surface);
+}
+
+.vttf-item-row + .vttf-item-row {
+  margin-top: -1px;
+}
+
+.vttf-item-row__grip {
+  color: var(--vttf-text-faint);
+  cursor: grab;
+  font-family: var(--vttf-font-mono);
+  font-size: 14px;
+}
+
+.vttf-item-row__thumb {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--vttf-radius-sm);
+  background: var(--vttf-surface-2);
+  border: 1px solid var(--vttf-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--vttf-font-mono);
+  font-size: 12px;
+  color: var(--vttf-text-faint);
+}
+
+.vttf-item-row__name {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.vttf-item-row__meta {
+  font-family: var(--vttf-font-mono);
+  font-size: 11px;
+  color: var(--vttf-text-faint);
 }

--- a/packages/styles/index.css
+++ b/packages/styles/index.css
@@ -1,16 +1,29 @@
 /*!
  * @vttforge/styles
  *
- * One-line import for consumers that want everything VTTForge ships, in the right
- * cascade-layer order.
+ * One-line import for consumers that want everything VTTForge ships:
  *
  *   @import '@vttforge/styles';
  *
- * Layer order matches Foundry v13's outer layer: tokens → reset → base → components → themes.
- * Foundry's own runtime wraps system CSS in its top-level `system` layer.
+ * Only tokens and the reset sit in a cascade layer. Base, components and the
+ * theme are deliberately unlayered.
+ *
+ * The reason is a rule of the cascade itself: an unlayered author rule beats
+ * every layered author rule, whatever the specificity. Foundry loads a system
+ * or module stylesheet unlayered unless its manifest asks otherwise, so most
+ * packages on the page write plain CSS. Put these components in a layer and a
+ * bare `button { border-radius: 99px }` from an unrelated module overrides
+ * every one of them, and no amount of specificity gets it back. Leaving the
+ * visible parts unlayered is what keeps a VTTForge sheet looking like itself
+ * when other packages are installed.
+ *
+ * Tokens and the reset stay layered on purpose, and lose on purpose. Tokens are
+ * custom properties a consumer must be able to override with one plain
+ * declaration. The reset touches bare elements inside `.vttf-app`, so keeping it
+ * layered means it never outranks a real rule from the system around it.
  */
 
-@layer vttforge.tokens, vttforge.reset, vttforge.base, vttforge.components, vttforge.themes;
+@layer vttforge.tokens, vttforge.reset;
 
 @import "./dist/tokens.css";
 @import "./reset.css";

--- a/packages/styles/styles.layer.css
+++ b/packages/styles/styles.layer.css
@@ -1,13 +1,17 @@
 /*!
  * @vttforge/styles — styles.layer.css
  *
- * Mantine-style variant: wraps `index.css` inside an explicit `@layer vttforge`
- * for consumers that want a single namespaced layer instead of the five
- * sub-layers (`vttforge.tokens`, `vttforge.reset`, `vttforge.base`,
- * `vttforge.components`, `vttforge.themes`).
+ * The opt-in variant: everything VTTForge ships, wrapped in one `@layer
+ * vttforge` you can order against your own layers.
  *
- * Use this entry when you need to control VTTForge's cascade position relative
- * to your own layers; use the default `index.css` otherwise.
+ *   @layer reset, vttforge, my-system;
+ *   @import '@vttforge/styles/layer';
+ *
+ * This entry trades away the cascade position the default entry gives you.
+ * Inside a layer, VTTForge's own rules lose to every unlayered rule on the
+ * page, which is how most other systems and modules ship their CSS. That is
+ * the point of the variant: you decide where the styles sit. Reach for
+ * `index.css` unless you have that need.
  */
 
 @layer vttforge {

--- a/packages/styles/themes/forge.css
+++ b/packages/styles/themes/forge.css
@@ -6,26 +6,24 @@
  * preference takes over. Explicit `data-theme="light"` and
  * `data-theme="foundry"` are handled by tokens.css.
  *
- * Imported by `index.css` and `styles.layer.css` after components, so theme
- * overrides win cleanly inside `@layer vttforge.themes`.
+ * Imported after components and, like them, unlayered: theme overrides win on
+ * source order.
  */
 
-@layer vttforge.themes {
-  @media (prefers-color-scheme: light) {
-    :where([data-theme="auto"]) {
-      --vttf-bg: oklch(0.985 0.004 80);
-      --vttf-bg-elevated: oklch(0.972 0.006 78);
-      --vttf-bg-sunken: oklch(0.945 0.01 72);
-      --vttf-surface: oklch(0.962 0.008 75);
-      --vttf-surface-2: oklch(0.928 0.012 68);
-      --vttf-border: oklch(0.88 0.014 62);
-      --vttf-border-strong: oklch(0.76 0.016 58);
-      --vttf-text: oklch(0.215 0.02 42);
-      --vttf-text-muted: oklch(0.43 0.018 48);
-      --vttf-text-faint: oklch(0.595 0.014 55);
-      --vttf-ember: oklch(0.565 0.18 36);
-      --vttf-ember-deep: oklch(0.43 0.16 30);
-      --vttf-ember-glow: oklch(0.67 0.17 42);
-    }
+@media (prefers-color-scheme: light) {
+  :where([data-theme="auto"]) {
+    --vttf-bg: oklch(0.985 0.004 80);
+    --vttf-bg-elevated: oklch(0.972 0.006 78);
+    --vttf-bg-sunken: oklch(0.945 0.01 72);
+    --vttf-surface: oklch(0.962 0.008 75);
+    --vttf-surface-2: oklch(0.928 0.012 68);
+    --vttf-border: oklch(0.88 0.014 62);
+    --vttf-border-strong: oklch(0.76 0.016 58);
+    --vttf-text: oklch(0.215 0.02 42);
+    --vttf-text-muted: oklch(0.43 0.018 48);
+    --vttf-text-faint: oklch(0.595 0.014 55);
+    --vttf-ember: oklch(0.565 0.18 36);
+    --vttf-ember-deep: oklch(0.43 0.16 30);
+    --vttf-ember-glow: oklch(0.67 0.17 42);
   }
 }


### PR DESCRIPTION
Base, components and the theme sat in `@layer vttforge.*`. That threw away the cascade position the package needs.

An unlayered author rule beats every layered one, whatever the specificity, and layer order is settled before specificity is ever consulted. Foundry loads a system or module stylesheet unlayered unless the manifest asks for a layer, so most packages on the page write plain CSS. One of them shipping this:

```css
button { border-radius: 99px; }
```

beat `.vttf-btn`, and nothing a consumer could write would win it back.

I measured it rather than reasoning about it. Two pages, identical but for the stylesheet, loaded against the real core CSS from a running Foundry with a rival rule added:

| build | rules in a layer | button radius |
|---|---|---|
| before | 102 | 99px, the rival wins |
| after | 0 | 6px, holds |

Worth saying plainly: the layered build did **not** lose to Foundry itself. `vttforge` is a layer core never declared, so it sorted last and won. The failure was only ever against other packages. Earlier notes in this repo claiming otherwise are corrected here.

Tokens and the reset stay layered, and lose on purpose. Tokens are custom properties a consumer overrides with one plain declaration, and a reset that outranks real rules is a bug waiting to happen.

`styles.layer.css` still wraps everything in one `@layer vttforge` for consumers who order these styles against layers of their own. It gives up the position by design, and now says so.

## Verification

The e2e suite gets a test that renders a sheet in a real Foundry, plants `button { border-radius: 99px }` on the page the way another module would, and fails if the button loses its radius. Run against the old build it reports 102 offending rules and a 99px button, so it can actually fail.