### PR TITLE
feat(cli): vttforge migrate, a v13 to v14 rewrite

### DIFF
--- a/.changeset/cli-migrate.md
+++ b/.changeset/cli-migrate.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/cli': minor
+---
+
+`vttforge migrate` rewrites a v13 system or module for v14: bare `mergeObject`-style globals, `-=` and `==` update keys, `rollMode`, context-menu and header-control keys, numeric Active Effect modes, whole-array `CONFIG.statusEffects` assignment, `legacyTransferral`, the core-sheet unregister lines, and the manifest's `type` and `compatibility`. It reports by default and writes with `--write`; what it cannot decide it reports as needing a decision.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -88,3 +88,37 @@ or flattened, because Foundry reads both.
 
 The exit code is non-zero on a HIGH finding. `--strict` makes any finding
 fail, for CI. `--json` prints the report as data.
+
+## `vttforge migrate`
+
+```bash
+vttforge migrate [dir] [--write] [--json]
+```
+
+Rewrites a v13 project for v14. Without `--write` it only reports what it
+would change, one line per edit, so a rewrite that landed inside a string or a
+comment is seen before it is written. Run it, read the report, run it again
+with `--write`, then run `vttforge audit`.
+
+| Rewrite | Before | After |
+|---|---|---|
+| Removed globals | `mergeObject(a, b)`, `Math.clamped(x, 0, 1)` | `foundry.utils.mergeObject(a, b)`, `Math.clamp(x, 0, 1)` |
+| Data operators | `'-=system.bio': null`, `"==system.stats": {...}` | `'system.bio': _del`, `"system.stats": _replace({...})` |
+| | `performDeletions: true`, `foundry.utils.objectsEqual` | `applyOperators: true`, `foundry.utils.equals` |
+| Roll modes | `rollMode: 'gmroll'`, `game.settings.get('core', 'rollMode')` | `messageMode: 'gm'`, `game.settings.get('core', 'messageMode')` |
+| | `CONFIG.Dice.rollModes`, `CONST.DICE_ROLL_MODES.PRIVATE` | `CONFIG.ChatMessage.modes`, `"gm"` |
+| Context menus and header controls | `name`, `condition`, `callback` | `label`, `visible`, `onClick` |
+| Active Effects | `mode: CONST.ACTIVE_EFFECT_MODES.ADD` | `type: "add"` |
+| Status effects | `CONFIG.statusEffects = list;` | `for (const effect of list) CONFIG.statusEffects[effect.id] = effect;` |
+| Gone in v14 | `CONFIG.ActiveEffect.legacyTransferral = ...`, `activeEffect: { legacyTransferral }`, `Actors.unregisterSheet('core', ...)` | removed |
+| Manifest | no `type`, `compatibility` below 14 | `"type": "system"` or `"module"`, `minimum` and `verified` at `"14"` |
+
+What it will not decide, it reports as "needs a decision": a `game.template`
+read (which becomes `game.model` or a `documentTypes` lookup depending on what
+was read), a `rollMode` whose value is an expression, the parameter list of a
+renamed `callback` (`onClick` receives `(event, target)`), a root-level
+`changes` array on an effect (now `system.changes`), a `compatibility.maximum`
+below 14, and the flat `gridDistance` / `gridUnits` keys.
+
+The rewrites are text-based, like the audit rules they mirror. A match inside
+a string literal is rewritten too; the preview is where that is caught.

--- a/apps/docs/recipes/migrating-to-v14.md
+++ b/apps/docs/recipes/migrating-to-v14.md
@@ -88,7 +88,11 @@ v16.
 
 ## Then
 
+Most of the list above is mechanical, and the CLI does it:
+
 ```bash
+vttforge migrate          # report what would change
+vttforge migrate --write  # apply it
 vttforge audit
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,6 +14,7 @@ vttforge init <name> [--type system|module] [--lang ts|js] [--id] [--title] [--d
 vttforge dev   [--foundry-data <path>] [--port <n>]
 vttforge build
 vttforge audit [dir] [--json] [--strict]
+vttforge migrate [dir] [--write] [--json]
 ```
 
 **`init`** writes a runnable system or module into `<name>/` from one of four templates (`system-ts`, `system-js`, `module-ts`, `module-js`). It asks for what you did not pass, or takes defaults with `--yes`, so it works in CI. It detects the package manager that invoked it (`pnpm`, `npm`, `bun`, `yarn`), installs, and runs `git init`.
@@ -23,6 +24,8 @@ vttforge audit [dir] [--json] [--strict]
 **`build`** runs the production build and writes `<id>-<version>.zip` at the project root with the manifest at the top level, which is what foundryvtt.com expects. `LICENSE`, `README.md` and `CHANGELOG.md` go in when present.
 
 **`audit`** checks the manifest, the source and the templates against the v14 breakages that fail quietly: the `flags.hotReload` shape, the removed grid fields, the v12 `styles` shape, `HTMLField`/`FilePathField` paths missing from `documentTypes`, `TypeDataModel` without `prepareBaseData`, a bad `_addDataFieldMigrations` override, token attributes that do not point at a `{ value, max }` field, a sheet template that opens a `<form>` the sheet already is, a declared subtype with no name in any language file, a `template.json` that erases the metadata `system.json` declares for the same type, and the v13 code v14 broke or deprecated: bare `mergeObject`-style globals, `-=` update keys, `rollMode`, whole-array `CONFIG.statusEffects` assignment, `legacyTransferral`, numeric Active Effect modes. `--json` for machines; `--strict` exits non-zero on any finding rather than only on HIGH.
+
+**`migrate`** rewrites a v13 project for v14: the removed globals, `-=` keys, `rollMode`, context-menu keys, numeric effect modes, whole-array `CONFIG.statusEffects`, `legacyTransferral`, the core-sheet unregister lines, and the manifest's `type` and `compatibility`. It reports by default and writes with `--write`; what it will not decide it lists as needing one.
 
 ## As a library
 

--- a/packages/cli/src/__tests__/cli-args.test.ts
+++ b/packages/cli/src/__tests__/cli-args.test.ts
@@ -117,7 +117,13 @@ describe('audit args', () => {
 });
 
 describe('command tree', () => {
-  it('registers the four subcommands', () => {
-    expect(Object.keys(main.subCommands ?? {}).sort()).toEqual(['audit', 'build', 'dev', 'init']);
+  it('registers the five subcommands', () => {
+    expect(Object.keys(main.subCommands ?? {}).sort()).toEqual([
+      'audit',
+      'build',
+      'dev',
+      'init',
+      'migrate',
+    ]);
   });
 });

--- a/packages/cli/src/__tests__/migrate/migrate-command.test.ts
+++ b/packages/cli/src/__tests__/migrate/migrate-command.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The command over a real directory: preview by default, written on request.
+ */
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runAudit } from '../../audit/index.js';
+import { runMigrateCommand } from '../../commands/migrate.js';
+
+let cwd: string;
+const MANIFEST =
+  '{\n  "id": "my-system",\n  "title": "T",\n  "compatibility": { "minimum": "13", "verified": "13" }\n}\n';
+const SOURCE =
+  "const merged = mergeObject(a, b);\nawait actor.update({ '-=system.bio': null });\nroll.toMessage({}, { rollMode: 'gmroll' });\n";
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'vttf-migrate-'));
+  await writeFile(join(cwd, 'system.json'), MANIFEST, 'utf8');
+  await writeFile(join(cwd, 'main.mjs'), SOURCE, 'utf8');
+});
+
+afterEach(async () => {
+  await rm(cwd, { recursive: true, force: true });
+});
+
+describe('vttforge migrate', () => {
+  it('previews by default and writes nothing', async () => {
+    let out = '';
+    const { report, exitCode } = await runMigrateCommand({
+      cwd,
+      out: (c) => {
+        out += c;
+      },
+    });
+    expect(exitCode).toBe(0);
+    expect(report.written).toBe(false);
+    expect(report.counts).toEqual({ files: 2, changes: 6, notes: 0 });
+    expect(out).toContain('Would rewrite 6 place(s) in 2 file(s)');
+    expect(out).toContain('--write');
+    expect(await readFile(join(cwd, 'main.mjs'), 'utf8')).toBe(SOURCE);
+    expect(await readFile(join(cwd, 'system.json'), 'utf8')).toBe(MANIFEST);
+  });
+
+  it('writes with --write, and the audit is clean afterwards', async () => {
+    let out = '';
+    const { report } = await runMigrateCommand({
+      cwd,
+      write: true,
+      out: (c) => {
+        out += c;
+      },
+    });
+    expect(report.written).toBe(true);
+    expect(out).toContain('Rewrote 6 place(s)');
+    expect(await readFile(join(cwd, 'main.mjs'), 'utf8')).toBe(
+      "const merged = foundry.utils.mergeObject(a, b);\nawait actor.update({ 'system.bio': _del });\nroll.toMessage({}, { messageMode: 'gm' });\n",
+    );
+    const manifest = JSON.parse(await readFile(join(cwd, 'system.json'), 'utf8'));
+    expect(manifest.type).toBe('system');
+    expect(manifest.compatibility).toEqual({ minimum: '14', verified: '14' });
+
+    const audit = await runAudit({ cwd });
+    expect(audit.findings.filter((f) => /VTTF-AUDIT-01[1-6]/.test(f.ruleId))).toEqual([]);
+
+    // A second run has nothing left to do.
+    const again = await runMigrateCommand({ cwd, out: () => {} });
+    expect(again.report.counts.changes).toBe(0);
+  });
+
+  it('emits JSON on request', async () => {
+    let out = '';
+    await runMigrateCommand({
+      cwd,
+      json: true,
+      out: (c) => {
+        out += c;
+      },
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.files.map((f: { file: string }) => f.file)).toEqual(['main.mjs', 'system.json']);
+  });
+
+  it('says so when the target is not a directory', async () => {
+    await expect(runMigrateCommand({ cwd: join(cwd, 'nope'), out: () => {} })).rejects.toThrow(
+      /not a directory/,
+    );
+  });
+});

--- a/packages/cli/src/__tests__/migrate/transforms.test.ts
+++ b/packages/cli/src/__tests__/migrate/transforms.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Each rewrite `vttforge migrate` makes, and each thing it refuses to decide.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  activeEffectModes,
+  contextMenuKeys,
+  dataOperators,
+  legacyTransferral,
+  removedGlobals,
+  rollMode,
+  statusEffectsAssignment,
+  transformManifest,
+  transformSource,
+  unregisterCoreSheets,
+} from '../../migrate/transforms.js';
+
+describe('removed globals', () => {
+  it('namespaces the v12 utilities and Math.clamped', () => {
+    const r = removedGlobals('const a = mergeObject(x, y);\nconst b = Math.clamped(v, 0, 1);\n');
+    expect(r.output).toBe(
+      'const a = foundry.utils.mergeObject(x, y);\nconst b = Math.clamp(v, 0, 1);\n',
+    );
+    expect(r.changes.map((c) => c.line)).toEqual([1, 2]);
+  });
+
+  it('leaves a name the file defines, and the already namespaced call', () => {
+    const src =
+      "function getProperty(o, k) { return o[k]; }\ngetProperty(x, 'y');\nfoundry.utils.mergeObject(a, b);\n";
+    expect(removedGlobals(src).output).toBe(src);
+  });
+
+  it('notes game.template instead of guessing', () => {
+    const r = removedGlobals('const t = game.template.Actor;\n');
+    expect(r.output).toContain('game.template');
+    expect(r.notes[0]?.message).toContain('game.model');
+  });
+});
+
+describe('data operators', () => {
+  it('turns deletion keys into _del, nested or not', () => {
+    const r = dataOperators(
+      "await a.update({ 'system.biography': legacy, '-=system.bio': null, \"flags.mod.-=old\": null });\n",
+    );
+    expect(r.output).toBe(
+      "await a.update({ 'system.biography': legacy, 'system.bio': _del, \"flags.mod.old\": _del });\n",
+    );
+    expect(r.changes).toHaveLength(2);
+  });
+
+  it('wraps a replacement value of any shape in _replace', () => {
+    const r = dataOperators(
+      'await a.update({ "==system.stats": { str: 10, list: [1, 2] }, other: 1 });\n',
+    );
+    expect(r.output).toBe(
+      'await a.update({ "system.stats": _replace({ str: 10, list: [1, 2] }), other: 1 });\n',
+    );
+  });
+
+  it('renames performDeletions and objectsEqual', () => {
+    const r = dataOperators(
+      'foundry.utils.mergeObject(a, b, { performDeletions: true });\nfoundry.utils.objectsEqual(a, b);\n',
+    );
+    expect(r.output).toBe(
+      'foundry.utils.mergeObject(a, b, { applyOperators: true });\nfoundry.utils.equals(a, b);\n',
+    );
+  });
+});
+
+describe('roll mode', () => {
+  it('maps the literal modes and the setting', () => {
+    const r = rollMode(
+      "roll.toMessage({}, { rollMode: 'gmroll' });\nconst m = game.settings.get('core', 'rollMode');\n",
+    );
+    expect(r.output).toBe(
+      "roll.toMessage({}, { messageMode: 'gm' });\nconst m = game.settings.get('core', 'messageMode');\n",
+    );
+    expect(r.notes).toEqual([]);
+  });
+
+  it('turns "roll" into undefined, and notes an expression', () => {
+    const r = rollMode('a({ rollMode: "roll" });\nb({ rollMode: chosen });\n');
+    expect(r.output).toBe('a({ messageMode: undefined });\nb({ messageMode: chosen });\n');
+    expect(r.notes).toHaveLength(1);
+    expect(r.notes[0]).toMatchObject({ line: 2 });
+  });
+
+  it('replaces the constants and CONFIG.Dice.rollModes', () => {
+    const r = rollMode(
+      'for (const k in CONFIG.Dice.rollModes) {}\nconst v = CONST.DICE_ROLL_MODES.PRIVATE;\n',
+    );
+    expect(r.output).toBe('for (const k in CONFIG.ChatMessage.modes) {}\nconst v = "gm";\n');
+  });
+});
+
+describe('context menu keys', () => {
+  it('renames the keys of an entry and notes the new callback shape', () => {
+    const src = `options.push({
+  name: 'MOD.choose',
+  icon: '<i class="fa-solid fa-check"></i>',
+  condition: () => game.user.isGM,
+  callback: (li) => open(li),
+});
+const other = { name: 'kept', value: 1 };
+`;
+    const r = contextMenuKeys(src);
+    expect(r.output).toContain("  label: 'MOD.choose',");
+    expect(r.output).toContain('  visible: () => game.user.isGM,');
+    expect(r.output).toContain('  onClick: (li) => open(li),');
+    expect(r.output).toContain("const other = { name: 'kept', value: 1 };");
+    expect(r.notes[0]?.message).toContain('(event, target)');
+  });
+});
+
+describe('legacyTransferral and core sheets', () => {
+  it('drops the assignment, the registerSystem option, and the unregister lines', () => {
+    const src = `CONFIG.ActiveEffect.legacyTransferral = false;
+registerSystem({
+  id: 'x',
+  activeEffect: { legacyTransferral: false },
+  onBeforeInit: () => {
+    const { Actors, Items } = foundry.documents.collections;
+    Actors.unregisterSheet('core', foundry.applications.sheets.ActorSheetV2);
+    Items.unregisterSheet("core", foundry.applications.sheets.ItemSheetV2);
+  },
+});
+`;
+    const out = unregisterCoreSheets(legacyTransferral(src).output).output;
+    expect(out).toBe(`registerSystem({
+  id: 'x',
+  onBeforeInit: () => {
+    const { Actors, Items } = foundry.documents.collections;
+  },
+});
+`);
+  });
+});
+
+describe('status effects and effect modes', () => {
+  it('adds status effects by id instead of assigning the array', () => {
+    const r = statusEffectsAssignment(
+      'CONFIG.statusEffects = [\n  { id: "a" },\n  { id: "b" },\n];\nif (CONFIG.statusEffects === x) {}\n',
+    );
+    expect(r.output).toBe(
+      'for (const effect of [\n  { id: "a" },\n  { id: "b" },\n]) CONFIG.statusEffects[effect.id] = effect;\nif (CONFIG.statusEffects === x) {}\n',
+    );
+  });
+
+  it('turns numeric modes into string types and notes system.changes', () => {
+    const r = activeEffectModes(
+      'changes: [{ key: "system.ac", mode: CONST.ACTIVE_EFFECT_MODES.ADD, value: 2 }]\nconst m = CONST.ACTIVE_EFFECT_MODES.OVERRIDE;\n',
+    );
+    expect(r.output).toBe(
+      'changes: [{ key: "system.ac", type: "add", value: 2 }]\nconst m = "override";\n',
+    );
+    expect(r.notes).toHaveLength(1);
+  });
+});
+
+describe('the manifest', () => {
+  it('declares the type next to the id and raises compatibility to 14', () => {
+    const r = transformManifest(
+      '{\n  "id": "my-system",\n  "title": "T",\n  "compatibility": { "minimum": "13", "verified": "13.341" }\n}\n',
+      'system',
+    );
+    expect(r).not.toBeNull();
+    const parsed = JSON.parse(r?.output ?? '{}');
+    expect(Object.keys(parsed).slice(0, 3)).toEqual(['id', 'type', 'title']);
+    expect(parsed.compatibility).toEqual({ minimum: '14', verified: '14' });
+    expect(r?.changes).toHaveLength(3);
+  });
+
+  it('leaves a v14 manifest alone and notes a maximum below 14', () => {
+    expect(
+      transformManifest(
+        '{"id":"m","type":"module","compatibility":{"minimum":"14","verified":"14"}}',
+        'module',
+      ),
+    ).toBeNull();
+    const r = transformManifest(
+      '{"id":"m","type":"module","compatibility":{"minimum":"14","verified":"14","maximum":"13"}}',
+      'module',
+    );
+    expect(r?.changes).toEqual([]);
+    expect(r?.notes[0]?.message).toContain('maximum');
+  });
+});
+
+describe('the whole pipeline', () => {
+  it('leaves a v14 file untouched', () => {
+    const src =
+      "import { registerSystem } from '@vttforge/core';\nregisterSystem({ id: 'x', statusEffects: [{ id: 'x.dazed' }] });\nawait a.update({ 'system.old': _del });\nawait roll.toMessage({}, { messageMode: 'gm' });\n";
+    const r = transformSource(src);
+    expect(r.output).toBe(src);
+    expect(r.changes).toEqual([]);
+    expect(r.notes).toEqual([]);
+  });
+});

--- a/packages/cli/src/audit/v14-rules.ts
+++ b/packages/cli/src/audit/v14-rules.ts
@@ -29,7 +29,7 @@ import type { RuleResult } from './types.js';
  * Only names with no plausible user-land meaning are listed: `duplicate`
  * and `debounce` are left out because a project can define its own.
  */
-const REMOVED_UTILS = [
+export const REMOVED_UTILS = [
   'mergeObject',
   'getProperty',
   'setProperty',

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,6 +12,7 @@ import { runAuditCommand } from './commands/audit.js';
 import { runBuild } from './commands/build.js';
 import { runDev } from './commands/dev.js';
 import { runInit, ScaffoldError } from './commands/init.js';
+import { runMigrateCommand } from './commands/migrate.js';
 import { VTTFORGE_CLI_VERSION } from './index.js';
 
 export const init = defineCommand({
@@ -199,17 +200,55 @@ export const audit = defineCommand({
   },
 });
 
+export const migrate = defineCommand({
+  meta: {
+    name: 'migrate',
+    description: 'Rewrite a v13 system or module for Foundry v14 (preview by default)',
+  },
+  args: {
+    path: {
+      type: 'positional',
+      description: 'Project root to rewrite (defaults to the current directory)',
+      required: false,
+    },
+    write: {
+      type: 'boolean',
+      default: false,
+      description: 'Write the edits. Without it, the command only reports what it would change',
+    },
+    json: {
+      type: 'boolean',
+      default: false,
+      description: 'Emit the report as JSON',
+    },
+  },
+  async run({ args }) {
+    try {
+      const { exitCode } = await runMigrateCommand({
+        cwd: args.path ? String(args.path) : undefined,
+        write: Boolean(args.write),
+        json: Boolean(args.json),
+      });
+      process.exitCode = exitCode;
+    } catch (error) {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    }
+  },
+});
+
 export const main = defineCommand({
   meta: {
     name: 'vttforge',
     version: VTTFORGE_CLI_VERSION,
     description:
-      'VTTForge CLI: scaffold, dev, build and audit for Foundry v14+ systems and modules',
+      'VTTForge CLI: scaffold, dev, build, audit and migrate for Foundry v14+ systems and modules',
   },
   subCommands: {
     init,
     dev,
     build,
     audit,
+    migrate,
   },
 });

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,0 +1,32 @@
+/**
+ * `vttforge migrate`: the CLI surface over the v13 → v14 rewrite.
+ *
+ * Exit codes:
+ *   0: ran, whether or not anything changed
+ *   1: the target is not a directory
+ */
+
+import { resolve } from 'node:path';
+import { formatMigrateReport, type MigrateReport, runMigrate } from '../migrate/index.js';
+
+export interface MigrateCommandOptions {
+  cwd?: string;
+  write?: boolean;
+  json?: boolean;
+  /** Custom writer (tests). Defaults to process.stdout.write. */
+  out?: (chunk: string) => void;
+}
+
+export async function runMigrateCommand(
+  options: MigrateCommandOptions = {},
+): Promise<{ report: MigrateReport; exitCode: 0 | 1 }> {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const out =
+    options.out ??
+    ((chunk: string) => {
+      process.stdout.write(chunk);
+    });
+  const report = await runMigrate({ cwd, write: options.write === true });
+  out(options.json ? `${JSON.stringify(report, null, 2)}\n` : formatMigrateReport(report));
+  return { report, exitCode: 0 };
+}

--- a/packages/cli/src/migrate/index.ts
+++ b/packages/cli/src/migrate/index.ts
@@ -1,0 +1,128 @@
+/**
+ * `vttforge migrate`: rewrite a v13 project for v14.
+ *
+ * Walks the same files the audit walks, applies the transforms, and reports
+ * every edit and every thing it saw and would not decide for you. Nothing is
+ * written unless asked: the preview is the default, because a text rewrite
+ * that touched a string literal is something to see before it lands.
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile, stat, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { _internal } from '../audit/source-rules.js';
+import { type Change, type Note, transformManifest, transformSource } from './transforms.js';
+
+interface FileResult {
+  /** Project-relative path. */
+  file: string;
+  changes: Change[];
+  notes: Note[];
+}
+
+export interface MigrateReport {
+  cwd: string;
+  /** Files with at least one change or note. */
+  files: FileResult[];
+  /** Whether the edits were written to disk. */
+  written: boolean;
+  counts: { files: number; changes: number; notes: number };
+}
+
+export interface MigrateOptions {
+  cwd: string;
+  /** Write the edits. Default false: report only. */
+  write?: boolean;
+}
+
+export async function runMigrate(options: MigrateOptions): Promise<MigrateReport> {
+  const { cwd } = options;
+  const write = options.write === true;
+  if (!existsSync(cwd) || !(await stat(cwd)).isDirectory()) {
+    throw new Error(`Migrate target is not a directory: ${cwd}`);
+  }
+
+  const files: FileResult[] = [];
+
+  for (const [name, kind] of [
+    ['system.json', 'system'],
+    ['module.json', 'module'],
+  ] as const) {
+    const path = join(cwd, name);
+    if (!existsSync(path)) continue;
+    let raw: string;
+    try {
+      raw = await readFile(path, 'utf8');
+      JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    const result = transformManifest(raw, kind);
+    if (result === null) continue;
+    files.push({ file: name, changes: result.changes, notes: result.notes });
+    if (write && result.changes.length > 0) await writeFile(path, result.output, 'utf8');
+  }
+
+  for await (const path of _internal.walkSourceFiles(cwd)) {
+    let source: string;
+    try {
+      source = await readFile(path, 'utf8');
+    } catch {
+      continue;
+    }
+    const result = transformSource(source);
+    if (result.changes.length === 0 && result.notes.length === 0) continue;
+    files.push({ file: relative(cwd, path), changes: result.changes, notes: result.notes });
+    if (write && result.output !== source) await writeFile(path, result.output, 'utf8');
+  }
+
+  files.sort((a, b) => a.file.localeCompare(b.file));
+  return {
+    cwd,
+    files,
+    written: write,
+    counts: {
+      files: files.length,
+      changes: files.reduce((n, f) => n + f.changes.length, 0),
+      notes: files.reduce((n, f) => n + f.notes.length, 0),
+    },
+  };
+}
+
+/** The report as text: one block per file, edits then notes. */
+export function formatMigrateReport(report: MigrateReport): string {
+  const lines: string[] = [];
+  if (report.files.length === 0) {
+    lines.push('Nothing to migrate. The project already reads as v14.');
+    return `${lines.join('\n')}\n`;
+  }
+  lines.push(
+    report.written
+      ? `Rewrote ${report.counts.changes} place(s) in ${report.counts.files} file(s).`
+      : `Would rewrite ${report.counts.changes} place(s) in ${report.counts.files} file(s). Run again with --write to apply.`,
+  );
+  for (const file of report.files) {
+    lines.push('', `${file.file}`);
+    for (const change of file.changes) {
+      lines.push(
+        `  ${change.line}: ${oneLine(change.before)}`,
+        `  ${' '.repeat(String(change.line).length)}  → ${oneLine(change.after)}`,
+      );
+    }
+    for (const note of file.notes) {
+      lines.push(`  ${note.line}: needs a decision: ${note.message}`);
+    }
+  }
+  if (report.counts.notes > 0) {
+    lines.push(
+      '',
+      `${report.counts.notes} place(s) need a decision. Run \`vttforge audit\` after editing them.`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function oneLine(text: string): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length > 100 ? `${flat.slice(0, 97)}...` : flat;
+}

--- a/packages/cli/src/migrate/transforms.ts
+++ b/packages/cli/src/migrate/transforms.ts
@@ -1,0 +1,550 @@
+/**
+ * The rewrites `vttforge migrate` applies to a v13 source file.
+ *
+ * Each transform is a pure function over the file's text. It returns the new
+ * text, one `Change` per edit it made, and one `Note` per thing it saw and
+ * would not touch: a rewrite that needs a decision (which page a `game.template`
+ * read should become) is reported, not guessed.
+ *
+ * Text-based, like the audit rules they mirror (`VTTF-AUDIT-011` to `016`).
+ * The patterns are short and mechanical, and a syntax tree would not make
+ * `'-=key'` easier to find. The cost is that a match inside a string or a
+ * comment is rewritten too; the preview exists so that is seen before it is
+ * written.
+ */
+
+import { REMOVED_UTILS } from '../audit/v14-rules.js';
+
+export interface Change {
+  /** 1-based line of the edit, in the original text. */
+  line: number;
+  /** What was there. */
+  before: string;
+  /** What is there now. */
+  after: string;
+  /** Which transform made it. */
+  rule: string;
+}
+
+export interface Note {
+  line: number;
+  rule: string;
+  /** What was seen, and what the reader has to decide. */
+  message: string;
+}
+
+export interface TransformResult {
+  output: string;
+  changes: Change[];
+  notes: Note[];
+}
+
+export type Transform = (source: string) => TransformResult;
+
+function lineAt(source: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < source.length; i += 1) {
+    if (source[i] === '\n') line += 1;
+  }
+  return line;
+}
+
+/** The whole line an index sits on, trimmed, for the report. */
+function lineText(source: string, index: number): string {
+  const start = source.lastIndexOf('\n', index - 1) + 1;
+  const end = source.indexOf('\n', index);
+  return source.slice(start, end === -1 ? source.length : end).trim();
+}
+
+/**
+ * Replace every match, recording one change per match against the original
+ * text. The replacement may be a string or a function, like `String#replace`.
+ */
+function rewrite(
+  source: string,
+  pattern: RegExp,
+  replacement: string | ((...groups: string[]) => string),
+  rule: string,
+): TransformResult {
+  const changes: Change[] = [];
+  const output = source.replace(pattern, (match: string, ...rest: unknown[]) => {
+    const offset = rest.find((r): r is number => typeof r === 'number') ?? 0;
+    const groups = rest.filter((r): r is string => typeof r === 'string');
+    const after = typeof replacement === 'string' ? replacement : replacement(match, ...groups);
+    if (after !== match) {
+      changes.push({ line: lineAt(source, offset), before: match, after, rule });
+    }
+    return after;
+  });
+  return { output, changes, notes: [] };
+}
+
+function merge(...results: TransformResult[]): TransformResult {
+  const last = results.at(-1);
+  return {
+    output: last?.output ?? '',
+    changes: results.flatMap((r) => r.changes),
+    notes: results.flatMap((r) => r.notes),
+  };
+}
+
+/** Run transforms in sequence, each on the previous one's output. */
+function pipe(source: string, transforms: readonly Transform[]): TransformResult {
+  const results: TransformResult[] = [];
+  let current = source;
+  for (const transform of transforms) {
+    const result = transform(current);
+    results.push(result);
+    current = result.output;
+  }
+  return merge(...results);
+}
+
+/**
+ * Bare v12 utility globals → `foundry.utils.*`; `Math.clamped` → `Math.clamp`.
+ *
+ * A name the file declares or imports itself is left alone, the same way
+ * `VTTF-AUDIT-011` leaves it alone. `game.template` is reported, not
+ * rewritten: whether it becomes `game.model` or a `documentTypes` read depends
+ * on what was read from it.
+ */
+export const removedGlobals: Transform = (source) => {
+  const own = new Set(
+    REMOVED_UTILS.filter((name) =>
+      new RegExp(
+        `(?:function\\s+${name}\\b|(?:const|let|var)\\s+${name}\\b|import[^;]*\\b${name}\\b|\\b${name}\\s*\\([^)]*\\)\\s*\\{)`,
+      ).test(source),
+    ),
+  );
+  const names = REMOVED_UTILS.filter((name) => !own.has(name));
+  const utils = names.length
+    ? rewrite(
+        source,
+        new RegExp(`(?<![\\w$.])(${names.join('|')})\\s*\\(`, 'g'),
+        (_m, name) => `foundry.utils.${name}(`,
+        'removed-globals',
+      )
+    : { output: source, changes: [], notes: [] };
+  const clamped = rewrite(utils.output, /\bMath\.clamped\s*\(/g, 'Math.clamp(', 'removed-globals');
+  const notes: Note[] = [];
+  for (const match of clamped.output.matchAll(/\bgame\.template\b/g)) {
+    notes.push({
+      line: lineAt(clamped.output, match.index ?? 0),
+      rule: 'removed-globals',
+      message:
+        "`game.template` is gone. Read type defaults from `game.model`, or the type list from the package's `documentTypes`.",
+    });
+  }
+  return { ...merge(utils, clamped), notes };
+};
+
+/**
+ * `'-=key': null` → `key: _del`; `'==key': value` → `key: _replace(value)`;
+ * `performDeletions` → `applyOperators`; `objectsEqual` → `equals`.
+ */
+export const dataOperators: Transform = (source) => {
+  const deletions = rewrite(
+    source,
+    /(['"])((?:[\w$]+\.)*)-=([\w$.]+)\1\s*:\s*null\b/g,
+    (_m, quote, prefix, key) => `${quote}${prefix}${key}${quote}: _del`,
+    'data-operators',
+  );
+  // `"==key": <value>` wraps a value of any shape, so the value is scanned to
+  // its end rather than matched: up to the comma or brace that closes it, with
+  // brackets, braces, parentheses and strings balanced along the way.
+  const replacements = wrapReplacementValues(deletions.output);
+  const flags = rewrite(
+    replacements.output,
+    /\bperformDeletions\s*:/g,
+    'applyOperators:',
+    'data-operators',
+  );
+  const equals = rewrite(
+    flags.output,
+    /\bfoundry\.utils\.objectsEqual\s*\(/g,
+    'foundry.utils.equals(',
+    'data-operators',
+  );
+  return merge(deletions, replacements, flags, equals);
+};
+
+function wrapReplacementValues(source: string): TransformResult {
+  const changes: Change[] = [];
+  const pattern = /(['"])((?:[\w$]+\.)*)==([\w$.]+)\1\s*:\s*/g;
+  let out = '';
+  let cursor = 0;
+  for (const match of source.matchAll(pattern)) {
+    const start = match.index ?? 0;
+    const valueStart = start + match[0].length;
+    const valueEnd = scanValueEnd(source, valueStart);
+    if (valueEnd === -1) continue;
+    const value = source.slice(valueStart, valueEnd).trimEnd();
+    const [, quote = '"', prefix = '', key = ''] = match;
+    const after = `${quote}${prefix}${key}${quote}: _replace(${value})`;
+    out += source.slice(cursor, start) + after;
+    cursor = valueStart + value.length;
+    changes.push({
+      line: lineAt(source, start),
+      before: source.slice(start, cursor),
+      after,
+      rule: 'data-operators',
+    });
+  }
+  out += source.slice(cursor);
+  return { output: out, changes, notes: [] };
+}
+
+/** Index just past a value that starts at `from`: the next `,` or `}` at depth zero. */
+function scanValueEnd(source: string, from: number): number {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let i = from; i < source.length; i += 1) {
+    const ch = source[i] ?? '';
+    if (quote) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+    else if (ch === '{' || ch === '[' || ch === '(') depth += 1;
+    else if (ch === '}' || ch === ']' || ch === ')') {
+      if (depth === 0) return i;
+      depth -= 1;
+    } else if (ch === ',' && depth === 0) return i;
+  }
+  return -1;
+}
+
+const ROLL_MODE_VALUES: Record<string, string> = {
+  publicroll: 'public',
+  gmroll: 'gm',
+  blindroll: 'blind',
+  selfroll: 'self',
+};
+
+const ROLL_MODE_CONSTANTS: Record<string, string> = {
+  PUBLIC: 'public',
+  PRIVATE: 'gm',
+  BLIND: 'blind',
+  SELF: 'self',
+};
+
+/**
+ * `rollMode` → `messageMode`, with the value mapped when it is a literal.
+ *
+ * `"roll"` meant "whatever the user's chat dropdown says", which is what an
+ * absent `messageMode` means now, so it becomes `undefined`. A value that is
+ * an expression is left for the reader, with a note.
+ */
+export const rollMode: Transform = (source) => {
+  const notes: Note[] = [];
+  const option = rewrite(
+    source,
+    /\brollMode\s*:\s*(['"])(publicroll|gmroll|blindroll|selfroll|roll)\1/g,
+    (_m, quote, value) =>
+      value === 'roll'
+        ? 'messageMode: undefined'
+        : `messageMode: ${quote}${ROLL_MODE_VALUES[value]}${quote}`,
+    'roll-mode',
+  );
+  const key = rewrite(
+    option.output,
+    /\brollMode\s*:/g,
+    (m) => m.replace('rollMode', 'messageMode'),
+    'roll-mode',
+  );
+  for (const change of key.changes) {
+    notes.push({
+      line: change.line,
+      rule: 'roll-mode',
+      message:
+        'The value is an expression. If it can be a v13 mode name, wrap it: `Roll._mapLegacyRollMode(value)`.',
+    });
+  }
+  const setting = rewrite(
+    key.output,
+    /(['"])core\1\s*,\s*(['"])rollMode\2/g,
+    (_m, q1, q2) => `${q1}core${q1}, ${q2}messageMode${q2}`,
+    'roll-mode',
+  );
+  const modes = rewrite(
+    setting.output,
+    /\bCONFIG\.Dice\.rollModes\b/g,
+    'CONFIG.ChatMessage.modes',
+    'roll-mode',
+  );
+  const constants = rewrite(
+    modes.output,
+    /\bCONST\.DICE_ROLL_MODES\.(PUBLIC|PRIVATE|BLIND|SELF)\b/g,
+    (_m, name) => `"${ROLL_MODE_CONSTANTS[name]}"`,
+    'roll-mode',
+  );
+  return { ...merge(option, key, setting, modes, constants), notes };
+};
+
+/**
+ * Context-menu entries and header controls: `name` → `label`, `condition` →
+ * `visible`, `callback` → `onClick`. Only inside an object literal that has a
+ * `callback` and an `icon` or `condition`, so an unrelated `name:` elsewhere
+ * is not renamed. The callback's parameters change too, from `(li)` to
+ * `(event, target)`, and that is noted rather than rewritten.
+ */
+export const contextMenuKeys: Transform = (source) => {
+  const changes: Change[] = [];
+  const notes: Note[] = [];
+  let output = source;
+  // Walk object literals from the innermost out: find `{`, balance to its `}`,
+  // and rewrite the keys of that literal when it looks like a menu entry.
+  const literals = objectLiterals(source);
+  for (const { start, end } of literals.reverse()) {
+    const body = output.slice(start, end);
+    if (!/\bcallback\s*:/.test(body) || !/\b(?:icon|condition)\s*:/.test(body)) continue;
+    const renamed = body
+      .replace(/(^|[{,\s])name\s*:/g, '$1label:')
+      .replace(/(^|[{,\s])condition\s*:/g, '$1visible:')
+      .replace(/(^|[{,\s])callback\s*:/g, '$1onClick:');
+    if (renamed === body) continue;
+    changes.push({
+      line: lineAt(source, start),
+      before: lineText(source, start),
+      after: 'label / visible / onClick keys',
+      rule: 'context-menu-keys',
+    });
+    notes.push({
+      line: lineAt(source, start),
+      rule: 'context-menu-keys',
+      message:
+        '`onClick` receives `(event, target)` where `callback` received the element. Check the parameter list.',
+    });
+    output = output.slice(0, start) + renamed + output.slice(end);
+  }
+  return { output, changes, notes };
+};
+
+/** Every `{ ... }` span in the text, outermost first, strings and comments skipped. */
+function objectLiterals(source: string): Array<{ start: number; end: number }> {
+  const spans: Array<{ start: number; end: number }> = [];
+  const stack: number[] = [];
+  let quote: string | null = null;
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i] ?? '';
+    const next = source[i + 1] ?? '';
+    if (quote) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      i = source.indexOf('\n', i);
+      if (i === -1) break;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      const close = source.indexOf('*/', i + 2);
+      i = close === -1 ? source.length : close + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+    else if (ch === '{') stack.push(i);
+    else if (ch === '}') {
+      const start = stack.pop();
+      if (start !== undefined) spans.push({ start, end: i + 1 });
+    }
+  }
+  return spans.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * `legacyTransferral` is gone: the assignment, and the `activeEffect`
+ * option `registerSystem` used to take for it.
+ */
+export const legacyTransferral: Transform = (source) => {
+  const statement = rewrite(
+    source,
+    /^[ \t]*CONFIG\.ActiveEffect\.legacyTransferral\s*=[^\n]*\n?/gm,
+    '',
+    'legacy-transferral',
+  );
+  const option = rewrite(
+    statement.output,
+    /^[ \t]*activeEffect\s*:\s*\{\s*legacyTransferral\s*:\s*(?:true|false)\s*,?\s*\}\s*,?[ \t]*\n?/gm,
+    '',
+    'legacy-transferral',
+  );
+  const key = rewrite(
+    option.output,
+    /^[ \t]*legacyTransferral\s*:\s*(?:true|false)\s*,?[ \t]*\n?/gm,
+    '',
+    'legacy-transferral',
+  );
+  return merge(statement, option, key);
+};
+
+/** v14 registers no core Actor or Item sheet, so there is nothing to unregister. */
+export const unregisterCoreSheets: Transform = (source) =>
+  rewrite(
+    source,
+    /^[ \t]*(?:foundry\.documents\.collections\.)?(?:Actors|Items)\.unregisterSheet\(\s*['"]core['"][^\n]*\n?/gm,
+    '',
+    'unregister-core-sheets',
+  );
+
+/**
+ * `CONFIG.statusEffects = list;` → add each entry by id. The setter empties
+ * the collection first, which wipes what other packages added.
+ */
+export const statusEffectsAssignment: Transform = (source) => {
+  const changes: Change[] = [];
+  let output = '';
+  let cursor = 0;
+  const pattern = /\bCONFIG\.statusEffects\s*=(?!=)\s*/g;
+  for (const match of source.matchAll(pattern)) {
+    const start = match.index ?? 0;
+    const valueStart = start + match[0].length;
+    const end = scanStatementEnd(source, valueStart);
+    if (end === -1) continue;
+    const value = source.slice(valueStart, end).trim();
+    const after = `for (const effect of ${value}) CONFIG.statusEffects[effect.id] = effect;`;
+    output += source.slice(cursor, start) + after;
+    cursor = end + 1;
+    changes.push({
+      line: lineAt(source, start),
+      before: source.slice(start, cursor).trim(),
+      after,
+      rule: 'status-effects',
+    });
+  }
+  output += source.slice(cursor);
+  return { output, changes, notes: [] };
+};
+
+/** Index of the `;` that ends a statement starting at `from`, brackets balanced. */
+function scanStatementEnd(source: string, from: number): number {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let i = from; i < source.length; i += 1) {
+    const ch = source[i] ?? '';
+    if (quote) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+    else if (ch === '{' || ch === '[' || ch === '(') depth += 1;
+    else if (ch === '}' || ch === ']' || ch === ')') depth -= 1;
+    else if (ch === ';' && depth === 0) return i;
+  }
+  return -1;
+}
+
+const EFFECT_MODES: Record<string, string> = {
+  CUSTOM: 'custom',
+  MULTIPLY: 'multiply',
+  ADD: 'add',
+  DOWNGRADE: 'downgrade',
+  UPGRADE: 'upgrade',
+  OVERRIDE: 'override',
+};
+
+/**
+ * `mode: CONST.ACTIVE_EFFECT_MODES.ADD` → `type: "add"`. A root-level
+ * `changes` array on an effect now lives under `system.changes`; that move
+ * depends on where the data is built, so it is noted.
+ */
+export const activeEffectModes: Transform = (source) => {
+  const typed = rewrite(
+    source,
+    /\bmode\s*:\s*CONST\.ACTIVE_EFFECT_MODES\.(CUSTOM|MULTIPLY|ADD|DOWNGRADE|UPGRADE|OVERRIDE)\b/g,
+    (_m, name) => `type: "${EFFECT_MODES[name]}"`,
+    'active-effect-modes',
+  );
+  const bare = rewrite(
+    typed.output,
+    /\bCONST\.ACTIVE_EFFECT_MODES\.(CUSTOM|MULTIPLY|ADD|DOWNGRADE|UPGRADE|OVERRIDE)\b/g,
+    (_m, name) => `"${EFFECT_MODES[name]}"`,
+    'active-effect-modes',
+  );
+  const notes: Note[] = typed.changes.map((c) => ({
+    line: c.line,
+    rule: 'active-effect-modes',
+    message: 'The change now belongs under `system.changes`, not a root-level `changes` array.',
+  }));
+  return { ...merge(typed, bare), notes };
+};
+
+/** The transforms, in the order they run. */
+const SOURCE_TRANSFORMS: ReadonlyArray<readonly [string, Transform]> = [
+  ['removed-globals', removedGlobals],
+  ['data-operators', dataOperators],
+  ['roll-mode', rollMode],
+  ['context-menu-keys', contextMenuKeys],
+  ['legacy-transferral', legacyTransferral],
+  ['unregister-core-sheets', unregisterCoreSheets],
+  ['status-effects', statusEffectsAssignment],
+  ['active-effect-modes', activeEffectModes],
+];
+
+export function transformSource(source: string): TransformResult {
+  return pipe(
+    source,
+    SOURCE_TRANSFORMS.map(([, t]) => t),
+  );
+}
+
+/**
+ * The manifest: `type` declared, `compatibility` raised to 14 where it is
+ * lower. Returns `null` when nothing needed to change.
+ */
+export function transformManifest(
+  raw: string,
+  kind: 'system' | 'module',
+): { output: string; changes: Change[]; notes: Note[] } | null {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const changes: Change[] = [];
+  const notes: Note[] = [];
+  if (parsed.type !== kind) {
+    parsed.type = kind;
+    changes.push({ line: 1, before: '(no "type")', after: `"type": "${kind}"`, rule: 'manifest' });
+  }
+  const compatibility = (parsed.compatibility ?? {}) as Record<string, unknown>;
+  for (const field of ['minimum', 'verified'] as const) {
+    const current = compatibility[field];
+    const major = Number.parseInt(String(current ?? '0'), 10);
+    if (!Number.isFinite(major) || major < 14) {
+      compatibility[field] = '14';
+      changes.push({
+        line: 1,
+        before: `compatibility.${field}: ${JSON.stringify(current ?? null)}`,
+        after: `compatibility.${field}: "14"`,
+        rule: 'manifest',
+      });
+    }
+  }
+  const maximum = compatibility.maximum;
+  if (maximum !== undefined && Number.parseInt(String(maximum), 10) < 14) {
+    notes.push({
+      line: 1,
+      rule: 'manifest',
+      message: `compatibility.maximum is ${JSON.stringify(maximum)}, which keeps the package off v14. Raise it or remove it.`,
+    });
+  }
+  if ('gridDistance' in parsed || 'gridUnits' in parsed) {
+    notes.push({
+      line: 1,
+      rule: 'manifest',
+      message:
+        'gridDistance / gridUnits are ignored on v14. Move them into `"grid": { "type", "distance", "units", "diagonals" }`.',
+    });
+  }
+  parsed.compatibility = compatibility;
+  if (changes.length === 0) return notes.length ? { output: raw, changes, notes } : null;
+  // Keep `type` next to `id`, where the v14 manifests put it.
+  const ordered: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (key === 'type') continue;
+    ordered[key] = value;
+    if (key === 'id') ordered.type = parsed.type;
+  }
+  if (!('type' in ordered)) ordered.type = parsed.type;
+  return { output: `${JSON.stringify(ordered, null, 2)}\n`, changes, notes };
+}

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -14,7 +14,7 @@
     "@vttforge/core": "^0.14.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.9.0",
+    "@vttforge/cli": "^0.10.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -15,7 +15,7 @@
     "@vttforge/core": "^0.14.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.9.0",
+    "@vttforge/cli": "^0.10.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -15,7 +15,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.9.0",
+    "@vttforge/cli": "^0.10.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -16,7 +16,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.9.0",
+    "@vttforge/cli": "^0.10.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"


### PR DESCRIPTION
## What

`vttforge migrate [dir] [--write] [--json]` rewrites a v13 project for v14. It covers what `VTTF-AUDIT-011` to `016` flag, plus the two lines v14 made pointless and the manifest:

| Rewrite | Before | After |
|---|---|---|
| Removed globals | `mergeObject(a, b)`, `Math.clamped(x, 0, 1)` | `foundry.utils.mergeObject(a, b)`, `Math.clamp(x, 0, 1)` |
| Data operators | `'-=system.bio': null`, `"==system.stats": {...}` | `'system.bio': _del`, `"system.stats": _replace({...})` |
| Roll modes | `rollMode: 'gmroll'`, `core.rollMode`, `CONFIG.Dice.rollModes` | `messageMode: 'gm'`, `core.messageMode`, `CONFIG.ChatMessage.modes` |
| Context menus | `name` / `condition` / `callback` | `label` / `visible` / `onClick` |
| Active Effects | `mode: CONST.ACTIVE_EFFECT_MODES.ADD` | `type: "add"` |
| Status effects | `CONFIG.statusEffects = list;` | add by id |
| Gone | `legacyTransferral`, `Actors.unregisterSheet('core', ...)` | removed |
| Manifest | no `type`, `compatibility` 13 | `type`, `minimum` and `verified` at 14 |

It reports by default; `--write` applies. What it will not decide (a `game.template` read, a `rollMode` expression, a renamed callback's parameter list, a root-level `changes` array, `compatibility.maximum` below 14, flat grid keys) it prints as "needs a decision".

Text-based, like the audit rules. A match inside a string or a comment is rewritten too; the preview is where that is seen.

## Evidence

Run against the pdf-character-sheet tree as it was before its own v14 change, the command proposed the same edits that were made by hand there: the manifest `type` and compatibility, the context-menu keys (with the parameter-list note), and one `flattenObject` that lived in a doc comment. `vttforge audit` is clean afterwards.

## Checks

- 24 new tests (each transform, the manifest, the pipeline on a v14 file, the command's preview/write/JSON/error paths, audit clean after write); 422 CLI tests
- docs: `guide/cli.md` section, `recipes/migrating-to-v14` points at it, CLI README
- templates pin `@vttforge/cli ^0.10.0` for the minor; changeset `cli` minor
- typecheck, lint, knip green