### PR TITLE
fix(styles): correct why the components are unlayered

### DIFF
--- a/.changeset/hungry-pans-shave.md
+++ b/.changeset/hungry-pans-shave.md
@@ -2,18 +2,21 @@
 '@vttforge/styles': minor
 ---
 
-Take the component styles out of their cascade layer, so plain CSS from another package cannot restyle your sheet.
+Take the component styles out of their cascade sub-layer, so your own CSS and this package's compose the way you expect.
 
-Base, components and the theme used to sit in `@layer vttforge.*`. That was a mistake. An unlayered rule beats every layered one, whatever the specificity, and layer order is settled before specificity is ever consulted. Foundry loads a system or module stylesheet unlayered unless the manifest asks otherwise, so most packages on the page write plain CSS. One of them shipping this:
+Foundry puts a system's stylesheet in `@layer system` and a module's in `@layer modules`. It does that for you: the manifest's `styles` entry takes an optional `layer`, and when you leave it out the server fills one in. So everything here already sat inside `system`.
+
+Inside it, base, components and the theme sat in `@layer vttforge.*` sub-layers while your own rules, in the same file or your own stylesheet, sat directly in `system`. An unlayered rule beats every layered one in the same layer, whatever the specificity, so your CSS won every time:
 
 ```css
-button { border-radius: 99px; }
+/* your stylesheet, in @layer system alongside this package */
+button { border-radius: 55px; }   /* used to beat .vttf-btn */
 ```
 
-used to win against `.vttf-btn`, and nothing you could write would win it back.
+Nothing you wrote could lose, which sounds convenient until a broad selector you wrote for one corner silently restyles every component. Now the two compose on specificity, so `.vttf-btn` holds and `.my-system .vttf-btn` wins.
 
 Tokens and the reset stay layered, and lose on purpose. Tokens are custom properties you must be able to override with one plain declaration, and a reset that outranks real rules is a bug waiting to happen.
 
-The `styles.layer.css` entry still wraps everything in one `@layer vttforge` for consumers who order these styles against layers of their own. It gives up the cascade position by design.
+**This does not change anything about other modules, and should not.** Foundry orders `system` before `modules`, so a module's CSS overrides a system's by design. That ordering is the platform's, not ours.
 
-If you were relying on `@layer vttforge.base`, `vttforge.components` or `vttforge.themes` to keep these styles below your own unlayered CSS, that no longer holds. Raise the specificity of your override, or import `styles.layer.css` instead.
+If you were relying on a plain selector of your own to override these components, raise its specificity.

--- a/apps/e2e/tests/system.spec.mjs
+++ b/apps/e2e/tests/system.spec.mjs
@@ -116,93 +116,63 @@ test('a character sheet renders its parts and its derived data', async ({ page }
   expect(sheet.derived.strMod).toBe(0);
 });
 
-test("another package's plain CSS cannot restyle the sheet", async ({ page }) => {
+test("the sheet styles compose with the system's own CSS, and yield to modules", async ({
+  page,
+}) => {
   await joinWorld(page);
 
-  // An unlayered author rule beats every layered one, whatever the
-  // specificity, and layer order is settled before specificity is consulted.
-  // Foundry loads a system or module stylesheet unlayered unless the manifest
-  // asks otherwise, so most packages on the page write plain CSS. Put the
-  // components in a layer and a bare element selector from an unrelated
-  // module wins.
+  // Foundry puts a system's stylesheet in `@layer system` and a module's in
+  // `@layer modules`. The manifest's `styles` entry takes an optional `layer`
+  // and the server fills one in when it is left out, so this file is layered
+  // before anyone here gets a say.
   //
-  // Two of ours stay layered on purpose. Tokens are custom properties a
-  // consumer overrides with one plain declaration, and the reset touches bare
-  // elements, so neither should outrank a real rule from the system around it.
-  const ALLOWED = ['vttforge.tokens', 'vttforge.reset'];
-
-  const cascade = await page.evaluate(async (allowed) => {
+  // That settles two different questions, and this test holds both.
+  const cascade = await page.evaluate(async () => {
     const actor = await Actor.create({ name: 'Cascade Check', type: 'character' });
     await actor.sheet.render(true);
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // The example system styles its sheet with its own classes, so nothing on
     // screen carries a `.vttf-` class. The element is planted; the stylesheet,
-    // the page and the rival rule below are all real.
+    // the page and the rival rules are all real.
     const button = document.createElement('button');
     button.className = 'vttf-btn';
     actor.sheet.element.querySelector('.window-content').append(button);
-    const before = getComputedStyle(button).borderRadius;
 
-    // Stand in for a second module, loaded after ours, styling elements the
-    // way modules commonly do: no layer, barely any specificity.
-    const rival = document.createElement('style');
-    rival.textContent = 'button { border-radius: 99px; }';
-    document.head.append(rival);
-    const after = getComputedStyle(button).borderRadius;
-
-    // Walk every stylesheet and note which layer, if any, each of our rules
-    // sits in. A cross-origin sheet throws on `cssRules`, so the count of
-    // those is carried out for the failure message: it explains an empty
-    // result that would otherwise look like a pass.
-    const offenders = [];
-    let unlayeredCount = 0;
-    let unreadable = 0;
-
-    const visit = (rules, layerName) => {
-      for (const rule of rules) {
-        if (rule instanceof CSSImportRule) {
-          if (rule.styleSheet) visit(rule.styleSheet.cssRules, rule.layerName ?? layerName);
-        } else if (rule instanceof CSSLayerBlockRule) {
-          visit(rule.cssRules, rule.name || '(anonymous)');
-        } else if (rule instanceof CSSGroupingRule) {
-          visit(rule.cssRules, layerName);
-        } else if (rule instanceof CSSStyleRule && rule.selectorText.includes('vttf-')) {
-          if (layerName === null) unlayeredCount += 1;
-          else if (!allowed.includes(layerName)) {
-            offenders.push(`@layer ${layerName} { ${rule.selectorText} }`);
-          }
-        }
-      }
+    const withRival = (css) => {
+      const style = document.createElement('style');
+      style.textContent = css;
+      document.head.append(style);
+      const radius = getComputedStyle(button).borderRadius;
+      style.remove();
+      return radius;
     };
 
-    for (const sheet of document.styleSheets) {
-      try {
-        visit(sheet.cssRules, null);
-      } catch {
-        unreadable += 1;
-      }
-    }
+    const alone = getComputedStyle(button).borderRadius;
+    // The system's own stylesheet, which lands in the same layer as ours.
+    const versusSystem = withRival('@layer system { button { border-radius: 55px; } }');
+    // A module, which Foundry sorts after every system.
+    const versusModule = withRival('@layer modules { button { border-radius: 99px; } }');
 
-    rival.remove();
     button.remove();
-    return { unreadable, unlayeredCount, offenders: offenders.slice(0, 10), before, after };
-  }, ALLOWED);
+    return { alone, versusSystem, versusModule };
+  });
 
-  // Proves the walk actually read our stylesheet, so an empty `offenders` is
-  // a real result and not a sheet it could not open.
-  expect(
-    cascade.unlayeredCount,
-    `no unlayered VTTForge rules found; ${cascade.unreadable} stylesheets were unreadable`,
-  ).toBeGreaterThan(50);
-  expect(
-    cascade.offenders,
-    'these rules paint the sheet from inside a cascade layer, so plain CSS from any other module beats them',
-  ).toEqual([]);
+  const seen = `alone ${cascade.alone}, against the system ${cascade.versusSystem}, against a module ${cascade.versusModule}`;
 
-  // --vttf-radius-md, and it holds while the rival rule is on the page.
-  expect(cascade.before).toBe('6px');
-  expect(cascade.after).toBe('6px');
+  // --vttf-radius-md, applied.
+  expect(cascade.alone, seen).toBe('6px');
+
+  // The point of leaving components unlayered: inside Foundry's `system`
+  // layer, a bare `button` selector of the system's own no longer outranks
+  // `.vttf-btn` for free. Specificity decides, and `.vttf-btn` has more of it.
+  expect(cascade.versusSystem, seen).toBe('6px');
+
+  // And the point of not fighting the platform: a module still wins, because
+  // Foundry orders `system` before `modules` so that modules can override
+  // systems. This fails if anyone sets `"layer": null` on the manifest entry
+  // to jump that queue.
+  expect(cascade.versusModule, seen).toBe('99px');
 });
 
 test('the module contributes a namespaced sub-type once enabled', async ({ page }) => {

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -40,20 +40,28 @@ The tokens are also published as data, `@vttforge/styles/tokens.json`, for anyth
 
 ## Cascade layers
 
-Only two pieces sit in a layer, `vttforge.tokens` and `vttforge.reset`. Base, components and the theme are unlayered on purpose.
+Foundry has already put this file in a layer by the time you see it. A system's stylesheet goes in `@layer system` and a module's in `@layer modules`. The manifest's `styles` entry takes an optional `layer`, and leaving it out lets the server fill one in:
 
-The cascade puts every unlayered author rule above every layered one, whatever the specificity. Foundry loads a system or module stylesheet unlayered unless the manifest asks otherwise, so most packages on the page write plain CSS. Put these components in a layer and a bare element selector from an unrelated module wins:
-
-```css
-/* some other module, no layer, almost no specificity */
-button { border-radius: 99px; }
+```json
+"styles": [{ "src": "styles/my-system.css" }]
 ```
 
-That rule used to beat `.vttf-btn`. Now it does not. Nothing you do with specificity would have won it back, because layer order is decided before specificity is ever consulted.
+So the question is never whether these rules are layered. It is how they sort against the rest of what is in that same layer, which is your own CSS.
 
-Tokens and the reset lose that fight on purpose. Tokens are custom properties you must be able to override with one plain declaration. The reset touches bare elements inside `.vttf-app`, and a reset that outranks real rules from the system around it is a bug waiting to happen.
+An unlayered rule beats every layered one in the same layer, whatever the specificity. That is why only `vttforge.tokens` and `vttforge.reset` sit in a sub-layer here, and base, components and the theme do not. Sub-layer the components and this wins every time:
 
-The `styles.layer.css` entry gives up that position by design: inside a layer, VTTForge loses to anything unlayered on the page. Use it only when you need to order these styles against layers of your own.
+```css
+/* your stylesheet, in the same layer as this package */
+button { border-radius: 55px; }   /* would beat .vttf-btn */
+```
+
+Nothing you wrote could lose, which sounds convenient until a broad selector meant for one corner restyles every component. Unlayered, the two compose on specificity: `.vttf-btn` holds, and `.my-system .vttf-btn` wins.
+
+Tokens and the reset lose that fight on purpose. Tokens are custom properties you must be able to override with one plain declaration, and a reset that outranks real rules is a bug waiting to happen.
+
+None of this affects other modules, and it should not. Foundry orders `system` before `modules`, so a module's CSS overrides a system's by design. You can opt out by setting `"layer": null` on the manifest entry, which makes your stylesheet unlayered and puts it above everything. Do not, unless you have a reason worth the fight: it takes your system out of the order every module author expects.
+
+The `styles.layer.css` entry wraps everything in one `@layer vttforge` nested inside Foundry's. That gives up composing on specificity, in exchange for ordering these styles as a block against layers of your own.
 
 ## See it
 

--- a/packages/styles/base.css
+++ b/packages/styles/base.css
@@ -3,8 +3,8 @@
  *
  * Element baselines and shared utilities on top of `tokens` + `reset`.
  *
- * Unlayered, so a plain rule from another package cannot outrank these
- * baselines. See `index.css` for why.
+ * Unlayered, so these baselines sort against a consumer's own CSS on
+ * specificity rather than always losing to it. See `index.css` for why.
  *
  * Owns `--vttf-focus-ring` rendering; components MUST NOT override `:focus-visible`.
  */

--- a/packages/styles/index.css
+++ b/packages/styles/index.css
@@ -8,14 +8,18 @@
  * Only tokens and the reset sit in a cascade layer. Base, components and the
  * theme are deliberately unlayered.
  *
- * The reason is a rule of the cascade itself: an unlayered author rule beats
- * every layered author rule, whatever the specificity. Foundry loads a system
- * or module stylesheet unlayered unless its manifest asks otherwise, so most
- * packages on the page write plain CSS. Put these components in a layer and a
- * bare `button { border-radius: 99px }` from an unrelated module overrides
- * every one of them, and no amount of specificity gets it back. Leaving the
- * visible parts unlayered is what keeps a VTTForge sheet looking like itself
- * when other packages are installed.
+ * Foundry has already put this file in a layer by the time you see it. A
+ * system's stylesheet goes in `@layer system` and a module's in
+ * `@layer modules`; the manifest's `styles` entry takes an optional `layer`,
+ * and leaving it out lets the server fill one in. So the question here is
+ * never whether these rules are layered. It is how they sort against the rest
+ * of what is in that same layer, which is your own CSS.
+ *
+ * An unlayered rule beats every layered one in the same layer, whatever the
+ * specificity. Sub-layer the components and a bare `button { }` of yours beats
+ * `.vttf-btn`, and nothing you write can lose. That sounds convenient until a
+ * broad selector meant for one corner restyles every component. Leaving them
+ * unlayered puts the two on the same footing, where specificity decides.
  *
  * Tokens and the reset stay layered on purpose, and lose on purpose. Tokens are
  * custom properties a consumer must be able to override with one plain

--- a/packages/styles/styles.layer.css
+++ b/packages/styles/styles.layer.css
@@ -2,16 +2,19 @@
  * @vttforge/styles — styles.layer.css
  *
  * The opt-in variant: everything VTTForge ships, wrapped in one `@layer
- * vttforge` you can order against your own layers.
+ * vttforge` you can order against layers of your own.
  *
- *   @layer reset, vttforge, my-system;
+ *   @layer vttforge, my-system;
  *   @import '@vttforge/styles/layer';
  *
- * This entry trades away the cascade position the default entry gives you.
- * Inside a layer, VTTForge's own rules lose to every unlayered rule on the
- * page, which is how most other systems and modules ship their CSS. That is
- * the point of the variant: you decide where the styles sit. Reach for
- * `index.css` unless you have that need.
+ * Foundry has already placed this file in `@layer system` (or `modules`), so
+ * this nests a layer inside that one. The effect is that every rule here loses
+ * to your own CSS in the same layer, whatever the specificity, which is the
+ * behaviour the default entry deliberately does not have.
+ *
+ * That is the trade the variant exists to make: you give up composing on
+ * specificity in exchange for being able to order these styles as a block.
+ * Reach for `index.css` unless you need that.
  */
 
 @layer vttforge {

--- a/packages/styles/themes/forge.css
+++ b/packages/styles/themes/forge.css
@@ -6,8 +6,8 @@
  * preference takes over. Explicit `data-theme="light"` and
  * `data-theme="foundry"` are handled by tokens.css.
  *
- * Imported after components and, like them, unlayered: theme overrides win on
- * source order.
+ * Imported after components and, like them, unlayered, so theme overrides win
+ * on source order.
  */
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
The reason I shipped in #143 was wrong, and this corrects it before the release goes out.

## What I got wrong

I claimed the layered build lost to other modules' plain CSS. It did not, and it could not have. Foundry's server fills in the cascade layer for a package's stylesheet whenever the manifest leaves it out:

```js
system.styles.forEach(({src, layer}) => c(src, 'style', ..., layer === undefined ? 'system' : layer))
modules:                                                     layer === undefined ? 'modules' : layer
```

So this CSS was always inside `@layer system`. The `vttforge.*` sub-layers nested inside that and never met a module at all. My local reproduction imported the stylesheet without a layer, which is a page shape Foundry never serves, and that is what produced the misleading result.

## What the change actually does

Measured against the real core CSS with the layer Foundry really applies:

| the button meets | before | after |
|---|---|---|
| nothing | 6px | 6px |
| the system's own `button { 55px }`, same layer | **55px** | **6px** |
| a module's `button { 99px }` in `@layer modules` | 99px | 99px |

The sub-layers lost to the consumer's own rules at any specificity, because those sit directly in the same layer and an unlayered rule beats a layered one within it. A bare `button { }` beat `.vttf-btn` and nothing the consumer wrote could lose, which is fine right up until a broad selector meant for one corner restyles every component. Unlayered, the two compose on specificity.

The module column not moving is the platform working as intended. Foundry orders `system` before `modules` so a module can override a system. The manifest can opt out with `"layer": null`, and the scaffolds deliberately do not.

## What is in here

The code change from #143 stands. This corrects the changeset, which has not been published yet, along with the README and the file headers. The end-to-end test now asserts both halves against a real Foundry: a rule in `@layer system` no longer wins, and a rule in `@layer modules` still does. That second assertion is what keeps the test honest, and it fails loudly if anyone later opts the scaffold out of the layer.