### PR TITLE
fix(cli): audit and migrate leave comments alone

### DIFF
--- a/.changeset/audit-migrate-skip-comments.md
+++ b/.changeset/audit-migrate-skip-comments.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/cli': patch
+---
+
+`vttforge audit` rules 011 to 016 and `vttforge migrate` no longer match inside comments. A call quoted in a JSDoc block or a `// TODO` line was a finding, and `migrate` rewrote it.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -79,7 +79,8 @@ deprecation warning that turns into a removal two versions from now.
 | `VTTF-AUDIT-015` | MEDIUM | `legacyTransferral`; v14 removed the flag and applies Item effects in place |
 | `VTTF-AUDIT-016` | MEDIUM | `CONST.ACTIVE_EFFECT_MODES`; changes now live in `system.changes` with a string `type`, removed in v16 |
 
-Rules 004 and 007 read the schema whether it is a `static defineSchema()` or
+Rules 011 to 016 blank out comments before they match, so a call quoted in a
+JSDoc block is not a finding. Rules 004 and 007 read the schema whether it is a `static defineSchema()` or
 a function handed to `BaseTypeDataModel`, and scope it to the class
 registered for that document. Rule 008 only looks at templates a
 `BaseActorSheet` or `BaseItemSheet` names in its `PARTS`, since those are the
@@ -120,5 +121,6 @@ renamed `callback` (`onClick` receives `(event, target)`), a root-level
 `changes` array on an effect (now `system.changes`), a `compatibility.maximum`
 below 14, and the flat `gridDistance` / `gridUnits` keys.
 
-The rewrites are text-based, like the audit rules they mirror. A match inside
-a string literal is rewritten too; the preview is where that is caught.
+The rewrites are text-based, like the audit rules they mirror. Comments are
+left alone. A match inside a string literal is rewritten too; the preview is
+where that is caught.

--- a/packages/cli/src/__tests__/audit/mask.test.ts
+++ b/packages/cli/src/__tests__/audit/mask.test.ts
@@ -1,0 +1,35 @@
+/**
+ * The comment mask keeps every offset, so a rule that matches on the masked
+ * text still reports the right line.
+ */
+import { describe, expect, it } from 'vitest';
+import { MASK, maskComments } from '../../audit/mask.js';
+
+const masked = (s: string) => maskComments(s).replace(new RegExp(MASK, 'g'), '#');
+
+describe('maskComments', () => {
+  it('blanks line and block comments and keeps the length and the newlines', () => {
+    const src = 'a(); // call b()\n/* c()\n d() */ e();\n';
+    const out = maskComments(src);
+    expect(out).toHaveLength(src.length);
+    expect(masked(src)).toBe('a(); ###########\n######\n####### e();\n');
+  });
+
+  it('does not start a comment inside a string or a template literal', () => {
+    expect(masked('const u = "http://x"; f();')).toBe('const u = "http://x"; f();');
+    expect(masked('const t = `a // b`; f();')).toBe('const t = `a // b`; f();');
+    expect(masked("const s = 'it\\'s // fine'; f();")).toBe("const s = 'it\\'s // fine'; f();");
+  });
+
+  it('does not start a comment inside a regex literal, but still sees a division', () => {
+    expect(masked('const r = /https?:\\/\\//g; f();')).toBe('const r = /https?:\\/\\//g; f();');
+    expect(masked('const r = /[/]/; f();')).toBe('const r = /[/]/; f();');
+    expect(masked('const n = a / b // half\n')).toBe('const n = a / b #######\n');
+  });
+
+  it('blanks a JSDoc block with a code fence in it', () => {
+    const src = '/**\n * ```js\n * mergeObject(a, b)\n * ```\n */\nexport const x = 1;\n';
+    expect(maskComments(src)).not.toContain('mergeObject');
+    expect(maskComments(src)).toContain('export const x = 1;');
+  });
+});

--- a/packages/cli/src/__tests__/audit/v14-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/v14-rules.test.ts
@@ -83,6 +83,39 @@ describe('VTTF-AUDIT-011: a global v14 removed', () => {
   });
 });
 
+describe('comments are not findings', () => {
+  it('ignores a call quoted in a JSDoc block, a line comment, and a block comment', async () => {
+    expect(
+      await auditSource(
+        [
+          '/**',
+          ' * `foundry.utils.flattenObject` looks like the tool and is not:',
+          ' * ```js',
+          ' * flattenObject({ system: actor.system })',
+          ' * ```',
+          ' */',
+          '// TODO: drop mergeObject(a, b) here',
+          '/* rollMode: "gmroll" was the old way; "-=key": null too */',
+          'export const walk = (o) => o;',
+        ].join('\n'),
+      ),
+    ).toEqual([]);
+  });
+
+  it('still reports the call after the comment, on its own line', async () => {
+    const findings = await auditSource(
+      '// mergeObject(a, b) is gone\nconst m = mergeObject(a, b);\n',
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ ruleId: 'VTTF-AUDIT-011', line: 2 });
+  });
+
+  it('does not mistake a URL in a string for a comment', async () => {
+    const findings = await auditSource('const u = "https://x.test"; mergeObject(a, b);\n');
+    expect(findings).toHaveLength(1);
+  });
+});
+
 describe('VTTF-AUDIT-012: -= / == update keys', () => {
   it('flags a deletion key', async () => {
     const findings = await auditSource(

--- a/packages/cli/src/__tests__/migrate/transforms.test.ts
+++ b/packages/cli/src/__tests__/migrate/transforms.test.ts
@@ -186,6 +186,42 @@ describe('the manifest', () => {
   });
 });
 
+describe('comments are left alone', () => {
+  it('rewrites the code and not the prose that mentions it', () => {
+    const src = [
+      '/**',
+      ' * flattenObject({ system: actor.system }) // → { system: CharacterData }',
+      ' */',
+      "// '-=system.bio': null used to work",
+      'const m = mergeObject(a, b); // not Math.clamped(x)',
+      "await a.update({ '-=system.bio': null });",
+      '',
+    ].join('\n');
+    const r = transformSource(src);
+    expect(r.output).toBe(
+      [
+        '/**',
+        ' * flattenObject({ system: actor.system }) // → { system: CharacterData }',
+        ' */',
+        "// '-=system.bio': null used to work",
+        'const m = foundry.utils.mergeObject(a, b); // not Math.clamped(x)',
+        "await a.update({ 'system.bio': _del });",
+        '',
+      ].join('\n'),
+    );
+    expect(r.changes.map((c) => c.line)).toEqual([5, 6]);
+  });
+
+  it('renames menu keys only outside comments inside the entry', () => {
+    const src =
+      'options.push({\n  // name: is the old key\n  name: "x",\n  icon: "i",\n  callback: () => 1,\n});\n';
+    const r = contextMenuKeys(src);
+    expect(r.output).toContain('  // name: is the old key');
+    expect(r.output).toContain('  label: "x",');
+    expect(r.output).toContain('  onClick: () => 1,');
+  });
+});
+
 describe('the whole pipeline', () => {
   it('leaves a v14 file untouched', () => {
     const src =

--- a/packages/cli/src/audit/mask.ts
+++ b/packages/cli/src/audit/mask.ts
@@ -1,0 +1,69 @@
+/**
+ * Blank out the comments in a source file, so a pattern that names a call
+ * or a key does not match the prose around it.
+ *
+ * Every character inside a `//` or `/* *\/` comment becomes `\0`, except the
+ * newlines, so offsets and line numbers in the result line up with the
+ * original. Strings and template literals are walked so a `//` inside a URL
+ * does not start a comment, and a regex literal is walked so `/\/\//` does
+ * not either. `\0` never appears in real source, which is what makes it a
+ * safe marker: `masked[i] === '\0'` says "this index is a comment".
+ */
+export const MASK = '\0';
+
+export function maskComments(source: string): string {
+  const out = source.split('');
+  let quote: string | null = null;
+  let lastCode = '';
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i] ?? '';
+    const next = source[i + 1] ?? '';
+    if (quote !== null) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      lastCode = ch;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      const end = source.indexOf('\n', i);
+      const stop = end === -1 ? source.length : end;
+      for (let j = i; j < stop; j += 1) out[j] = MASK;
+      i = stop - 1;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      const close = source.indexOf('*/', i + 2);
+      const stop = close === -1 ? source.length : close + 2;
+      for (let j = i; j < stop; j += 1) if (source[j] !== '\n') out[j] = MASK;
+      i = stop - 1;
+      continue;
+    }
+    if (ch === '/' && startsRegex(lastCode)) {
+      // Walk to the closing slash, honouring escapes and character classes.
+      let inClass = false;
+      let j = i + 1;
+      for (; j < source.length; j += 1) {
+        const c = source[j] ?? '';
+        if (c === '\\') j += 1;
+        else if (c === '\n') break;
+        else if (inClass) inClass = c !== ']';
+        else if (c === '[') inClass = true;
+        else if (c === '/') break;
+      }
+      i = j;
+      lastCode = '/';
+      continue;
+    }
+    if (!/\s/.test(ch)) lastCode = ch;
+  }
+  return out.join('');
+}
+
+/** After one of these a `/` opens a regex literal, not a division. */
+function startsRegex(lastCode: string): boolean {
+  return lastCode === '' || '(,=:[!&|?{};+-*%<>~^'.includes(lastCode);
+}

--- a/packages/cli/src/audit/v14-rules.ts
+++ b/packages/cli/src/audit/v14-rules.ts
@@ -10,11 +10,14 @@
  *
  * Regex heuristics like the rest of the source rules, for the same reason:
  * the patterns are short and a TypeScript AST would not make them more
- * precise. Each rule reports the first match per file; one finding is enough
- * to send the reader to the file, and the fix is a search-and-replace there.
+ * precise. Comments are blanked first, so prose that mentions a call is not
+ * a finding. Each rule reports the first match per file; one finding is
+ * enough to send the reader to the file, and the fix is a search-and-replace
+ * there.
  */
 
 import { readFile } from 'node:fs/promises';
+import { maskComments } from './mask.js';
 import { _internal } from './source-rules.js';
 import type { RuleResult } from './types.js';
 
@@ -242,6 +245,10 @@ export async function runV14Rules(cwd: string): Promise<RuleResult[]> {
     } catch {
       continue;
     }
+    // Comments are blanked before matching, so a call quoted in a JSDoc
+    // block or a `// TODO: drop mergeObject(` line is not a finding. The
+    // mask keeps every offset, so the line numbers still point at the file.
+    content = maskComments(content);
     results.push(
       ...rule011(file, content),
       ...rule012(file, content),

--- a/packages/cli/src/migrate/transforms.ts
+++ b/packages/cli/src/migrate/transforms.ts
@@ -8,11 +8,12 @@
  *
  * Text-based, like the audit rules they mirror (`VTTF-AUDIT-011` to `016`).
  * The patterns are short and mechanical, and a syntax tree would not make
- * `'-=key'` easier to find. The cost is that a match inside a string or a
- * comment is rewritten too; the preview exists so that is seen before it is
- * written.
+ * `'-=key'` easier to find. Comments are left alone: every match has to
+ * start in code. A match inside a string literal is still rewritten, which
+ * is what the preview is for.
  */
 
+import { MASK, maskComments } from '../audit/mask.js';
 import { REMOVED_UTILS } from '../audit/v14-rules.js';
 
 export interface Change {
@@ -67,8 +68,10 @@ function rewrite(
   rule: string,
 ): TransformResult {
   const changes: Change[] = [];
+  const code = maskComments(source);
   const output = source.replace(pattern, (match: string, ...rest: unknown[]) => {
     const offset = rest.find((r): r is number => typeof r === 'number') ?? 0;
+    if (code[offset] === MASK) return match;
     const groups = rest.filter((r): r is string => typeof r === 'string');
     const after = typeof replacement === 'string' ? replacement : replacement(match, ...groups);
     if (after !== match) {
@@ -127,7 +130,9 @@ export const removedGlobals: Transform = (source) => {
     : { output: source, changes: [], notes: [] };
   const clamped = rewrite(utils.output, /\bMath\.clamped\s*\(/g, 'Math.clamp(', 'removed-globals');
   const notes: Note[] = [];
+  const code = maskComments(clamped.output);
   for (const match of clamped.output.matchAll(/\bgame\.template\b/g)) {
+    if (code[match.index ?? 0] === MASK) continue;
     notes.push({
       line: lineAt(clamped.output, match.index ?? 0),
       rule: 'removed-globals',
@@ -171,10 +176,12 @@ export const dataOperators: Transform = (source) => {
 function wrapReplacementValues(source: string): TransformResult {
   const changes: Change[] = [];
   const pattern = /(['"])((?:[\w$]+\.)*)==([\w$.]+)\1\s*:\s*/g;
+  const code = maskComments(source);
   let out = '';
   let cursor = 0;
   for (const match of source.matchAll(pattern)) {
     const start = match.index ?? 0;
+    if (code[start] === MASK) continue;
     const valueStart = start + match[0].length;
     const valueEnd = scanValueEnd(source, valueStart);
     if (valueEnd === -1) continue;
@@ -299,10 +306,18 @@ export const contextMenuKeys: Transform = (source) => {
   for (const { start, end } of literals.reverse()) {
     const body = output.slice(start, end);
     if (!/\bcallback\s*:/.test(body) || !/\b(?:icon|condition)\s*:/.test(body)) continue;
-    const renamed = body
-      .replace(/(^|[{,\s])name\s*:/g, '$1label:')
-      .replace(/(^|[{,\s])condition\s*:/g, '$1visible:')
-      .replace(/(^|[{,\s])callback\s*:/g, '$1onClick:');
+    const bodyCode = maskComments(body);
+    const KEYS: Record<string, string> = {
+      name: 'label',
+      condition: 'visible',
+      callback: 'onClick',
+    };
+    // One pass, so the offsets checked against the mask are the body's own.
+    const renamed = body.replace(
+      /(^|[{,\s])(name|condition|callback)(\s*:)/g,
+      (m, lead: string, key: string, colon: string, offset: number) =>
+        bodyCode[offset + lead.length] === MASK ? m : `${lead}${KEYS[key]}${colon}`,
+    );
     if (renamed === body) continue;
     changes.push({
       line: lineAt(source, start),
@@ -398,8 +413,10 @@ export const statusEffectsAssignment: Transform = (source) => {
   let output = '';
   let cursor = 0;
   const pattern = /\bCONFIG\.statusEffects\s*=(?!=)\s*/g;
+  const code = maskComments(source);
   for (const match of source.matchAll(pattern)) {
     const start = match.index ?? 0;
+    if (code[start] === MASK) continue;
     const valueStart = start + match[0].length;
     const end = scanStatementEnd(source, valueStart);
     if (end === -1) continue;


### PR DESCRIPTION
## What

`VTTF-AUDIT-011` to `016` and every `vttforge migrate` rewrite now skip comments. A shared `maskComments` blanks `//` and `/* */` bodies with a marker that keeps every offset, so a match is checked against its start and line numbers still point at the file. Strings, template literals and regex literals are walked so a `//` inside a URL or a `/\/\//` pattern does not open a comment.

## Why

The first real-world run of both flagged `flattenObject(` inside a JSDoc code fence in pdf-character-sheet, and `migrate` rewrote the comment.

## Checks

- 9 new tests: the mask (lengths, strings, regex literals, division, JSDoc fences), the audit (comment-only file clean, real call still reported on its line, URL in a string), migrate (prose untouched, code rewritten, menu keys inside comments kept)
- 431 CLI tests, typecheck, lint, knip green; changeset `cli` patch