### PR TITLE
fix(vite-plugin): pass the Babel decorators plugin as a module

### DIFF
--- a/.changeset/vite-plugin-babel-resolution.md
+++ b/.changeset/vite-plugin-babel-resolution.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/vite-plugin': patch
+---
+
+The decorator lowering passes the Babel plugin as a module instead of by name. Babel resolved the name from the consumer's project root, where the package is not installed, so every build outside this repository failed with "Cannot find package '@babel/plugin-proposal-decorators'".

--- a/knip.json
+++ b/knip.json
@@ -12,8 +12,7 @@
       "project": ["preview/**/*.js"]
     },
     "packages/vite-plugin": {
-      "ignore": ["src/__tests__/fixtures/**"],
-      "ignoreDependencies": ["@babel/plugin-proposal-decorators"]
+      "ignore": ["src/__tests__/fixtures/**"]
     },
     "examples/simple-system": {
       "entry": ["scripts/main.mjs"],

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -21,6 +21,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { cp, mkdir, readdir, stat } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
+import decorators from '@babel/plugin-proposal-decorators';
 import babel from '@rolldown/plugin-babel';
 import type { Plugin, PluginOption, UserConfig } from 'vite';
 import { version } from '../package.json' with { type: 'json' };
@@ -245,11 +246,15 @@ function syncManifest(opts: ResolvedOptions, builtCssSources: Set<string>): Mani
 function decoratorLowering(): PluginOption {
   // `babel()` resolves asynchronously. Vite accepts a promise in `plugins`
   // and awaits it, so this stays a plain synchronous call for the consumer.
+  //
+  // The plugin is passed as a module, not by name. Babel resolves a name from
+  // the consumer's project root, where the package is not installed: it is a
+  // dependency of this plugin, and a strict package manager keeps it here.
   return babel({
     presets: [
       {
         preset: () => ({
-          plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]],
+          plugins: [[decorators, { version: '2023-11' }]],
         }),
         rolldown: { filter: { code: '@' } },
       },


### PR DESCRIPTION
## What

The decorator lowering now imports `@babel/plugin-proposal-decorators` and passes the module to Babel, instead of naming it as a string.

## Why

Babel resolves a plugin name from the consumer's project root. The package is this plugin's own dependency, so with pnpm it lives under `@vttforge/vite-plugin`'s node_modules and the consumer's root cannot see it. Every `vttforge build` outside this repository failed on 0.5.0 with:

```
Cannot find package '@babel/plugin-proposal-decorators' imported from <project>/babel-virtual-resolve-base.js
```

The examples never hit it because the workspace root hoists the package. Found while moving a real module onto 0.5.0.

## Checks

typecheck, tests, build, lint, knip green. The consumer that failed builds after this change.