### PR TITLE
docs(core): drop the third-party reference from an old changelog entry

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -385,9 +385,9 @@
 run(), targetVersion }`. Call `register()` from `init` to register the
   `schemaVersion` setting; call `run()` from `ready` (gated by
   `game.user.isGM`) to execute every pending migration in order. Migrations use
-  semver versions and `foundry.utils.isNewerVersion` for comparison — the same
+  semver versions and `foundry.utils.isNewerVersion` for comparison, the same
   contract `system.json`'s `flags.<systemId>.needsMigrationVersion` /
-  `compatibleMigrationVersion` use, matching the dnd5e production pattern.
+  `compatibleMigrationVersion` use.
 
   Failure semantics: `schemaVersion` is committed per-migration, so a
   mid-sequence throw leaves the world at the last successful version and the


### PR DESCRIPTION
Text only, in the 0.6.0 entry. The line named another system as the source of the version-comparison contract; it now just states the contract.

No changeset: nothing about the runner changes.

This is the last such reference in a tracked file. It does not reach the tarballs already on npm, which are immutable.