### PR TITLE
docs(core): drop the third-party reference from the migration comment

### DIFF
--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -3,8 +3,8 @@
  *
  * Versions are semver strings so they line up with `system.json`'s
  * `flags.<systemId>.needsMigrationVersion` / `compatibleMigrationVersion` and
- * with `foundry.utils.isNewerVersion` (the comparator dnd5e uses in
- * production). A migration that targets `"2.4.0"` runs once the stored
+ * with `foundry.utils.isNewerVersion`, which is the comparator the runner
+ * uses. A migration that targets `"2.4.0"` runs once the stored
  * `schemaVersion` is anything strictly older than `"2.4.0"`.
  */
 


### PR DESCRIPTION
Comment only. The line named another system as the source of the version comparator; it now just says what the runner does.

No changeset: nothing about the runner changes, and the comment does not survive the build.