### PR TITLE
feat(web): make the site findable

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -78,6 +78,22 @@ export default defineConfig({
   cleanUrls: true,
   lastUpdated: true,
 
+  /**
+   * One canonical URL per page, derived from the file it was built from.
+   *
+   * The docs are reachable at more than one path (a directory and its
+   * `index.html`), and the generated API reference repeats names across
+   * packages. Naming the canonical leaves the crawler nothing to guess.
+   */
+  transformPageData(pageData) {
+    const path = pageData.relativePath.replace(/(index)?\.md$/, '');
+    pageData.frontmatter.head ??= [];
+    pageData.frontmatter.head.push([
+      'link',
+      { rel: 'canonical', href: `https://vttforge.dev/docs/${path}` },
+    ]);
+  },
+
   themeConfig: {
     logo: '/logo.svg',
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="An SDK and CLI for Foundry VTT v13+ systems and modules. Typed data models, sheets that already know their tabs and drops, and a dev loop that reloads in place." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="canonical" href="https://vttforge.dev/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="VTTForge" />
     <meta property="og:title" content="VTTForge" />

--- a/scripts/assemble-site.mjs
+++ b/scripts/assemble-site.mjs
@@ -17,8 +17,17 @@
  * `dist/` directory across the site root. So the stylesheet graph is copied
  * beside the page and the one reference is rewritten to match.
  */
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -98,6 +107,85 @@ writeFileSync(join(out, 'CNAME'), `${DOMAIN}\n`);
 // Jekyll would otherwise skip any path starting with an underscore, which is
 // where VitePress puts its assets.
 writeFileSync(join(out, '.nojekyll'), '');
+
+/**
+ * Every page in the assembled tree, as a site-relative URL.
+ *
+ * Walking the output rather than listing sources is what keeps this honest:
+ * the docs alone are 200-odd generated pages, and a hand-kept list would be
+ * wrong by the next release.
+ */
+function pageUrls(dir = out, urls = []) {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      if (entry === 'assets') continue;
+      pageUrls(path, urls);
+      continue;
+    }
+    if (!entry.endsWith('.html')) continue;
+    // 404 is served, not indexed. README is a VitePress build artefact.
+    if (entry === '404.html' || entry === 'README.html') continue;
+    const rel = relative(out, path).split(sep).join('/');
+    urls.push(`/${rel.replace(/index\.html$/, '').replace(/\.html$/, '')}`);
+  }
+  return urls;
+}
+
+const urls = pageUrls().sort();
+
+// A sitemap so the crawler does not have to find 200-odd generated reference
+// pages by following links from the landing page.
+writeFileSync(
+  join(out, 'sitemap.xml'),
+  `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls
+    .map((u) => `  <url><loc>https://${DOMAIN}${u}</loc></url>`)
+    .join('\n')}\n</urlset>\n`,
+);
+
+// Absent, this file means the same thing as the version below: crawl
+// everything. It exists to name the sitemap, which is the part a crawler
+// cannot guess.
+writeFileSync(
+  join(out, 'robots.txt'),
+  ['User-agent: *', 'Allow: /', '', `Sitemap: https://${DOMAIN}/sitemap.xml`, ''].join('\n'),
+);
+
+// llms.txt is a proposed convention for assistants reading a site directly.
+// No search engine consumes it; it costs one file and answers the question
+// "what is this project and where is the real documentation".
+writeFileSync(
+  join(out, 'llms.txt'),
+  `# VTTForge
+
+> An SDK and CLI for building Foundry VTT v13+ systems and modules. It holds the
+> plumbing every module rewrites by hand: data models, sheet boilerplate,
+> migrations, the build. A Foundry version bump then lands in one place instead
+> of in every module.
+
+Every package is below 1.0.0, where a minor may break you. See the stability
+page before pinning.
+
+## Start here
+
+- [Getting started](https://${DOMAIN}/docs/guide/getting-started): scaffold a system or module and open it in Foundry.
+- [The startup lifecycle](https://${DOMAIN}/docs/guide/lifecycle): the four stages Foundry boots through, and what belongs in each.
+- [Data models](https://${DOMAIN}/docs/guide/data-models): typed schemas on \`TypeDataModel\`.
+- [Sheets](https://${DOMAIN}/docs/guide/sheets): \`ApplicationV2\` sheets with tabs and drag-drop already wired.
+
+## Reference
+
+- [CLI reference](https://${DOMAIN}/docs/guide/cli): every command, and the ten audit rules.
+- [Stability policy](https://${DOMAIN}/docs/stability): what each export promises, and what \`@experimental\` means here.
+- [Error registry](https://${DOMAIN}/docs/errors/): every \`VTTF-NNNN\` code with its cause and fix.
+- [API reference](https://${DOMAIN}/docs/reference/): generated from the source.
+
+## About
+
+- [Transparency](https://${DOMAIN}/docs/transparency): how this is built, and what every change has to pass.
+- [Source](https://github.com/vttforge/vttforge): MIT.
+`,
+);
 
 console.log(`Assembled → ${out}`);
 console.log(`  /               landing page`);


### PR DESCRIPTION
The site served no sitemap, no `robots.txt` and no canonical URLs. A crawler had to reach 190 pages by following links from the landing page, and most of them are generated API reference that nothing links to directly.

## What it does

**`/sitemap.xml`**, built by walking the assembled tree rather than from a list. The docs alone are ~180 generated pages; a hand-kept list would be wrong by the next release. It covers all three halves the site serves: the landing page, `/docs/` and `/design-system/`.

**`/robots.txt`**, which unblocks nothing on its own. Its absence already means "crawl everything". It exists to name the sitemap, which is the part a crawler cannot guess.

**Canonical URLs.** One on the landing page, and one per docs page derived from its source file. This matters here because every docs page is reachable as both a directory and an `index.html`, and the generated reference repeats type names across packages.

**`/llms.txt`**. No search engine reads it and it will not affect ranking. It costs one file and answers "what is this project and where is the real documentation" for an assistant reading the site directly.

## Verification

- The sitemap parses as XML: 190 URLs, no duplicates, none over the 50k limit.
- Every URL in it resolves to a file in the assembled tree, checked programmatically.
- Every link in `llms.txt` resolves too: 9 of 9.
- Canonical present and correct on the landing page and on a sample of docs pages after a real build.

## Not in here

Search Console verification is account-bound, so it stays with the owner. Submitting this sitemap there is what actually starts the crawl.

Worth saying plainly: none of this substitutes for inbound links. A new domain with nothing pointing at it gets crawled slowly whatever the sitemap says.