### PR TITLE
docs(testing): no sheet rendering helper, and why

### DIFF
--- a/apps/docs/guide/testing.md
+++ b/apps/docs/guide/testing.md
@@ -104,3 +104,12 @@ Reaching for a mock past that line produces tests that pass and tell you
 nothing. Several bugs in this SDK were found only by opening a real Foundry: a
 sheet registered but unreachable, a class extending the wrong base, an
 annotation layer whose CSS class name did not match what the library styles.
+
+That is also why there is no helper that mounts a sheet against a mock actor
+and hands back its HTML, and there will not be one. Rendering a sheet is the
+Application framework: the Handlebars mixin, `PARTS`, template loading,
+Foundry's own helpers, tabs, form handling. A copy of that inside a mock would
+render something like what Foundry renders, and a test that passes against
+the copy and fails in the real thing is worse than no test. Test the context
+in Vitest, with `_prepareContext`, and test the render in a real world, with
+Quench or the end-to-end run.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -79,4 +79,8 @@ still be imported by the vitest run.
 
 Anything before `_renderHTML` is testable in Vitest. Real rendering is Quench's
 half. Reaching for a mock past that line produces tests that pass and tell you
-nothing.
+nothing. So there is no helper that mounts a sheet against a mock actor and
+returns its HTML, and there will not be one: a copy of the Application
+framework inside a mock renders something like Foundry, and a test that passes
+against the copy is worse than none. Test the context in Vitest and the render
+in a real world.


### PR DESCRIPTION
## What

Closes the last open item of the testing track as a decision not to build it. The testing guide and the package README now say there is no helper that mounts a sheet against a mock actor, and why: rendering is the Application framework (Handlebars mixin, `PARTS`, template loading, Foundry's helpers, tabs, forms), a copy of it inside a mock renders something like Foundry, and a test that passes against the copy and fails in the real thing is worse than no test. The line stays where the guide already drew it: context in Vitest, render in Quench or the end-to-end run.

Docs only, no changeset.