### PR TITLE
chore(core): drop a reference-system name from a source comment

### DIFF
--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -3,8 +3,8 @@
  *
  * Versions are semver strings so they line up with `system.json`'s
  * `flags.<systemId>.needsMigrationVersion` / `compatibleMigrationVersion` and
- * with `foundry.utils.isNewerVersion` (the comparator dnd5e uses in
- * production). A migration that targets `"2.4.0"` runs once the stored
+ * with `foundry.utils.isNewerVersion`, which is the comparator Foundry itself
+ * uses. A migration that targets `"2.4.0"` runs once the stored
  * `schemaVersion` is anything strictly older than `"2.4.0"`.
  */
 


### PR DESCRIPTION
The sentence was explaining which comparator to use for migration versions, and the answer is Foundry's own `foundry.utils.isNewerVersion`. Naming someone else's system alongside it added nothing and is the kind of reference this repo keeps out of tracked files.

Comment only. No behaviour change, so no changeset.

The same name survives in one published `@vttforge/core` CHANGELOG entry. Left alone: that is release history, and rewriting it would misrepresent what shipped.