### PR TITLE
feat(core): offer the i18nInit and setup hooks

### DIFF
--- a/.changeset/brown-cows-invite.md
+++ b/.changeset/brown-cows-invite.md
@@ -1,0 +1,7 @@
+---
+'@vttforge/cli': patch
+---
+
+Follow the `@vttforge/core` minor in the scaffold's pin, so a new project gets the `onI18nInit` and `onSetup` hooks.
+
+On a `0.x` version a caret pins the minor, so `^0.11.0` would have kept new projects on the release before them.

--- a/.changeset/olive-donkeys-happen.md
+++ b/.changeset/olive-donkeys-happen.md
@@ -1,0 +1,27 @@
+---
+'@vttforge/core': minor
+---
+
+Add `onI18nInit` and `onSetup` to `registerSystem` and `registerModule`.
+
+Foundry starts a world in four stages and only two of them were reachable. The missing two are the ones that are hard to work around.
+
+`i18nInit` is the first moment `game.i18n` works. A label localized during `init` comes back as the key you passed in, because the language files have not loaded, and that raw key is what players read on screen. Translate CONFIG labels in `onI18nInit` instead, once, rather than calling `localize` on every render.
+
+`setup` runs after every package has finished its own `init`. A setting registered during `init` can be read from here on, and a module can see what the system around it registered instead of racing it.
+
+```ts
+registerSystem({
+  id: 'my-system',
+  onI18nInit: () => {
+    for (const ability of Object.values(CONFIG.MY_SYSTEM.abilities)) {
+      ability.label = game.i18n.localize(ability.label);
+    }
+  },
+  onSetup: () => {
+    if (settings.get('showTutorial')) openTutorial();
+  },
+});
+```
+
+Both are optional and neither is GM-gated. Omit one and no hook is staged for it.

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -107,6 +107,7 @@ export default defineConfig({
           text: 'Guide',
           items: [
             { text: 'Getting started', link: '/guide/getting-started' },
+            { text: 'The startup lifecycle', link: '/guide/lifecycle' },
             { text: 'Data models', link: '/guide/data-models' },
             { text: 'Sheets', link: '/guide/sheets' },
             { text: 'Modules', link: '/guide/modules' },

--- a/apps/docs/guide/lifecycle.md
+++ b/apps/docs/guide/lifecycle.md
@@ -1,0 +1,73 @@
+# The startup lifecycle
+
+Foundry starts a world in four stages, and each one exists because the stage
+before it cannot do the job. `registerSystem` and `registerModule` take a
+callback for each.
+
+```ts
+registerSystem({
+  id: 'my-system',
+  onBeforeInit: () => {},   // before any CONFIG mutation
+  onAfterInit: () => {},    // init, after the mutations
+  onI18nInit: () => {},     // languages loaded
+  onSetup: () => {},        // every package loaded
+  onReady: async () => {},  // the world is open
+});
+```
+
+Register only the ones you use. A callback you leave out stages no hook at all.
+
+## What each stage is for
+
+**`init`** is where CONFIG gets written: data models, document classes, sheets,
+the initiative formula, settings. `registerSystem` does most of it for you from
+the options you pass. `onBeforeInit` runs first, before anything is touched, and
+is the usual home for `globalThis.<systemId>`. `onAfterInit` runs last, and is
+where settings get registered.
+
+There is no `game.user` yet, no `game.actors`, no canvas.
+
+**`i18nInit`** is the first moment `game.i18n` works. This matters more than it
+sounds. A label you localize during `init` comes back as the key you passed in,
+because the language files have not loaded, and that raw key is what players
+read on screen. So translate CONFIG labels here, once:
+
+```ts
+onI18nInit: () => {
+  for (const ability of Object.values(CONFIG.MY_SYSTEM.abilities)) {
+    ability.label = game.i18n.localize(ability.label);
+  }
+},
+```
+
+Doing it once here beats calling `localize` on every render, and it is the
+difference between a config table that reads `MY.Abilities.str` and one that
+reads Strength.
+
+**`setup`** runs after every package has finished its own `init`. Two things
+become possible. A setting you registered during `init` can now be read. And a
+module can now see what the system around it registered, which is why a module
+that extends a system does that work here rather than racing it in `init`.
+
+Compendium packs are available. World documents are not.
+
+**`ready`** is the world, open. `game.actors`, `game.scenes`, `game.user`, the
+canvas. Migrations go here, guarded, because they write to the world:
+
+```ts
+onReady: async () => {
+  if (!game.user.isGM) return;
+  await migrations.run();
+},
+```
+
+None of the callbacks are gated for you. `onReady` fires on every client, so a
+GM check is yours to write.
+
+## Why not do everything in `ready`
+
+It is tempting, because everything exists by then. The cost is that the user
+watches it happen. CONFIG written during `ready` lands after the sidebar has
+rendered against the old values, and a sheet that opened first opened wrong.
+Each stage is the earliest point its work can succeed, and earlier is what
+keeps the load looking like one step instead of several.

--- a/apps/docs/guide/settings-and-migrations.md
+++ b/apps/docs/guide/settings-and-migrations.md
@@ -27,7 +27,8 @@ Reading a key that was never registered throws `VTTF-0003` instead of
 returning `undefined`. A typo in a setting name is found the first time it is
 read, not by a user who wonders why a switch does nothing.
 
-Registration has to happen inside `init`. Reads work any time after.
+Registration has to happen inside `init`. Reads work from `setup` on. See [the
+startup lifecycle](/guide/lifecycle) for what each stage can do.
 
 ## Migrations
 

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.11.0"
+    "@vttforge/core": "^0.12.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.6.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.11.0"
+    "@vttforge/core": "^0.12.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.6.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.11.0",
+    "@vttforge/core": "^0.12.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.11.0",
+    "@vttforge/core": "^0.12.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/register-module.test.ts
+++ b/packages/core/src/__tests__/register-module.test.ts
@@ -22,11 +22,19 @@ class PdfActorData {}
 let CONFIG: FoundryConfig;
 let initHooks: Array<() => void>;
 let readyHooks: Array<() => void>;
+/** Every hook staged, in the order registerModule staged it. */
+let staged: Array<[string, () => void]>;
+
+/** The callbacks staged for one hook name. */
+function hooksFor(event: string): Array<() => void> {
+  return staged.filter(([name]) => name === event).map(([, fn]) => fn);
+}
 
 beforeEach(() => {
   _resetRegisteredModulesForTests();
   initHooks = [];
   readyHooks = [];
+  staged = [];
   CONFIG = {
     Actor: { dataModels: {}, documentClass: 'SystemActor' },
     Item: { dataModels: {}, documentClass: 'SystemItem' },
@@ -37,6 +45,7 @@ beforeEach(() => {
   (globalThis as Record<string, unknown>).CONFIG = CONFIG;
   (globalThis as Record<string, unknown>).Hooks = {
     once: (event: string, fn: () => void) => {
+      staged.push([event, fn]);
       if (event === 'init') initHooks.push(fn);
       if (event === 'ready') readyHooks.push(fn);
       return 0;
@@ -176,5 +185,58 @@ describe('registerModule', () => {
     });
     fireInit();
     expect(enrichers.map((e) => e.id)).toEqual(['pdf-character-sheet.link']);
+  });
+
+  it('does not register i18nInit or setup hooks when their callbacks are omitted', () => {
+    registerModule({ id: MODULE_ID });
+    expect(hooksFor('i18nInit')).toHaveLength(0);
+    expect(hooksFor('setup')).toHaveLength(0);
+  });
+
+  it('runs onI18nInit on the i18nInit hook, not on init', () => {
+    const onI18nInit = vi.fn();
+    registerModule({ id: MODULE_ID, onI18nInit });
+
+    // The whole point of the hook: CONFIG labels cannot be translated during
+    // init, because game.i18n has not loaded yet.
+    for (const hook of initHooks) hook();
+    expect(onI18nInit).not.toHaveBeenCalled();
+
+    const [hook] = hooksFor('i18nInit');
+    expect(hook).toBeDefined();
+    hook?.();
+    expect(onI18nInit).toHaveBeenCalledOnce();
+  });
+
+  it('runs onSetup on the setup hook', () => {
+    const onSetup = vi.fn();
+    registerModule({ id: MODULE_ID, onSetup });
+    const [hook] = hooksFor('setup');
+    expect(hook).toBeDefined();
+    hook?.();
+    expect(onSetup).toHaveBeenCalledOnce();
+  });
+
+  it('supports async onSetup (the returned promise is fire-and-forget)', async () => {
+    let resolved = false;
+    const onSetup = vi.fn(async () => {
+      await Promise.resolve();
+      resolved = true;
+    });
+    registerModule({ id: MODULE_ID, onSetup });
+    hooksFor('setup')[0]?.();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+
+  it('stages all four callbacks in the order Foundry fires them', () => {
+    registerModule({
+      id: MODULE_ID,
+      onAfterInit: vi.fn(),
+      onI18nInit: vi.fn(),
+      onSetup: vi.fn(),
+      onReady: vi.fn(),
+    });
+    expect(staged.map(([name]) => name)).toEqual(['init', 'i18nInit', 'setup', 'ready']);
   });
 });

--- a/packages/core/src/__tests__/register-system.test.ts
+++ b/packages/core/src/__tests__/register-system.test.ts
@@ -224,4 +224,70 @@ describe('registerSystem', () => {
     initCallback();
     expect(enrichers.map((e) => e.id)).toEqual(['my-system.spell']);
   });
+
+  it('does not register i18nInit or setup hooks when their callbacks are omitted', () => {
+    const { hooks } = setupFoundryGlobals();
+    registerSystem({ id: 'my-system' });
+    const staged = hooks.once.mock.calls.map((call) => call[0]);
+    expect(staged).not.toContain('i18nInit');
+    expect(staged).not.toContain('setup');
+  });
+
+  it('runs onI18nInit on the i18nInit hook, not on init', () => {
+    const { hooks } = setupFoundryGlobals();
+    const onI18nInit = vi.fn();
+    registerSystem({ id: 'my-system', onI18nInit });
+
+    // The whole point of the hook: CONFIG labels cannot be translated during
+    // init, because game.i18n has not loaded yet.
+    const initCallback = hooks.once.mock.calls.find(
+      (call) => call[0] === 'init',
+    )?.[1] as () => void;
+    initCallback();
+    expect(onI18nInit).not.toHaveBeenCalled();
+
+    const callback = hooks.once.mock.calls.find(
+      (call) => call[0] === 'i18nInit',
+    )?.[1] as () => void;
+    expect(callback).toBeDefined();
+    callback();
+    expect(onI18nInit).toHaveBeenCalledOnce();
+  });
+
+  it('runs onSetup on the setup hook', () => {
+    const { hooks } = setupFoundryGlobals();
+    const onSetup = vi.fn();
+    registerSystem({ id: 'my-system', onSetup });
+    const callback = hooks.once.mock.calls.find((call) => call[0] === 'setup')?.[1] as () => void;
+    expect(callback).toBeDefined();
+    callback();
+    expect(onSetup).toHaveBeenCalledOnce();
+  });
+
+  it('supports async onSetup (returned promise is fire-and-forget)', async () => {
+    const { hooks } = setupFoundryGlobals();
+    let resolved = false;
+    const onSetup = vi.fn(async () => {
+      await Promise.resolve();
+      resolved = true;
+    });
+    registerSystem({ id: 'my-system', onSetup });
+    const callback = hooks.once.mock.calls.find((call) => call[0] === 'setup')?.[1] as () => void;
+    callback();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+
+  it('stages all four callbacks in the order Foundry fires them', () => {
+    const { hooks } = setupFoundryGlobals();
+    registerSystem({
+      id: 'my-system',
+      onAfterInit: vi.fn(),
+      onI18nInit: vi.fn(),
+      onSetup: vi.fn(),
+      onReady: vi.fn(),
+    });
+    const staged = hooks.once.mock.calls.map((call) => call[0]);
+    expect(staged).toEqual(['init', 'i18nInit', 'setup', 'ready']);
+  });
 });

--- a/packages/core/src/register-module.ts
+++ b/packages/core/src/register-module.ts
@@ -67,6 +67,26 @@ export interface ModuleRegistration {
   readonly onAfterInit?: () => void;
 
   /**
+   * Runs on `i18nInit`, after Foundry loads the language files.
+   *
+   * This is where CONFIG labels get translated. `game.i18n` is not loaded
+   * during `init`, so `game.i18n.localize()` called there returns the key you
+   * passed it, and the untranslated key is what players see.
+   */
+  readonly onI18nInit?: () => void;
+
+  /**
+   * Runs on `setup`, after every package is loaded and before the canvas is
+   * drawn.
+   *
+   * For a module this is also the first point where the system it is extending
+   * has finished its own `init`, so it is the place to read what the system
+   * registered. A setting registered during `init` can only be read from here
+   * on. Keep world data out of it, that is `onReady`.
+   */
+  readonly onSetup?: () => void | Promise<void>;
+
+  /**
    * Runs once on `ready`.
    *
    * **Not GM-gated.** Guard inside your callback when the work is GM-only.
@@ -150,6 +170,16 @@ export function registerModule(config: ModuleRegistration): ModuleRegistration {
   hooks.once('init', () => {
     applyInit(config);
   });
+  if (config.onI18nInit !== undefined) {
+    hooks.once('i18nInit', () => {
+      config.onI18nInit?.();
+    });
+  }
+  if (config.onSetup !== undefined) {
+    hooks.once('setup', () => {
+      void config.onSetup?.();
+    });
+  }
   if (config.onReady !== undefined) {
     hooks.once('ready', () => {
       void config.onReady?.();

--- a/packages/core/src/register-system.ts
+++ b/packages/core/src/register-system.ts
@@ -5,14 +5,17 @@
  * Conforms to the canonical Foundry init lifecycle:
  *
  *   init       → CONFIG mutations (dataModels, documentClass, statusEffects)
- *   i18nInit   → translate CONFIG labels
- *   setup      → enrichers, packs
+ *   i18nInit   → translate the labels those mutations just wrote
+ *   setup      → work that needs registered settings or loaded packages
  *   ready      → migrations (GM-only; the consumer guards inside onReady)
  *
- * v0.1 scope: `init` + `ready`. `setup` / `i18nInit` callbacks remain v0.1.1.
+ * All four are offered. The middle two exist because `init` is too early for
+ * some work and `ready` is too late: `game.i18n` has not loaded during `init`,
+ * so a CONFIG label translated there comes out as its own key, and settings
+ * registered during `init` cannot be read until `setup`.
  *
- * Per PRD §11 open question #1, we wrap the hook ourselves ("explicit hook for
- * now"); callers don't need to write `Hooks.once("init", ...)` themselves.
+ * We wrap the hooks so callers never write `Hooks.once("init", ...)`
+ * themselves.
  */
 
 import { VttfError, type VttfErrorCode } from './errors/registry.js';
@@ -82,6 +85,37 @@ export interface SystemRegistration {
   readonly onAfterInit?: () => void;
 
   /**
+   * Optional `i18nInit` hook. Fires after Foundry loads the language files and
+   * before `setup`.
+   *
+   * This is where CONFIG labels get translated. `game.i18n` is not loaded
+   * during `init`, so `game.i18n.localize()` called there returns the key you
+   * passed it, and the untranslated key is what players see. Do it here
+   * instead, once, rather than localizing on every render.
+   *
+   * @example
+   * ```ts
+   * onI18nInit: () => {
+   *   for (const ability of Object.values(CONFIG.MY_SYSTEM.abilities)) {
+   *     ability.label = game.i18n.localize(ability.label);
+   *   }
+   * },
+   * ```
+   */
+  readonly onI18nInit?: () => void;
+
+  /**
+   * Optional `setup` hook. Fires after every package is loaded and before the
+   * canvas is drawn.
+   *
+   * The home for work that `init` is too early for and `ready` too late: a
+   * setting registered during `init` can only be read from here on, and
+   * compendium packs are available. Keep world data out of it, that is
+   * `onReady`.
+   */
+  readonly onSetup?: () => void | Promise<void>;
+
+  /**
    * Optional `ready` hook. Fires once after Foundry has finished bootstrap.
    * The natural home for migration runners (`createMigrationRunner().run()`).
    *
@@ -142,6 +176,16 @@ export function registerSystem(config: SystemRegistration): SystemRegistration {
   hooks.once('init', () => {
     applyInit(config);
   });
+  if (config.onI18nInit !== undefined) {
+    hooks.once('i18nInit', () => {
+      config.onI18nInit?.();
+    });
+  }
+  if (config.onSetup !== undefined) {
+    hooks.once('setup', () => {
+      void config.onSetup?.();
+    });
+  }
   if (config.onReady !== undefined) {
     hooks.once('ready', () => {
       // Foundry awaits ready-hook results, but `Hooks.once` types it as


### PR DESCRIPTION
Reopens #144, which GitHub closed when its base branch was deleted on merging #143. Same work, rebuilt on main.

Foundry starts a world in four stages. `registerSystem` and `registerModule` reached two of them, and the missing two are the ones that are hard to work around.

**`i18nInit`** is the first moment `game.i18n` works. A label localized during `init` comes back as the key that was passed in, because the language files have not loaded, and that raw key is what players read on screen. Translating CONFIG labels once here beats calling `localize` on every render.

**`setup`** runs after every package has finished its own `init`. A setting registered during `init` can be read from here on, and a module can see what the system around it registered instead of racing it.

```ts
registerSystem({
  id: 'my-system',
  onI18nInit: () => {
    for (const ability of Object.values(CONFIG.MY_SYSTEM.abilities)) {
      ability.label = game.i18n.localize(ability.label);
    }
  },
  onSetup: () => {
    if (settings.get('showTutorial')) openTutorial();
  },
});
```

Both optional, neither GM-gated, and omitting one stages no hook for it.

Adds a guide covering what each of the four stages is for and why doing everything in `ready` costs you a load that looks like several steps.

Tests cover both registration functions: the callback fires on its own hook and not on `init`, an async `onSetup` is fire-and-forget, and all four stage in the order Foundry fires them.

The template pin follows the core minor, so a new project actually gets the hooks.