### PR TITLE
feat(testing): let withMockFoundry install any global

### DIFF
--- a/.changeset/lazy-moles-judge.md
+++ b/.changeset/lazy-moles-judge.md
@@ -1,0 +1,15 @@
+---
+'@vttforge/testing': minor
+---
+
+`withMockFoundry` takes a `globals` option for anything outside the fixed set it installs.
+
+Foundry puts every document class on the global scope, and code under test reaches for them by name. `JournalEntry.create`, `Actor.create`, `ChatMessage.getSpeaker`. None of those were covered, so testing code that touched one meant saving and restoring the global by hand in every file.
+
+```ts
+const foundry = withMockFoundry({
+  globals: { JournalEntry: { create: vi.fn() } },
+});
+```
+
+`restore()` clears them along with the rest, putting back whatever was there before, including nothing. Naming one of the built-ins overrides it rather than being overwritten by it.

--- a/apps/docs/guide/testing.md
+++ b/apps/docs/guide/testing.md
@@ -23,6 +23,17 @@ not merely on what did not throw.
 
 `restore()` puts every global back, including deleting the ones that never
 existed.
+Anything else your code reads goes in `globals`. Foundry puts every document
+class on the global scope, and the fixed set above does not include them:
+
+```ts
+const foundry = withMockFoundry({
+  globals: { JournalEntry: { create: vi.fn() } },
+});
+```
+
+`restore()` clears those too, and puts back whatever was there before.
+
 
 Importing from this entry also declares the globals, so `game.settings` in a
 test does not produce "Cannot find name 'game'". There is nothing to configure.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -28,6 +28,17 @@ settings, notifications) so a test can assert on what happened rather than only
 on what did not throw. `restore()` puts every global back, including deleting the
 ones that never existed.
 
+Anything else your code reads goes in `globals`. Foundry puts every document
+class on the global scope, and the fixed set above does not include them:
+
+```ts
+const foundry = withMockFoundry({
+  globals: { JournalEntry: { create: vi.fn() } },
+});
+```
+
+`restore()` clears those too.
+
 The mock documents behave like real ones where it counts: `update` merges rather
 than replacing, and dotted paths expand. Both matter: a mock that replaces lets
 a test pass while the real thing drops every sibling key.

--- a/packages/testing/src/__tests__/with-mock-foundry.test.ts
+++ b/packages/testing/src/__tests__/with-mock-foundry.test.ts
@@ -93,6 +93,34 @@ describe('withMockFoundry', () => {
   });
 });
 
+describe('extra globals', () => {
+  it('installs a global the fixed set does not cover', () => {
+    // Foundry puts every document class on the global scope, and code under
+    // test reaches for them by name: Actor.create, JournalEntry.create.
+    const JournalEntry = { create: () => Promise.resolve({ id: 'j1' }) };
+    mock = withMockFoundry({ globals: { JournalEntry } });
+    expect((globalThis as Record<string, unknown>).JournalEntry).toBe(JournalEntry);
+  });
+
+  it('removes it again on restore', () => {
+    withMockFoundry({ globals: { JournalEntry: {} } }).restore();
+    expect('JournalEntry' in globalThis).toBe(false);
+  });
+
+  it('puts back a value that was already there', () => {
+    const scope = globalThis as Record<string, unknown>;
+    scope.JournalEntry = 'the original';
+    withMockFoundry({ globals: { JournalEntry: 'the mock' } }).restore();
+    expect(scope.JournalEntry).toBe('the original');
+    delete scope.JournalEntry;
+  });
+
+  it('lets you override one of the built-ins', () => {
+    mock = withMockFoundry({ globals: { CONST: { mine: true } } });
+    expect((globalThis as Record<string, unknown>).CONST).toEqual({ mine: true });
+  });
+});
+
 describe('mock documents', () => {
   it('records every update the code under test made', async () => {
     const actor = createMockActor({ name: 'Vitória' });

--- a/packages/testing/src/vitest/with-mock-foundry.ts
+++ b/packages/testing/src/vitest/with-mock-foundry.ts
@@ -82,6 +82,22 @@ export interface MockFoundryOptions {
   foundry?: Record<string, unknown>;
   /** Extra `game.*` members, merged over the defaults. */
   game?: Record<string, unknown>;
+  /**
+   * Any other globals your code reads, installed for the life of the mock and
+   * removed by `restore()` along with the rest.
+   *
+   * Foundry puts each document class on the global scope, and code under test
+   * reaches for them by name: `Actor.create`, `JournalEntry.create`,
+   * `ChatMessage.getSpeaker`. Those are not part of the fixed set this helper
+   * installs, so name the ones you need.
+   *
+   * ```ts
+   * withMockFoundry({
+   *   globals: { JournalEntry: { create: vi.fn() } },
+   * });
+   * ```
+   */
+  globals?: Record<string, unknown>;
 }
 
 const GLOBALS = ['foundry', 'game', 'CONFIG', 'Hooks', 'ui', 'CONST'] as const;
@@ -138,7 +154,10 @@ function expandObject(flat: Record<string, unknown>): Record<string, unknown> {
 export function withMockFoundry(options: MockFoundryOptions = {}): MockFoundry {
   const saved = new Map<string, unknown>();
   const scope = globalThis as Record<string, unknown>;
-  for (const name of GLOBALS) saved.set(name, scope[name]);
+  const extra = Object.keys(options.globals ?? {});
+  // Saved before anything is installed, so `restore()` puts back whatever was
+  // there, including nothing.
+  for (const name of [...GLOBALS, ...extra]) saved.set(name, scope[name]);
 
   const hooks: RecordedHook[] = [];
   const settings: RecordedSetting[] = [];
@@ -262,6 +281,10 @@ export function withMockFoundry(options: MockFoundryOptions = {}): MockFoundry {
     },
     ...options.game,
   };
+
+  // Last, so naming one of the built-ins here overrides it rather than
+  // being overwritten by it.
+  for (const [name, value] of Object.entries(options.globals ?? {})) scope[name] = value;
 
   return {
     hooks,


### PR DESCRIPTION
Found by using it. Writing tests for a module that creates a `JournalEntry`, there was no way to mock the class.

Foundry puts every document class on the global scope, and code under test reaches for them by name: `JournalEntry.create`, `Actor.create`, `ChatMessage.getSpeaker`. The helper installed a fixed set of six and none of those were in it, so the consumer saved and restored the global by hand in every file.

```ts
const foundry = withMockFoundry({
  globals: { JournalEntry: { create: vi.fn() } },
});
```

They are torn down with the rest, restoring whatever was there before, including nothing. Naming one of the built-ins overrides it rather than losing to it, since the extras install last.