### PR TITLE
fix(web): stop the landing page scrolling sideways on a phone

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -304,7 +304,6 @@
             </tbody>
           </table>
           </div>
-          </div>
         </div>
       </section>
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -255,6 +255,7 @@
             <p class="bk-sub">Cherry-pick what you need. <span class="mono">@vttforge/core</span> is enough for a system; the rest layer on top. All on npm, with provenance.</p>
           </div>
 
+          <div class="pkg-table-wrap">
           <table class="pkg-table">
             <thead>
               <tr><th>package</th><th>what it does</th><th>status</th></tr>
@@ -302,6 +303,8 @@
               </tr>
             </tbody>
           </table>
+          </div>
+          </div>
         </div>
       </section>
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -758,6 +758,30 @@
 
   /* ════════ RESPONSIVE ════════ */
 
+  /*
+   * A grid or flex item defaults to `min-width: auto`, which means it refuses
+   * to shrink below its content. A wide child, a code block or a table, then
+   * pushes the whole document past the viewport and the page scrolls
+   * sideways. Naming the items lets them shrink so the scroll happens inside
+   * the code block, where it belongs.
+   */
+  .ba-grid > *,
+  .try-grid > *,
+  .feat-grid > *,
+  .hero-meta > * {
+    min-width: 0;
+  }
+
+  .vttf-codeblock {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  /* The packages table has more columns than a phone has room for. */
+  .pkg-table-wrap {
+    overflow-x: auto;
+  }
+
   @media (max-width: 900px) {
     .ba-grid {
       grid-template-columns: 1fr;
@@ -785,6 +809,23 @@
     }
     footer.bottom .cols {
       grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  @media (max-width: 520px) {
+    header.top .row {
+      gap: var(--vttf-space-3);
+    }
+    /* The hero badge two lines down says the same thing. */
+    header.top .ver-pill {
+      display: none;
+    }
+    .top-cta {
+      padding: 8px 12px;
+      font-size: 13px;
+    }
+    footer.bottom .cols {
+      grid-template-columns: 1fr;
     }
   }
 }


### PR DESCRIPTION
At 375px the document was 651px wide. The page scrolled sideways and the GitHub button was cut off at the edge.

Three causes, all the same shape: **a grid item defaults to `min-width: auto`**, so it refuses to shrink below its content, and a wide child pushes the whole page.

- The code blocks already had `overflow-x: auto` on their `pre`. It never fired, because the grid track around them grew instead of constraining them. Naming the grid items so they can shrink moves the scroll inside the block, where it belongs.
- The packages table is 509px of columns. It gets its own scroll container.
- The header drops the "on npm" pill below 520px. The hero badge two lines down says the same thing, and losing it gives the GitHub button room.

## Verification

Measured, not eyeballed. A control test confirms the harness discriminates: injecting a 900px element into a page reports 533px of overflow, and removing it returns to 0.

- All **218 built pages** at 375px: none scroll sideways.
- The landing page at 320, 375, 414 and 768: document width equals viewport width at every one.
- The four code blocks and the table fit their containers and scroll internally; at 768 the table stops scrolling because it fits.

Only the landing page needed changes. The docs were already clean at every width.