### PR TITLE
feat(core): ship the decorators, and lower them in the build

### DIFF
--- a/.changeset/calm-pins-follow.md
+++ b/.changeset/calm-pins-follow.md
@@ -1,0 +1,7 @@
+---
+'@vttforge/cli': patch
+---
+
+Follow the `@vttforge/core` and `@vttforge/vite-plugin` minors in the scaffold's pins, so a new project gets the decorators and the build that lowers them.
+
+On a `0.x` version a caret pins the minor, so the old pins would have kept new projects on the releases before them. The templates ship inside this package, so the corrected pins only reach anyone when the CLI is published too.

--- a/.changeset/tidy-foxes-lower.md
+++ b/.changeset/tidy-foxes-lower.md
@@ -1,0 +1,9 @@
+---
+'@vttforge/vite-plugin': minor
+---
+
+Lower TC39 decorators in the build, so `@ActorDataModel` and friends work in the bundle Foundry loads.
+
+Vite 8 replaced esbuild with Oxc, and Oxc does not yet lower Stage 3 decorators. A system that applied one and ran `vttforge build` shipped the `@` untransformed and failed to load in every browser, with no error at build time. The plugin now runs Babel's decorator plugin ahead of Oxc, the workaround the Vite 8 migration guide gives, filtered to files that contain an `@`. A project that never uses a decorator pays nothing.
+
+**One type changed.** `vttforge()` now returns `Plugin[]` rather than `Plugin`: the decorator lowering, then the plugin proper. `plugins: [vttforge({ id })]` keeps working unchanged because Vite flattens nested plugin arrays. Only code that annotated the result as `Plugin` needs to widen it.

--- a/.changeset/witty-owls-decorate.md
+++ b/.changeset/witty-owls-decorate.md
@@ -1,0 +1,28 @@
+---
+'@vttforge/core': minor
+---
+
+Add four decorators, marked `@experimental`, for the registrations every package writes by hand: `@ActorDataModel`, `@ItemDataModel`, `@DocumentSheet` and `@OnHook`.
+
+```ts
+@ActorDataModel('character')
+class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
+
+@DocumentSheet({ id: 'character', document: 'Actor', namespace: 'my-system', types: ['character'], makeDefault: true })
+class CharacterSheet extends BaseActorSheet() {}
+
+class Chat {
+  @OnHook('renderChatMessageHTML')
+  static onRender(message: unknown, html: HTMLElement) {}
+}
+```
+
+The timing is the whole point. `CONFIG` may only be touched inside the `init` hook, but a class is defined the moment its module is imported, long before `init`. The obvious version, assigning to `CONFIG` from the decorator body, works in a test and silently does nothing in Foundry. These subscribe a listener at definition time and do the assignment when `init` fires.
+
+`@DocumentSheet` takes a required `id` and goes through `registerSheets`, the same path `registerSystem({ sheets })` takes. Foundry saves the sheet key on every document using it and builds that key from the class name, which a bundler renames between builds. The `id` is what keeps the saved key pointing at a sheet that still exists.
+
+`@OnHook` accepts static methods only. An instance method has no instance to run against when the listener is registered, and inventing one would be a guess; it throws `VTTF-0002` and says so.
+
+These are standard TC39 decorators, not the legacy `experimentalDecorators` kind. Oxc, which Vite 8 uses, does not lower them yet, so a build that applies them needs the Babel decorator plugin ahead of Oxc. `@vttforge/vite-plugin` adds it for you, filtered to files that contain an `@`, so a project that never uses a decorator pays nothing.
+
+All four are `@experimental`: they are new and no consumer has used them yet, so the shape can change in a minor. `registerSystem` and `registerModule` remain the supported path and are what the scaffolds use.

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -128,6 +128,7 @@ export default defineConfig({
             { text: 'Sheets', link: '/guide/sheets' },
             { text: 'Modules', link: '/guide/modules' },
             { text: 'Settings and migrations', link: '/guide/settings-and-migrations' },
+            { text: 'Decorators', link: '/guide/decorators' },
             { text: 'The dev loop', link: '/guide/dev-loop' },
             { text: 'Testing', link: '/guide/testing' },
             { text: 'CLI reference', link: '/guide/cli' },

--- a/apps/docs/guide/decorators.md
+++ b/apps/docs/guide/decorators.md
@@ -1,0 +1,63 @@
+# Decorators
+
+Four decorators for the registrations every package writes by hand. They are
+`@experimental`: new, and no consumer has used them yet, so the shape can
+change in a minor. `registerSystem` and `registerModule` remain the supported
+path, and are what the scaffolds use.
+
+```ts
+import { ActorDataModel, DocumentSheet, OnHook } from '@vttforge/core';
+
+@ActorDataModel('character')
+class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
+
+@DocumentSheet({
+  id: 'character',
+  document: 'Actor',
+  namespace: 'my-system',
+  types: ['character'],
+  makeDefault: true,
+})
+class CharacterSheet extends BaseActorSheet() {}
+
+class Chat {
+  @OnHook('renderChatMessageHTML')
+  static onRender(message: unknown, html: HTMLElement) {}
+}
+```
+
+## The timing is the whole point
+
+`CONFIG` may only be touched inside the `init` hook. But a class is defined
+the moment its module is imported, long before `init` fires. The obvious
+decorator, one that assigns to `CONFIG` from its body, works in a unit test
+and silently does nothing in Foundry.
+
+These subscribe a listener when the class is defined and do the assignment
+when `init` fires. `Hooks` exists as soon as Foundry's scripts load, so
+subscribing at definition time is safe; the write waits for its moment.
+
+## `@DocumentSheet` needs an `id`
+
+Foundry saves a sheet's key on every document whose owner picks it, and builds
+that key from the class name. A bundler renames classes between builds, and
+the saved key then names a sheet that no longer exists. `@DocumentSheet` goes
+through `registerSheets`, the same path `registerSystem({ sheets })` takes,
+which pins the class name to the `id` you give it. Pick it once and keep it.
+
+## `@OnHook` takes static methods only
+
+An instance method has no instance to run against when the listener is
+registered, and inventing one would be a guess. Decorating an instance method
+throws `VTTF-0002` and says so.
+
+## The build has to lower them
+
+These are standard TC39 decorators, not the legacy `experimentalDecorators`
+kind. Oxc, which Vite 8 uses, does not lower them yet, and a bundle that still
+contains a raw `@` fails to load in every browser with no error at build time.
+
+`@vttforge/vite-plugin` adds Babel's decorator plugin ahead of Oxc for you,
+filtered to files that contain an `@`, so a project that never uses a decorator
+pays nothing. If you build with something other than the plugin, add
+`@babel/plugin-proposal-decorators` with `version: "2023-11"` yourself.

--- a/knip.json
+++ b/knip.json
@@ -12,7 +12,8 @@
       "project": ["preview/**/*.js"]
     },
     "packages/vite-plugin": {
-      "ignore": ["src/__tests__/fixtures/**"]
+      "ignore": ["src/__tests__/fixtures/**"],
+      "ignoreDependencies": ["@babel/plugin-proposal-decorators"]
     },
     "examples/simple-system": {
       "entry": ["scripts/main.mjs"],
@@ -36,6 +37,10 @@
     },
     "apps/e2e": {
       "entry": ["tests/*.spec.mjs"]
+    },
+    "packages/core": {
+      "entry": ["src/**/*.test-d.ts"],
+      "ignoreDependencies": ["@babel/plugin-proposal-decorators"]
     }
   }
 }

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,11 +11,11 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.12.0"
+    "@vttforge/core": "^0.13.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.8.0",
-    "@vttforge/vite-plugin": "^0.4.0",
+    "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },
   "engines": {

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,11 +12,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.12.0"
+    "@vttforge/core": "^0.13.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.8.0",
-    "@vttforge/vite-plugin": "^0.4.0",
+    "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,12 +11,12 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.12.0",
+    "@vttforge/core": "^0.13.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.8.0",
-    "@vttforge/vite-plugin": "^0.4.0",
+    "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },
   "engines": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,12 +12,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.12.0",
+    "@vttforge/core": "^0.13.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.8.0",
-    "@vttforge/vite-plugin": "^0.4.0",
+    "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,10 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@babel/core": "catalog:",
+    "@babel/plugin-proposal-decorators": "catalog:",
+    "@rolldown/plugin-babel": "catalog:",
+    "@vttforge/testing": "workspace:*",
     "happy-dom": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",

--- a/packages/core/src/__tests__/decorators.test.ts
+++ b/packages/core/src/__tests__/decorators.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The timing is what these decorators exist for, so it is what these cases
+ * check: nothing may touch CONFIG until `init` fires.
+ *
+ * Driven through `@vttforge/testing`, which is also the first real use of
+ * that package outside its own suite.
+ */
+import { type MockFoundry, withMockFoundry } from '@vttforge/testing/vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ActorDataModel, DocumentSheet, ItemDataModel, OnHook } from '../decorators.js';
+import { VttfError } from '../errors/registry.js';
+
+let mock: MockFoundry | undefined;
+
+afterEach(() => {
+  mock?.restore();
+  mock = undefined;
+});
+
+describe('@ActorDataModel', () => {
+  it('registers nothing until init fires', () => {
+    mock = withMockFoundry();
+
+    @ActorDataModel('character')
+    class CharacterData {}
+    void CharacterData;
+
+    // Defining the class is not enough, and must not be: CONFIG may only be
+    // touched inside init, and the class is defined at import time.
+    expect(CONFIG.Actor.dataModels).toEqual({});
+
+    mock.callHook('init');
+    expect(CONFIG.Actor.dataModels.character).toBe(CharacterData);
+  });
+
+  it('files a module subtype under its prefixed key', () => {
+    mock = withMockFoundry();
+
+    @ActorDataModel('my-module.vehicle')
+    class VehicleData {}
+
+    mock.callHook('init');
+    expect(CONFIG.Actor.dataModels['my-module.vehicle']).toBe(VehicleData);
+  });
+});
+
+describe('@ItemDataModel', () => {
+  it('registers on the Item bag', () => {
+    mock = withMockFoundry();
+
+    @ItemDataModel('weapon')
+    class WeaponData {}
+
+    mock.callHook('init');
+    expect(CONFIG.Item.dataModels.weapon).toBe(WeaponData);
+    expect(CONFIG.Actor.dataModels).toEqual({});
+  });
+});
+
+describe('@DocumentSheet', () => {
+  it('files the sheet under the id it was given, not its class name', () => {
+    mock = withMockFoundry();
+
+    @DocumentSheet({
+      id: 'character',
+      document: 'Actor',
+      namespace: 'my-system',
+      types: ['character'],
+      makeDefault: true,
+      label: 'MY.Sheet',
+    })
+    class CharacterSheet {}
+
+    // Nothing until init: CONFIG may only be touched there.
+    expect(mock.sheets).toHaveLength(0);
+    mock.callHook('init');
+
+    // This is the key Foundry writes to `flags.core.sheetClass`. It is built
+    // from the class name, which a minifier renames between builds, so the
+    // decorator goes through `registerSheets`, which pins the name to the id.
+    expect(mock.sheets).toHaveLength(1);
+    expect(mock.sheets[0]?.key).toBe('my-system.character');
+    expect(mock.sheets[0]?.sheetClass).toBe(CharacterSheet);
+    expect(mock.sheets[0]?.options).toMatchObject({
+      types: ['character'],
+      makeDefault: true,
+      label: 'MY.Sheet',
+    });
+  });
+
+  it('passes no types when none are given, which means every type', () => {
+    mock = withMockFoundry();
+
+    @DocumentSheet({ id: 'any', document: 'Actor', namespace: 'm' })
+    class AnySheet {}
+    void AnySheet;
+
+    mock.callHook('init');
+    // `types: undefined` is what Foundry reads as "all"; the key must not be
+    // an array, or it would mean "none".
+    expect(mock.sheets[0]?.options.types).toBeUndefined();
+    expect(mock.sheets[0]?.options.makeDefault).toBe(false);
+  });
+
+  it('rejects an id it cannot pin, the same way registerSheets does', () => {
+    mock = withMockFoundry();
+
+    @DocumentSheet({ id: '', document: 'Actor', namespace: 'm' })
+    class Unnamed {}
+    void Unnamed;
+
+    expect(() => mock?.callHook('init')).toThrow(VttfError);
+  });
+});
+
+describe('@OnHook', () => {
+  it('subscribes when the class is defined, not at init', () => {
+    mock = withMockFoundry();
+    const seen: unknown[] = [];
+
+    // biome-ignore lint/complexity/noStaticOnlyClass: @OnHook only accepts static methods, and that is what this case exercises
+    class MyModule {
+      @OnHook('renderChatMessageHTML')
+      static onRender(message: unknown) {
+        seen.push(message);
+      }
+    }
+    void MyModule;
+
+    expect(mock.hooks.map((h) => h.event)).toEqual(['renderChatMessageHTML']);
+    mock.callHook('renderChatMessageHTML', 'a message');
+    expect(seen).toEqual(['a message']);
+  });
+
+  it('refuses an instance method, and says why', () => {
+    mock = withMockFoundry();
+    expect(() => {
+      class Bad {
+        @OnHook('ready')
+        onReady() {}
+      }
+      void Bad;
+    }).toThrow(VttfError);
+  });
+});
+
+describe('without a Foundry runtime', () => {
+  it('throws VTTF-0002 rather than registering into nothing', () => {
+    delete (globalThis as Record<string, unknown>).Hooks;
+    expect(() => {
+      @ActorDataModel('character')
+      class Orphan {}
+      void Orphan;
+    }).toThrow(VttfError);
+  });
+});

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -1,0 +1,203 @@
+/**
+ * Decorators for the registrations every package writes by hand.
+ *
+ * The timing is the whole problem these solve. `CONFIG` may only be touched
+ * inside the `init` hook, but a class is defined the moment its module is
+ * imported — long before `init`. So the obvious version, which assigns to
+ * `CONFIG` from the decorator body, works in a test and silently does nothing
+ * in Foundry.
+ *
+ * These register a listener instead. `Hooks` is a plain static class that
+ * exists as soon as Foundry's scripts load, so subscribing at class-definition
+ * time is safe; the assignment itself waits for `init` like it must.
+ *
+ * Standard TC39 decorators, not the legacy `experimentalDecorators` kind.
+ */
+
+import { VttfError } from './errors/registry.js';
+import { registerSheets, type SheetDocumentKind } from './register-sheets.js';
+
+interface HooksApi {
+  once(event: string, fn: () => void): unknown;
+  on(event: string, fn: (...args: unknown[]) => unknown): unknown;
+}
+
+function hooks(): HooksApi {
+  const api = (globalThis as Record<string, unknown>).Hooks as HooksApi | undefined;
+  if (typeof api?.once !== 'function') {
+    throw new VttfError(
+      'VTTF-0002',
+      'globalThis.Hooks is not available. Decorated classes must be defined inside the Foundry runtime (or stub Hooks in tests).',
+    );
+  }
+  return api;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: a decorator receives whatever class it is applied to
+type AnyClass = abstract new (...args: any[]) => any;
+
+/** Run something in `init`, which is the only place CONFIG may be touched. */
+function atInit(fn: () => void): void {
+  hooks().once('init', fn);
+}
+
+/**
+ * The `dataModels` bag for a document kind.
+ *
+ * Reached through a helper because the failure worth reporting is a missing
+ * `CONFIG.Actor`, not a `TypeError` about reading a property of undefined
+ * three frames deep inside a hook.
+ */
+function dataModelsFor(kind: 'Actor' | 'Item'): Record<string, unknown> {
+  const cfg = (globalThis as Record<string, unknown>).CONFIG as
+    | Record<string, { dataModels?: Record<string, unknown> } | undefined>
+    | undefined;
+  const bag = cfg?.[kind]?.dataModels;
+  if (bag === undefined) {
+    throw new VttfError(
+      'VTTF-0002',
+      `CONFIG.${kind}.dataModels is not available inside the init hook.`,
+    );
+  }
+  return bag;
+}
+
+/**
+ * File this data model under an Actor subtype.
+ *
+ * ```ts
+ * @ActorDataModel('character')
+ * class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
+ * ```
+ *
+ * The type is the key as it appears in your manifest's `documentTypes`. A
+ * module contributing a subtype uses the prefixed form its manifest declares
+ * — `my-module.vehicle` — because that is the key Foundry files it under.
+ *
+ * @experimental New in 0.13, and no consumer has used it yet. The shape can
+ * change in a minor.
+ */
+export function ActorDataModel(type: string) {
+  return (target: AnyClass, _context: ClassDecoratorContext): void => {
+    atInit(() => {
+      dataModelsFor('Actor')[type] = target;
+    });
+  };
+}
+
+/** The same for an Item subtype.
+ *
+ * @experimental New in 0.13, and no consumer has used it yet. The shape can
+ * change in a minor.
+ */
+export function ItemDataModel(type: string) {
+  return (target: AnyClass, _context: ClassDecoratorContext): void => {
+    atInit(() => {
+      dataModelsFor('Item')[type] = target;
+    });
+  };
+}
+
+export interface DocumentSheetOptions {
+  /**
+   * The id the sheet is filed under, as `<namespace>.<id>`.
+   *
+   * Foundry saves this key on every document whose owner picks the sheet, and
+   * builds it from the class name, which a bundler renames between builds.
+   * Naming the id here is what keeps the saved key pointing at a sheet that
+   * still exists. Pick it once and keep it.
+   */
+  id: string;
+  /** Which document this sheet is for. */
+  document: SheetDocumentKind;
+  /** The namespace to register under: your system or module id. */
+  namespace: string;
+  /** The subtypes it applies to. Omit for every type. */
+  types?: readonly string[];
+  /** Whether it becomes the default for those types. */
+  makeDefault?: boolean;
+  /** The label shown in the sheet picker, usually a locale key. */
+  label?: string;
+}
+
+/**
+ * The document classes `registerSheets` needs, read at init.
+ *
+ * `CONFIG.<kind>.documentClass` may be replaced by the system during its own
+ * init, so it is read when the hook fires rather than when the class is
+ * defined.
+ */
+function documentClasses(): Readonly<Record<SheetDocumentKind, unknown>> {
+  const cfg = (globalThis as Record<string, unknown>).CONFIG as
+    | Record<string, { documentClass?: unknown } | undefined>
+    | undefined;
+  if (cfg === undefined) {
+    throw new VttfError('VTTF-0002', 'CONFIG is not available inside the init hook.');
+  }
+  return { Actor: cfg.Actor?.documentClass, Item: cfg.Item?.documentClass };
+}
+
+/**
+ * Register this sheet for a document type.
+ *
+ * ```ts
+ * @DocumentSheet({ id: 'character', document: 'Actor', namespace: 'my-system', types: ['character'], makeDefault: true })
+ * class CharacterSheet extends BaseActorSheet() {}
+ * ```
+ *
+ * Goes through `registerSheets`, the same path `registerSystem({ sheets })`
+ * takes, so the persisted key is `<namespace>.<id>` and survives a rebuild.
+ *
+ * @experimental New in 0.13, and no consumer has used it yet. The shape can
+ * change in a minor.
+ */
+export function DocumentSheet(options: DocumentSheetOptions) {
+  return (target: AnyClass, _context: ClassDecoratorContext): void => {
+    atInit(() => {
+      registerSheets(
+        options.namespace,
+        [
+          {
+            id: options.id,
+            document: options.document,
+            sheet: target,
+            ...(options.types ? { types: options.types } : {}),
+            ...(options.label ? { label: options.label } : {}),
+            ...(options.makeDefault !== undefined ? { makeDefault: options.makeDefault } : {}),
+          },
+        ],
+        documentClasses(),
+      );
+    });
+  };
+}
+
+/**
+ * Call this method when a hook fires.
+ *
+ * ```ts
+ * class MyModule {
+ *   @OnHook('renderChatMessageHTML')
+ *   static onChatRender(message: unknown, html: HTMLElement) {}
+ * }
+ * ```
+ *
+ * Only static methods: an instance method has no instance to run against at
+ * the time the listener is registered, and inventing one would be a guess.
+ *
+ * @experimental New in 0.13, and no consumer has used it yet. The shape can
+ * change in a minor.
+ */
+export function OnHook(event: string) {
+  return (target: (...args: unknown[]) => unknown, context: ClassMethodDecoratorContext): void => {
+    if (!context.static) {
+      throw new VttfError(
+        'VTTF-0002',
+        `@OnHook('${event}') is on an instance method (${String(context.name)}). Hook listeners are registered before any instance exists — make it static.`,
+      );
+    }
+    context.addInitializer(function (this: unknown) {
+      hooks().on(event, (...args: unknown[]) => target.apply(this, args));
+    });
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,13 @@ export {
 } from './data/fields.js';
 export type { InferField, InferSchema, Prettify } from './data/infer-schema.js';
 export {
+  ActorDataModel,
+  DocumentSheet,
+  type DocumentSheetOptions,
+  ItemDataModel,
+  OnHook,
+} from './decorators.js';
+export {
   ERROR_MANIFEST_VERSION,
   type ErrorManifest,
   getErrorManifest,

--- a/packages/core/vitest.config.mjs
+++ b/packages/core/vitest.config.mjs
@@ -12,6 +12,15 @@ import babel from '@rolldown/plugin-babel';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  test: {
+    // Stated rather than left to the default: Knip reads this config to find
+    // the test entries, and with no `include` it sees none of them.
+    include: ['src/**/*.test.ts'],
+    // `.test-d.ts` files are type-level tests. They only run under
+    // `vitest --typecheck`, which is how they always ran. Put them in
+    // `include` and vitest runs them as runtime tests, which fails.
+    typecheck: { include: ['src/**/*.test-d.ts'] },
+  },
   plugins: [
     babel({
       presets: [

--- a/packages/core/vitest.config.mjs
+++ b/packages/core/vitest.config.mjs
@@ -1,0 +1,27 @@
+/**
+ * Vite 8 replaced esbuild with Oxc, and Oxc does not yet lower TC39 Stage 3
+ * decorators (oxc-project/oxc#9170). Without this, a decorated class reaches
+ * Node untransformed and the runner dies with "Invalid or unexpected token".
+ *
+ * The workaround is the one the Vite 8 migration guide gives: run Babel's
+ * decorator plugin ahead of Oxc, filtered so only files that contain an `@`
+ * pay for it. `2023-11` is the current Stage 3 semantics, which is what the
+ * decorators in `src/decorators.ts` are written against.
+ */
+import babel from '@rolldown/plugin-babel';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [
+    babel({
+      presets: [
+        {
+          preset: () => ({
+            plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]],
+          }),
+          rolldown: { filter: { code: '@' } },
+        },
+      ],
+    }),
+  ],
+});

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -59,5 +59,10 @@
   "publishConfig": {
     "access": "public",
     "provenance": false
+  },
+  "dependencies": {
+    "@babel/core": "catalog:",
+    "@babel/plugin-proposal-decorators": "catalog:",
+    "@rolldown/plugin-babel": "catalog:"
   }
 }

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -10,6 +10,8 @@ import {
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { Plugin, PluginOption } from 'vite';
+import { build } from 'vite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import pluginPackage from '../../package.json' with { type: 'json' };
 import vttforge, { VTTFORGE_VITE_PLUGIN_VERSION, type VttforgeOptions } from '../index';
@@ -25,8 +27,27 @@ function createFixtureWorkspace(): string {
 // biome-ignore lint/suspicious/noExplicitAny: test helpers call Vite plugin hooks with mocked contexts
 type AnyFn = (...args: any[]) => any;
 
+/**
+ * `vttforge()` returns the decorator lowering and then the plugin proper.
+ * The hook tests below drive the plugin proper.
+ */
+function mainPlugin(plugins: PluginOption[]): Plugin {
+  // The decorator lowering is a promise Vite resolves; the plugin proper is
+  // the one plain object with our name.
+  const found = plugins.find(
+    (p): p is Plugin =>
+      typeof p === 'object' &&
+      p !== null &&
+      !Array.isArray(p) &&
+      !('then' in p) &&
+      p.name === '@vttforge/vite-plugin',
+  );
+  if (!found) throw new Error('main plugin not found in vttforge() output');
+  return found;
+}
+
 async function invokeConfigHook(
-  plugin: ReturnType<typeof vttforge>,
+  plugin: Plugin,
   root: string,
   command: 'build' | 'serve' = 'build',
 ): Promise<Record<string, unknown>> {
@@ -46,7 +67,7 @@ async function invokeConfigHook(
   return (result ?? {}) as Record<string, unknown>;
 }
 
-async function invokeHook(plugin: ReturnType<typeof vttforge>, name: 'writeBundle'): Promise<void> {
+async function invokeHook(plugin: Plugin, name: 'writeBundle'): Promise<void> {
   const hook = plugin[name] as unknown as AnyFn | undefined;
   if (typeof hook !== 'function') return;
   await hook.call(plugin);
@@ -71,8 +92,19 @@ describe('@vttforge/vite-plugin', () => {
     expect(VTTFORGE_VITE_PLUGIN_VERSION).toBe(pluginPackage.version);
   });
 
+  it('returns the decorator lowering ahead of the plugin proper', async () => {
+    const plugins = vttforge(defaultOptions());
+    // Two entries, in this order. Vite flattens the array and awaits promised
+    // entries, so a consumer's `plugins: [vttforge({ id })]` never sees it.
+    expect(plugins).toHaveLength(2);
+    const lowering = (await plugins[0]) as Plugin;
+    expect(typeof lowering.name).toBe('string');
+    expect(lowering.name).not.toBe('@vttforge/vite-plugin');
+    expect((plugins[1] as Plugin).name).toBe('@vttforge/vite-plugin');
+  });
+
   it('returns a Vite plugin with the right shape', () => {
-    const plugin = vttforge(defaultOptions());
+    const plugin = mainPlugin(vttforge(defaultOptions()));
     expect(plugin.name).toBe('@vttforge/vite-plugin');
     expect(plugin.enforce).toBe('pre');
     expect(typeof plugin.config).toBe('function');
@@ -82,14 +114,16 @@ describe('@vttforge/vite-plugin', () => {
   describe('option validation', () => {
     it('throws when id is missing', () => {
       expect(() =>
-        invokeConfigHook(vttforge({ id: '' } as VttforgeOptions), workdir),
+        invokeConfigHook(mainPlugin(vttforge({ id: '' } as VttforgeOptions)), workdir),
       ).rejects.toThrow(/`id` option is required/);
     });
 
     it('throws when kind is invalid', () => {
       expect(() =>
         invokeConfigHook(
-          vttforge({ id: 'fixture-system', kind: 'plugin' } as unknown as VttforgeOptions),
+          mainPlugin(
+            vttforge({ id: 'fixture-system', kind: 'plugin' } as unknown as VttforgeOptions),
+          ),
           workdir,
         ),
       ).rejects.toThrow(/`kind` must be 'system' or 'module'/);
@@ -97,14 +131,14 @@ describe('@vttforge/vite-plugin', () => {
 
     it('throws when entry file is missing', async () => {
       rmSync(resolve(workdir, 'scripts/main.mjs'));
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       await expect(invokeConfigHook(plugin, workdir)).rejects.toThrow(/Entry file not found/);
     });
   });
 
   describe('Vite config shape', () => {
     it('sets base to /systems/<id>/ for systems', async () => {
-      const plugin = vttforge(defaultOptions({ kind: 'system' }));
+      const plugin = mainPlugin(vttforge(defaultOptions({ kind: 'system' })));
       const config = await invokeConfigHook(plugin, workdir);
       expect(config.base).toBe('/systems/fixture-system/');
     });
@@ -114,13 +148,13 @@ describe('@vttforge/vite-plugin', () => {
         resolve(workdir, 'module.json'),
         readFileSync(resolve(workdir, 'system.json'), 'utf8'),
       );
-      const plugin = vttforge(defaultOptions({ kind: 'module' }));
+      const plugin = mainPlugin(vttforge(defaultOptions({ kind: 'module' })));
       const config = await invokeConfigHook(plugin, workdir);
       expect(config.base).toBe('/modules/fixture-system/');
     });
 
     it('disables publicDir and sets browser target', async () => {
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       const config = await invokeConfigHook(plugin, workdir);
       expect(config.publicDir).toBe(false);
       const build = config.build as Record<string, unknown>;
@@ -128,7 +162,7 @@ describe('@vttforge/vite-plugin', () => {
     });
 
     it('emits main.mjs entry with no hashing', async () => {
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       const config = await invokeConfigHook(plugin, workdir);
       const build = config.build as Record<string, unknown>;
       const rollup = build.rollupOptions as Record<string, unknown>;
@@ -150,7 +184,7 @@ describe('@vttforge/vite-plugin', () => {
     });
 
     it('includes CSS entries from the manifest in rollup input under flat basename keys', async () => {
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       const config = await invokeConfigHook(plugin, workdir);
       const build = config.build as Record<string, unknown>;
       const rollup = build.rollupOptions as Record<string, unknown>;
@@ -159,7 +193,7 @@ describe('@vttforge/vite-plugin', () => {
     });
 
     it('keeps the external list empty so Foundry gets a fully resolved bundle', async () => {
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       const config = await invokeConfigHook(plugin, workdir);
       const build = config.build as Record<string, unknown>;
       const rollup = build.rollupOptions as Record<string, unknown>;
@@ -167,7 +201,7 @@ describe('@vttforge/vite-plugin', () => {
     });
 
     it('disables minification when running in watch / serve mode', async () => {
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       const config = await invokeConfigHook(plugin, workdir, 'serve');
       const build = config.build as Record<string, unknown>;
       expect(build.minify).toBe(false);
@@ -176,7 +210,7 @@ describe('@vttforge/vite-plugin', () => {
 
   describe('static + manifest pipeline', () => {
     it('copies static assets to dist/ on writeBundle', async () => {
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       await invokeConfigHook(plugin, workdir);
       await invokeHook(plugin, 'writeBundle');
       expect(existsSync(resolve(workdir, 'dist/lang/en.json'))).toBe(true);
@@ -185,7 +219,7 @@ describe('@vttforge/vite-plugin', () => {
     });
 
     it('syncs version from package.json and rewrites manifest paths on writeBundle', async () => {
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       await invokeConfigHook(plugin, workdir);
       await invokeHook(plugin, 'writeBundle');
       const manifest = JSON.parse(
@@ -200,7 +234,7 @@ describe('@vttforge/vite-plugin', () => {
     });
 
     it('throws when manifest id does not match plugin option', async () => {
-      const plugin = vttforge(defaultOptions({ id: 'wrong-id' }));
+      const plugin = mainPlugin(vttforge(defaultOptions({ id: 'wrong-id' })));
       await invokeConfigHook(plugin, workdir);
       await expect(invokeHook(plugin, 'writeBundle')).rejects.toThrow(
         /Manifest id 'fixture-system' does not match plugin option id 'wrong-id'/,
@@ -208,7 +242,7 @@ describe('@vttforge/vite-plugin', () => {
     });
 
     it('respects a custom staticAssets list', async () => {
-      const plugin = vttforge(defaultOptions({ staticAssets: ['lang'] }));
+      const plugin = mainPlugin(vttforge(defaultOptions({ staticAssets: ['lang'] })));
       await invokeConfigHook(plugin, workdir);
       await invokeHook(plugin, 'writeBundle');
       expect(existsSync(resolve(workdir, 'dist/lang/en.json'))).toBe(true);
@@ -226,7 +260,7 @@ describe('@vttforge/vite-plugin', () => {
         readFileSync(resolve(workdir, 'system.json'), 'utf8'),
       );
       rmSync(resolve(workdir, 'system.json'));
-      const plugin = vttforge(defaultOptions({ manifest: 'static/system.json' }));
+      const plugin = mainPlugin(vttforge(defaultOptions({ manifest: 'static/system.json' })));
       await invokeConfigHook(plugin, workdir);
       await invokeHook(plugin, 'writeBundle');
       expect(existsSync(resolve(workdir, 'dist/system.json'))).toBe(true);
@@ -242,7 +276,7 @@ describe('@vttforge/vite-plugin', () => {
         readFileSync(resolve(workdir, 'system.json'), 'utf8'),
       );
       rmSync(resolve(workdir, 'system.json'));
-      const plugin = vttforge(defaultOptions({ manifest: 'forge.json' }));
+      const plugin = mainPlugin(vttforge(defaultOptions({ manifest: 'forge.json' })));
       await invokeConfigHook(plugin, workdir);
       await invokeHook(plugin, 'writeBundle');
       expect(existsSync(resolve(workdir, 'dist/system.json'))).toBe(true);
@@ -250,7 +284,7 @@ describe('@vttforge/vite-plugin', () => {
     });
 
     it('drops stylesheet entries added after Vite started instead of advertising an unbuilt file', async () => {
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       await invokeConfigHook(plugin, workdir);
       // Simulate the consumer editing the manifest mid-watch to declare a
       // brand-new stylesheet that the captured rollup input graph never saw.
@@ -277,7 +311,7 @@ describe('@vttforge/vite-plugin', () => {
       >;
       manifest.styles = [{ src: 'styles/main.css' }];
       writeFileSync(resolve(workdir, 'system.json'), JSON.stringify(manifest, null, 2));
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       await invokeConfigHook(plugin, workdir);
       await invokeHook(plugin, 'writeBundle');
       const written = JSON.parse(
@@ -297,7 +331,7 @@ describe('@vttforge/vite-plugin', () => {
       >;
       manifest.styles = [{ src: 'styles/main.css', layer: 'fixture-system' }];
       writeFileSync(resolve(workdir, 'system.json'), JSON.stringify(manifest, null, 2));
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       await invokeConfigHook(plugin, workdir);
       await invokeHook(plugin, 'writeBundle');
       const written = JSON.parse(
@@ -311,7 +345,7 @@ describe('@vttforge/vite-plugin', () => {
       // Same basename, but the new source was never in Rollup's input graph.
       // The manifest must NOT advertise it under the old path with the
       // outdated bundle content.
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       await invokeConfigHook(plugin, workdir);
       mkdirSync(resolve(workdir, 'themes'));
       writeFileSync(resolve(workdir, 'themes/main.css'), '.themed { color: gold; }');
@@ -340,10 +374,45 @@ describe('@vttforge/vite-plugin', () => {
       >;
       manifest.styles = ['styles/main.css', 'styles/themes/main.css'];
       writeFileSync(resolve(workdir, 'system.json'), JSON.stringify(manifest, null, 2));
-      const plugin = vttforge(defaultOptions());
+      const plugin = mainPlugin(vttforge(defaultOptions()));
       await expect(invokeConfigHook(plugin, workdir)).rejects.toThrow(
         /Stylesheet basename collision/,
       );
+    });
+  });
+
+  describe('decorators', () => {
+    it('lowers a TC39 decorator so the bundle Foundry loads has no raw `@`', async () => {
+      // Oxc, which Vite 8 uses, does not lower Stage 3 decorators. Without
+      // the plugin's Babel pass this file reaches dist untransformed and the
+      // system fails to load in every browser, with no error at build time.
+      writeFileSync(
+        resolve(workdir, 'scripts/decorated.mjs'),
+        [
+          'function tag(value) { return (target) => { target.tagged = value; }; }',
+          '@tag("yes")',
+          'export class Decorated {}',
+          '',
+        ].join('\n'),
+      );
+      writeFileSync(
+        resolve(workdir, 'scripts/main.mjs'),
+        "export { Decorated } from './decorated.mjs';\n",
+      );
+
+      await build({
+        root: workdir,
+        logLevel: 'silent',
+        plugins: [vttforge(defaultOptions())],
+      });
+
+      const out = readFileSync(resolve(workdir, 'dist/main.mjs'), 'utf8');
+      // A decorator that survived would sit at the start of a line as `@name`.
+      expect(out).not.toMatch(/^\s*@[A-Za-z_$]/m);
+      // The class and its decorator's effect are still there, so it was
+      // lowered, not dropped.
+      expect(out).toContain('Decorated');
+      expect(out).toContain('tagged');
     });
   });
 });

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -21,7 +21,8 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { cp, mkdir, readdir, stat } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
-import type { Plugin, UserConfig } from 'vite';
+import babel from '@rolldown/plugin-babel';
+import type { Plugin, PluginOption, UserConfig } from 'vite';
 import { version } from '../package.json' with { type: 'json' };
 
 export interface VttforgeOptions {
@@ -233,7 +234,35 @@ function syncManifest(opts: ResolvedOptions, builtCssSources: Set<string>): Mani
 }
 
 /**
+ * Lower TC39 decorators, which Oxc does not do yet.
+ *
+ * Vite 8 replaced esbuild with Oxc, and Oxc does not lower Stage 3 decorators
+ * (oxc-project/oxc#9170). Without this, `@ActorDataModel(...)` reaches the
+ * bundle untransformed and the system fails to load in every browser. This is
+ * the workaround the Vite 8 migration guide gives, and it is filtered to files
+ * that contain an `@`, so a project that never uses a decorator pays nothing.
+ */
+function decoratorLowering(): PluginOption {
+  // `babel()` resolves asynchronously. Vite accepts a promise in `plugins`
+  // and awaits it, so this stays a plain synchronous call for the consumer.
+  return babel({
+    presets: [
+      {
+        preset: () => ({
+          plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]],
+        }),
+        rolldown: { filter: { code: '@' } },
+      },
+    ],
+  });
+}
+
+/**
  * Vite plugin for Foundry VTT systems and modules.
+ *
+ * Returns two entries: decorator lowering, then the plugin proper. Vite
+ * flattens nested plugin arrays and awaits promised entries, so
+ * `plugins: [vttforge({ id })]` is unchanged.
  *
  * @example
  * ```js
@@ -246,7 +275,11 @@ function syncManifest(opts: ResolvedOptions, builtCssSources: Set<string>): Mani
  * });
  * ```
  */
-export default function vttforge(options: VttforgeOptions): Plugin {
+export default function vttforge(options: VttforgeOptions): PluginOption[] {
+  return [decoratorLowering(), vttforgePlugin(options)];
+}
+
+function vttforgePlugin(options: VttforgeOptions): Plugin {
   let resolved: ResolvedOptions;
   let cssEntries: string[] = [];
   let builtCssSources: Set<string> = new Set();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,12 @@ catalogs:
     '@arethetypeswrong/cli':
       specifier: ^0.18.5
       version: 0.18.5
+    '@babel/core':
+      specifier: ^8.0.1
+      version: 8.0.1
+    '@babel/plugin-proposal-decorators':
+      specifier: ^8.0.2
+      version: 8.0.2
     '@biomejs/biome':
       specifier: ^2.5.11
       version: 2.5.11
@@ -24,6 +30,9 @@ catalogs:
     '@playwright/test':
       specifier: ^1.62.1
       version: 1.62.1
+    '@rolldown/plugin-babel':
+      specifier: ^0.2.4
+      version: 0.2.4
     '@types/archiver':
       specifier: ^8.0.0
       version: 8.0.0
@@ -248,6 +257,18 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.5
+      '@babel/core':
+        specifier: 'catalog:'
+        version: 8.0.1
+      '@babel/plugin-proposal-decorators':
+        specifier: 'catalog:'
+        version: 8.0.2(@babel/core@8.0.1)
+      '@rolldown/plugin-babel':
+        specifier: 'catalog:'
+        version: 0.2.4(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.2.6)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@vttforge/testing':
+        specifier: workspace:*
+        version: link:../testing
       happy-dom:
         specifier: 'catalog:'
         version: 20.12.0
@@ -352,6 +373,16 @@ importers:
         version: 4.1.11(@types/node@26.4.0)(happy-dom@20.12.0)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/vite-plugin:
+    dependencies:
+      '@babel/core':
+        specifier: 'catalog:'
+        version: 8.0.1
+      '@babel/plugin-proposal-decorators':
+        specifier: 'catalog:'
+        version: 8.0.2(@babel/core@8.0.1)
+      '@rolldown/plugin-babel':
+        specifier: 'catalog:'
+        version: 0.2.4(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.2.6)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -468,26 +499,129 @@ packages:
     resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
     engines: {node: '>=20'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/compat-data@8.0.0':
+    resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/core@8.0.1':
+    resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-compilation-targets@8.0.0':
+    resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-create-class-features-plugin@8.0.1':
+    resolution: {integrity: sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-member-expression-to-functions@8.0.0':
+    resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-optimise-call-expression@8.0.0':
+    resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-plugin-utils@8.0.1':
+    resolution: {integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
+  '@babel/helper-replace-supers@8.0.1':
+    resolution: {integrity: sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+    resolution: {integrity: sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-validator-option@8.0.0':
+    resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@8.0.0':
+    resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+
+  '@babel/plugin-proposal-decorators@8.0.2':
+    resolution: {integrity: sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
+  '@babel/plugin-syntax-decorators@8.0.1':
+    resolution: {integrity: sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/traverse@8.0.4':
+    resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@biomejs/biome@2.5.11':
     resolution: {integrity: sha512-Tj0dnkLPdW0ASjHfj2D/ZkkvPU2wrFmnE1jWTD2xzV1ycapV1DutbYXk4NDnR3rYTi1ZCbNFD4G2gRMEY65WaA==}
@@ -867,8 +1001,18 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.6.0':
     resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
@@ -1377,6 +1521,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/plugin-babel@0.2.4':
+    resolution: {integrity: sha512-ygmm2j/mN+aCvstHo0x3IOu4uc6LqXT9SJ3q4kpfG/+Yhfz0B+E47FITcC0FljZADwUFARP6E2kiE+Lc26D8wg==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -1606,8 +1767,14 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/gensync@1.0.5':
+    resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
+
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -2137,6 +2304,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.11.21:
+    resolution: {integrity: sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -2151,6 +2323,11 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browserslist@4.28.9:
+    resolution: {integrity: sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
@@ -2178,6 +2355,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2322,6 +2502,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  electron-to-chromium@1.5.422:
+    resolution: {integrity: sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==}
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -2479,6 +2662,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -2662,12 +2849,20 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-yaml@3.15.2:
     resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
   js-yaml@4.3.2:
     resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json5@2.2.3:
@@ -2920,6 +3115,10 @@ packages:
 
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
+
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
 
   normalize-path@3.0.0:
@@ -3543,6 +3742,12 @@ packages:
       synckit:
         optional: true
 
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
@@ -3925,20 +4130,153 @@ snapshots:
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
 
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+
+  '@babel/compat-data@8.0.0': {}
+
+  '@babel/core@8.0.1':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helpers': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+      '@types/gensync': 1.0.5
+      convert-source-map: 2.0.0
+      empathic: 2.0.1
+      gensync: 1.0.0-beta.2
+      import-meta-resolve: 4.2.0
+      json5: 2.2.3
+      obug: 2.1.4
+      semver: 7.8.5
+
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.4
+
+  '@babel/helper-compilation-targets@8.0.0':
+    dependencies:
+      '@babel/compat-data': 8.0.0
+      '@babel/helper-validator-option': 8.0.0
+      browserslist: 4.28.9
+      lru-cache: 11.5.2
+      semver: 7.8.5
+
+  '@babel/helper-create-class-features-plugin@8.0.1(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 8.0.0
+      '@babel/helper-member-expression-to-functions': 8.0.0
+      '@babel/helper-optimise-call-expression': 8.0.0
+      '@babel/helper-replace-supers': 8.0.1(@babel/core@8.0.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
+      '@babel/traverse': 8.0.4
+      semver: 7.8.5
+
+  '@babel/helper-globals@8.0.0': {}
+
+  '@babel/helper-member-expression-to-functions@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+
+  '@babel/helper-optimise-call-expression@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.4
+
+  '@babel/helper-plugin-utils@8.0.1(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+
+  '@babel/helper-replace-supers@8.0.1(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-member-expression-to-functions': 8.0.0
+      '@babel/helper-optimise-call-expression': 8.0.0
+      '@babel/traverse': 8.0.4
+
+  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.4': {}
+
+  '@babel/helper-validator-option@8.0.0': {}
+
+  '@babel/helpers@8.0.0':
+    dependencies:
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
 
   '@babel/parser@7.29.8':
     dependencies:
       '@babel/types': 7.29.8
 
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
+
+  '@babel/plugin-proposal-decorators@8.0.2(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
+      '@babel/plugin-syntax-decorators': 8.0.1(@babel/core@8.0.1)
+
+  '@babel/plugin-syntax-decorators@8.0.1(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+
+  '@babel/traverse@8.0.4':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+      obug: 2.1.4
 
   '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
 
   '@biomejs/biome@2.5.11':
     optionalDependencies:
@@ -4336,7 +4674,19 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.6.0': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
@@ -4702,6 +5052,15 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.2.6':
     optional: true
 
+  '@rolldown/plugin-babel@0.2.4(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.2.6)(vite@8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 8.0.1
+      picomatch: 4.0.7
+      rolldown: 1.2.6
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      vite: 8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0)
+
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.63.1':
@@ -4878,9 +5237,13 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/gensync@1.0.5': {}
+
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/jsesc@2.5.1': {}
 
   '@types/linkify-it@5.0.0': {}
 
@@ -5311,6 +5674,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.11.21: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -5324,6 +5689,14 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browserslist@4.28.9:
+    dependencies:
+      baseline-browser-mapping: 2.11.21
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.422
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.9)
 
   buffer-crc32@1.0.0: {}
 
@@ -5354,6 +5727,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -5481,6 +5856,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  electron-to-chromium@1.5.422: {}
 
   emoji-regex-xs@1.0.0: {}
 
@@ -5636,6 +6013,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   generator-function@2.0.1: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -5822,6 +6201,8 @@ snapshots:
 
   jju@1.4.0: {}
 
+  js-tokens@10.0.0: {}
+
   js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
@@ -5830,6 +6211,8 @@ snapshots:
   js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
 
   json5@2.2.3: {}
 
@@ -6079,6 +6462,8 @@ snapshots:
       char-regex: 1.0.2
       emojilib: 2.4.0
       skin-tone: 2.0.0
+
+  node-releases@2.0.54: {}
 
   normalize-path@3.0.0: {}
 
@@ -6772,6 +7157,12 @@ snapshots:
   unrun@0.3.1:
     dependencies:
       rolldown: 1.2.6
+
+  update-browserslist-db@1.3.2(browserslist@4.28.9):
+    dependencies:
+      browserslist: 4.28.9
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   url@0.11.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,9 @@ catalog:
   typescript: ^7.0.2
   vite: ^8.2.2
   vitest: ^4.1.11
+  '@rolldown/plugin-babel': ^0.2.4
+  '@babel/plugin-proposal-decorators': ^8.0.2
+  '@babel/core': ^8.0.1
 
 # pnpm 11 reads settings from here, not .npmrc — .npmrc keeps registry and auth
 # only. It does not warn when it finds them in the old place, so anything left
@@ -53,6 +56,7 @@ supportedArchitectures:
 # applying the moment knip bumps — drop the block then rather than growing it.
 minimumReleaseAgeExclude:
   - knip@6.34.0
+  - '@rolldown/plugin-babel@0.2.4'
 
 # pnpm 11 turns an ignored build script into a hard error. lefthook needs its
 # postinstall to write the git hooks.


### PR DESCRIPTION
Track 6 was parked as blocked by the vitest transform. It was never the design; it was the toolchain, and the fix was documented all along.

## The cause, researched

Vite 8 replaced esbuild with Oxc, and Oxc does not lower TC39 Stage 3 decorators ([oxc-project/oxc#9170](https://github.com/oxc-project/oxc/issues/9170), no timeline). That is why `esbuild: { target }` had no effect: the key still exists but is converted to the Oxc equivalent. The [Vite 8 migration guide](https://vite.dev/guide/migration) gives the workaround: `@rolldown/plugin-babel` with `@babel/plugin-proposal-decorators` at `2023-11`, filtered to files containing an `@`. Applied to core's vitest config, the parked tests pass unchanged.

## A design fix on the way in

`@DocumentSheet` called Foundry's `registerSheet` directly. That bypassed `registerSheets`, which exists to pin the class name so the sheet key Foundry saves on every document survives a bundler renaming the class. It now takes a required `id` and goes through `registerSheets`; the test asserts the persisted key is `<namespace>.<id>`.

## The same gap hits consumers

A system that applied one of these and ran `vttforge build` shipped a raw `@` and failed to load in every browser, with no error at build time. `@vttforge/vite-plugin` now adds the same Babel pass, filtered the same way, so a project that never uses a decorator pays nothing.

`vttforge()` returns `PluginOption[]` rather than `Plugin`: the lowering (a promise Vite awaits itself) and then the plugin proper. `plugins: [vttforge({ id })]` is unchanged because Vite flattens nested arrays. Only code that annotated the result as `Plugin` needs to widen it; said so in the changeset.

## Verification

- Core: 9 decorator tests, including that nothing touches `CONFIG` before `init`, the pinned sheet key, and the static-only rule on `@OnHook`. Suite 194 → 203.
- Vite plugin: a real `vite.build()` over a fixture with an applied decorator asserts no `@` survives and the decorator's effect is present. Suite 23 → 25.
- The published core bundle contains no decorator syntax either way: `decorators.ts` defines factories, it applies none.
- Typecheck, lint, build, template-pin guard all green.

All four are `@experimental`. `registerSystem` / `registerModule` stay the supported path and what the scaffolds use. Docs page added.