### PR TITLE
chore(deps): stop Dependabot proposing TypeScript majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,14 @@ updates:
       # fvtt-types is intentionally pinned to a git SHA from main (PRD §5);
       # last npm release is 10+ months stale. Bump manually when needed.
       - dependency-name: fvtt-types
+      # TypeScript majors. apps/docs pins ~6.0.0 because typedoc needs the JS
+      # compiler API, and TypeScript 7.0 ships without one (7.1 is expected to
+      # bring a new, different API). typedoc's peer range ends at 6.0.x and it
+      # crashes under 7. This entry covers the whole workspace, so a future
+      # TypeScript 8 also needs a manual look; the catalog is already on 7.
+      # Re-evaluate when typedoc's peer range includes 7.x.
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
 
   # GitHub Actions versions
   - package-ecosystem: github-actions


### PR DESCRIPTION
Follow-up to #166, which left TypeScript 7 out of the batch with evidence. Without this, Dependabot reopens the 7.x bump for `apps/docs` on every TypeScript release, and it breaks the docs build every time (#162).

## Why the docs cannot take TypeScript 7

`apps/docs` pins `~6.0.0` because typedoc needs the JS compiler API. Two primary sources:

- **Microsoft, announcing TypeScript 7.0:** "While TypeScript 7.0 is here, it does not ship with an API. We expect TypeScript 7.1 to ship with a new (and different) API." Their recommended path for tools that need programmatic access is running 6.0 side by side via `@typescript/typescript6`. ([announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/))
- **typedoc's maintainer:** "TS 7.0 will almost certainly release without an API, but the API *might* be available in 7.1," and typedoc is "6–12 months away from even getting started on using the Go API." ([TypeStrong/typedoc#3068](https://github.com/TypeStrong/typedoc/discussions/3068))

typedoc 0.28.20 is the latest and its peer range ends at `6.0.x`; under 7.0.2 it crashes with `Cannot read properties of undefined (reading 'PropertyDeclaration')`.

## What this does

Adds `typescript` with `update-types: ['version-update:semver-major']` to the npm entry's `ignore`. That entry is `directory: /` and covers the whole workspace, so it also holds back a future TypeScript 8 for the catalog, which is already on 7. The comment in the file says so, and names the trigger to revisit: **typedoc's peer range including 7.x**.

YAML validated. #162 can be closed; Dependabot will not reopen it.