### PR TITLE
feat(core): @SystemSetting on a static accessor

### DIFF
--- a/.changeset/system-setting-decorator.md
+++ b/.changeset/system-setting-decorator.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/core': minor
+---
+
+`@SystemSetting`, the last of the planned decorators. Put it on a static accessor and the setting is registered at `init`; reading the accessor calls `game.settings.get`, assigning to it calls `game.settings.set`, and the accessor's initializer is the default. Experimental, like the other four.

--- a/.changeset/templates-core-015.md
+++ b/.changeset/templates-core-015.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/cli': patch
+---
+
+The templates pin `@vttforge/core` at `^0.15.0`, the release that carries `@SystemSetting`.

--- a/apps/docs/guide/decorators.md
+++ b/apps/docs/guide/decorators.md
@@ -1,12 +1,12 @@
 # Decorators
 
-Four decorators for the registrations every package writes by hand. They are
+Five decorators for the registrations every package writes by hand. They are
 `@experimental`: new, and no consumer has used them yet, so the shape can
 change in a minor. `registerSystem` and `registerModule` remain the supported
 path, and are what the scaffolds use.
 
 ```ts
-import { ActorDataModel, DocumentSheet, OnHook } from '@vttforge/core';
+import { ActorDataModel, DocumentSheet, OnHook, SystemSetting } from '@vttforge/core';
 
 @ActorDataModel('character')
 class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
@@ -24,6 +24,14 @@ class Chat {
   @OnHook('renderChatMessageHTML')
   static onRender(message: unknown, html: HTMLElement) {}
 }
+
+class Settings {
+  @SystemSetting({ namespace: 'my-system', scope: 'world', config: true, type: Boolean })
+  static accessor homebrew = false;
+}
+
+Settings.homebrew; // game.settings.get('my-system', 'homebrew')
+Settings.homebrew = true; // game.settings.set('my-system', 'homebrew', true)
 ```
 
 ## The timing is the whole point
@@ -50,6 +58,16 @@ which pins the class name to the `id` you give it. Pick it once and keep it.
 An instance method has no instance to run against when the listener is
 registered, and inventing one would be a guess. Decorating an instance method
 throws `VTTF-0002` and says so.
+
+## `@SystemSetting` sits on a static accessor
+
+The accessor's initializer is the setting's default, and the key is the
+accessor's name unless you pass `key`. Reads go to `game.settings.get` and
+writes to `game.settings.set`, so the field itself holds nothing. The write
+cannot be awaited, because an assignment has no result; when you need to know
+it landed, call `game.settings.set` yourself. An instance accessor throws
+`VTTF-0002`: a setting has one value for the world or the client, not one per
+instance.
 
 ## The build has to lower them
 

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.14.0"
+    "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.9.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.14.0"
+    "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.9.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -11,7 +11,7 @@
     "dev": "vttforge dev"
   },
   "dependencies": {
-    "@vttforge/core": "^0.14.0",
+    "@vttforge/core": "^0.15.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.14.0",
+    "@vttforge/core": "^0.15.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/decorators.test.ts
+++ b/packages/core/src/__tests__/decorators.test.ts
@@ -7,7 +7,13 @@
  */
 import { type MockFoundry, withMockFoundry } from '@vttforge/testing/vitest';
 import { afterEach, describe, expect, it } from 'vitest';
-import { ActorDataModel, DocumentSheet, ItemDataModel, OnHook } from '../decorators.js';
+import {
+  ActorDataModel,
+  DocumentSheet,
+  ItemDataModel,
+  OnHook,
+  SystemSetting,
+} from '../decorators.js';
 import { VttfError } from '../errors/registry.js';
 
 let mock: MockFoundry | undefined;
@@ -152,5 +158,77 @@ describe('without a Foundry runtime', () => {
       class Orphan {}
       void Orphan;
     }).toThrow(VttfError);
+  });
+});
+
+describe('@SystemSetting', () => {
+  it('registers nothing until init fires, then reads and writes through game.settings', async () => {
+    mock = withMockFoundry();
+
+    class Settings {
+      @SystemSetting({ namespace: 'my-system', scope: 'world', config: true, type: Boolean })
+      static accessor homebrew = false;
+    }
+
+    expect(mock.settings).toEqual([]);
+
+    mock.callHook('init');
+    expect(mock.settings).toEqual([
+      {
+        namespace: 'my-system',
+        key: 'homebrew',
+        config: { scope: 'world', config: true, type: Boolean, default: false },
+      },
+    ]);
+    expect(Settings.homebrew).toBe(false);
+
+    Settings.homebrew = true;
+    await Promise.resolve();
+    expect(Settings.homebrew).toBe(true);
+    expect(game.settings.get('my-system', 'homebrew')).toBe(true);
+  });
+
+  it('takes an explicit key and default over the accessor name and initializer', () => {
+    mock = withMockFoundry();
+
+    class Settings {
+      @SystemSetting({
+        namespace: 'my-system',
+        key: 'difficultyLevel',
+        scope: 'client',
+        type: String,
+        default: 'hard',
+      })
+      static accessor difficulty = 'normal';
+    }
+
+    mock.callHook('init');
+    expect(mock.settings[0]).toMatchObject({ key: 'difficultyLevel', config: { default: 'hard' } });
+    expect(Settings.difficulty).toBe('hard');
+  });
+
+  it('refuses an instance accessor (VTTF-0002)', () => {
+    mock = withMockFoundry();
+
+    expect(() => {
+      class Settings {
+        @SystemSetting({ namespace: 'my-system', scope: 'world', type: Number })
+        accessor level = 1;
+      }
+      void Settings;
+    }).toThrow(VttfError);
+  });
+
+  it('says so when read before game exists', () => {
+    mock = withMockFoundry();
+
+    class Settings {
+      @SystemSetting({ namespace: 'my-system', scope: 'world', type: Number })
+      static accessor level = 1;
+    }
+
+    mock.restore();
+    mock = undefined;
+    expect(() => Settings.level).toThrow(/VTTF-0002/);
   });
 });

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -15,6 +15,7 @@
  */
 
 import { VttfError } from './errors/registry.js';
+import type { GameApi, SettingConfig } from './foundry-globals.js';
 import { registerSheets, type SheetDocumentKind } from './register-sheets.js';
 
 interface HooksApi {
@@ -199,5 +200,94 @@ export function OnHook(event: string) {
     context.addInitializer(function (this: unknown) {
       hooks().on(event, (...args: unknown[]) => target.apply(this, args));
     });
+  };
+}
+
+/**
+ * `game.settings`, read when it is used rather than when the class is
+ * defined: the class is defined at import time, and `game` is not there yet.
+ */
+function gameSettings(): GameApi['settings'] {
+  const game = (globalThis as Record<string, unknown>).game as GameApi | undefined;
+  if (game?.settings === undefined) {
+    throw new VttfError(
+      'VTTF-0002',
+      'game.settings is not available. A @SystemSetting accessor can be read or written inside or after the init hook.',
+    );
+  }
+  return game.settings;
+}
+
+export interface SystemSettingOptions<T> extends Omit<SettingConfig<T>, 'default'> {
+  /** The namespace to register under: your system or module id. */
+  namespace: string;
+  /** The setting key. Defaults to the accessor's name. */
+  key?: string;
+  /**
+   * The initial value. Omit it and the accessor's own initializer is used:
+   * `static accessor homebrew = false` registers with `default: false`.
+   */
+  default?: T;
+}
+
+/**
+ * Register a setting, and read and write it through a static accessor.
+ *
+ * ```ts
+ * class Settings {
+ *   @SystemSetting({ namespace: 'my-system', scope: 'world', config: true, type: Boolean })
+ *   static accessor homebrew = false;
+ * }
+ *
+ * Settings.homebrew;         // game.settings.get('my-system', 'homebrew')
+ * Settings.homebrew = true;  // game.settings.set('my-system', 'homebrew', true)
+ * ```
+ *
+ * The registration waits for `init`, like every other decorator here. The
+ * setter cannot be awaited, because assignment has no result: when you need
+ * to know the write landed, call `game.settings.set` yourself.
+ *
+ * Only static accessors: a setting has one value for the world or the
+ * client, not one per instance.
+ *
+ * @experimental New in 0.15, and no consumer has used it yet. The shape can
+ * change in a minor.
+ */
+export function SystemSetting<T>(options: SystemSettingOptions<T>) {
+  return (
+    _target: ClassAccessorDecoratorTarget<unknown, T>,
+    context: ClassAccessorDecoratorContext<unknown, T>,
+  ): ClassAccessorDecoratorResult<unknown, T> => {
+    if (!context.static) {
+      throw new VttfError(
+        'VTTF-0002',
+        `@SystemSetting is on an instance accessor (${String(context.name)}). A setting has one value, not one per instance: make it static.`,
+      );
+    }
+    const { namespace, key: explicitKey, default: explicitDefault, ...config } = options;
+    const key = explicitKey ?? String(context.name);
+    let initial: T | undefined;
+
+    atInit(() => {
+      gameSettings().register<T>(namespace, key, {
+        ...config,
+        default: (explicitDefault ?? initial) as T,
+      });
+    });
+
+    return {
+      // The initializer is the default, and nothing else: the value lives
+      // in game.settings, so the field itself is never read.
+      init(value: T): T {
+        initial = value;
+        return value;
+      },
+      get(): T {
+        return gameSettings().get<T>(namespace, key);
+      },
+      set(value: T): void {
+        void gameSettings().set<T>(namespace, key, value);
+      },
+    };
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,6 +103,8 @@ export {
   type DocumentSheetOptions,
   ItemDataModel,
   OnHook,
+  SystemSetting,
+  type SystemSettingOptions,
 } from './decorators.js';
 export {
   ERROR_MANIFEST_VERSION,

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -414,5 +414,36 @@ describe('@vttforge/vite-plugin', () => {
       expect(out).toContain('Decorated');
       expect(out).toContain('tagged');
     });
+
+    it('lowers a decorated static accessor, which is what @SystemSetting sits on', async () => {
+      writeFileSync(
+        resolve(workdir, 'scripts/settings.mjs'),
+        [
+          'function setting() { return (target, context) => ({ get() { return "read"; }, set() {}, init(v) { return v; } }); }',
+          'export class Settings {',
+          '  @setting()',
+          '  static accessor homebrew = false;',
+          '}',
+          '',
+        ].join('\n'),
+      );
+      writeFileSync(
+        resolve(workdir, 'scripts/main.mjs'),
+        "export { Settings } from './settings.mjs';\n",
+      );
+
+      await build({
+        root: workdir,
+        logLevel: 'silent',
+        plugins: [vttforge(defaultOptions())],
+      });
+
+      const out = readFileSync(resolve(workdir, 'dist/main.mjs'), 'utf8');
+      expect(out).not.toMatch(/^\s*@[A-Za-z_$]/m);
+      // Babel lowers the accessor to a getter/setter pair; only its helper text
+      // still says "accessor". The declaration itself must be gone.
+      expect(out).not.toMatch(/\baccessor\s+homebrew\b/);
+      expect(out).toContain('homebrew');
+    });
   });
 });


### PR DESCRIPTION
## What

`@SystemSetting`, the last decorator on the list. It goes on a `static accessor`:

```ts
class Settings {
  @SystemSetting({ namespace: 'my-system', scope: 'world', config: true, type: Boolean })
  static accessor homebrew = false;
}
Settings.homebrew;        // game.settings.get('my-system', 'homebrew')
Settings.homebrew = true; // game.settings.set('my-system', 'homebrew', true)
```

The registration waits for `init`, like the other decorators. The key defaults to the accessor's name and the initializer to the default; both can be passed explicitly. An instance accessor throws `VTTF-0002`. Experimental, same as the four from 0.13.

## Checks

- core: 4 new tests (timing, explicit key/default, instance refusal, read before `game`), 208 total
- vite-plugin: a build test proving Babel lowers a decorated `static accessor` (Oxc does not)
- docs: `guide/decorators.md` section; changeset `core` minor
- typecheck, lint, knip green