### PR TITLE
fix(cli): migrate tells a menu entry from a Dialog button

### DIFF
--- a/.changeset/migrate-menu-entry-shape.md
+++ b/.changeset/migrate-menu-entry-shape.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/cli': patch
+---
+
+`vttforge migrate` no longer renames the keys of a Dialog button, or of a class body that happens to hold a context-menu entry. An entry is an object whose own keys include `callback` and `name` or `condition`; a button has `icon`, `label` and `callback`, and keeps `callback` on v14.

--- a/packages/cli/src/__tests__/migrate/transforms.test.ts
+++ b/packages/cli/src/__tests__/migrate/transforms.test.ts
@@ -112,6 +112,45 @@ const other = { name: 'kept', value: 1 };
   });
 });
 
+describe('context menu keys, the shapes that are not entries', () => {
+  it('leaves a Dialog button alone: it has icon, label and callback, and keeps callback', () => {
+    const src = `new Dialog({
+  title: "T",
+  buttons: {
+    create: {
+      icon: '<i class="fas fa-check"></i>',
+      label: game.i18n.localize("X"),
+      callback: (html) => save(html),
+    },
+  },
+  default: "create",
+});
+`;
+    const r = contextMenuKeys(src);
+    expect(r.output).toBe(src);
+    expect(r.changes).toEqual([]);
+  });
+
+  it('renames only the entry, not the class body or the nested object around it', () => {
+    const src = `class Sheet {
+  static name = "kept";
+  menu() {
+    return [{ name: "MOD.x", condition: () => true, callback: (li) => ({ name: li.dataset.name }) }];
+  }
+}
+`;
+    const r = contextMenuKeys(src);
+    expect(r.output).toBe(`class Sheet {
+  static name = "kept";
+  menu() {
+    return [{ label: "MOD.x", visible: () => true, onClick: (li) => ({ name: li.dataset.name }) }];
+  }
+}
+`);
+    expect(r.changes).toHaveLength(1);
+  });
+});
+
 describe('legacyTransferral and core sheets', () => {
   it('drops the assignment, the registerSystem option, and the unregister lines', () => {
     const src = `CONFIG.ActiveEffect.legacyTransferral = false;

--- a/packages/cli/src/migrate/transforms.ts
+++ b/packages/cli/src/migrate/transforms.ts
@@ -291,34 +291,37 @@ export const rollMode: Transform = (source) => {
 
 /**
  * Context-menu entries and header controls: `name` → `label`, `condition` →
- * `visible`, `callback` → `onClick`. Only inside an object literal that has a
- * `callback` and an `icon` or `condition`, so an unrelated `name:` elsewhere
- * is not renamed. The callback's parameters change too, from `(li)` to
- * `(event, target)`, and that is noted rather than rewritten.
+ * `visible`, `callback` → `onClick`.
+ *
+ * Only an object literal whose own keys include `callback` and `name` or
+ * `condition` is an entry. A Dialog button has `icon`, `label` and
+ * `callback`, and keeps `callback` on v14, so `icon` is not a signal; and
+ * only the literal's own keys count, so a class body or a `buttons` bag that
+ * happens to contain an entry is not itself treated as one. The callback's
+ * parameters change too, from `(li)` to `(event, target)`, and that is noted
+ * rather than rewritten.
  */
 export const contextMenuKeys: Transform = (source) => {
   const changes: Change[] = [];
   const notes: Note[] = [];
-  let output = source;
-  // Walk object literals from the innermost out: find `{`, balance to its `}`,
-  // and rewrite the keys of that literal when it looks like a menu entry.
-  const literals = objectLiterals(source);
-  for (const { start, end } of literals.reverse()) {
-    const body = output.slice(start, end);
-    if (!/\bcallback\s*:/.test(body) || !/\b(?:icon|condition)\s*:/.test(body)) continue;
-    const bodyCode = maskComments(body);
-    const KEYS: Record<string, string> = {
-      name: 'label',
-      condition: 'visible',
-      callback: 'onClick',
-    };
-    // One pass, so the offsets checked against the mask are the body's own.
-    const renamed = body.replace(
-      /(^|[{,\s])(name|condition|callback)(\s*:)/g,
-      (m, lead: string, key: string, colon: string, offset: number) =>
-        bodyCode[offset + lead.length] === MASK ? m : `${lead}${KEYS[key]}${colon}`,
-    );
-    if (renamed === body) continue;
+  const RENAME: Record<string, string> = {
+    name: 'label',
+    condition: 'visible',
+    callback: 'onClick',
+  };
+  // Innermost first, so an edit never moves the offsets of a literal still
+  // to be visited: an inner literal sits entirely inside its outer one, and
+  // editing it changes the outer one's end, never its start.
+  const edits: Array<{ start: number; end: number; text: string }> = [];
+  for (const { start, end } of objectLiterals(source).sort((a, b) => b.start - a.start)) {
+    const keys = ownKeys(source, start, end);
+    const names = new Set(keys.map((k) => k.name));
+    if (!names.has('callback') || !(names.has('name') || names.has('condition'))) continue;
+    for (const key of keys) {
+      const to = RENAME[key.name];
+      if (to !== undefined)
+        edits.push({ start: key.offset, end: key.offset + key.name.length, text: to });
+    }
     changes.push({
       line: lineAt(source, start),
       before: lineText(source, start),
@@ -331,10 +334,82 @@ export const contextMenuKeys: Transform = (source) => {
       message:
         '`onClick` receives `(event, target)` where `callback` received the element. Check the parameter list.',
     });
-    output = output.slice(0, start) + renamed + output.slice(end);
+  }
+  let output = source;
+  for (const edit of edits.sort((a, b) => b.start - a.start)) {
+    output = output.slice(0, edit.start) + edit.text + output.slice(edit.end);
   }
   return { output, changes, notes };
 };
+
+/**
+ * The keys an object literal declares itself, with the offset of each name.
+ *
+ * Walks the span between the braces at depth one: a key is an identifier
+ * followed by `:` where a property may start, which is right after the
+ * opening brace or after a comma at that depth. Nested literals, arrays,
+ * calls, strings and comments are stepped over.
+ */
+function ownKeys(
+  source: string,
+  start: number,
+  end: number,
+): Array<{ name: string; offset: number }> {
+  const keys: Array<{ name: string; offset: number }> = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let expectKey = true;
+  for (let i = start; i < end; i += 1) {
+    const ch = source[i] ?? '';
+    const next = source[i + 1] ?? '';
+    if (quote) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      const nl = source.indexOf('\n', i);
+      i = nl === -1 ? end : nl;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      const close = source.indexOf('*/', i + 2);
+      i = close === -1 ? end : close + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      expectKey = false;
+      continue;
+    }
+    if (ch === '{' || ch === '[' || ch === '(') {
+      depth += 1;
+      expectKey = depth === 1 && ch === '{';
+      continue;
+    }
+    if (ch === '}' || ch === ']' || ch === ')') {
+      depth -= 1;
+      expectKey = false;
+      continue;
+    }
+    if (depth !== 1) continue;
+    if (ch === ',') {
+      expectKey = true;
+      continue;
+    }
+    if (/\s/.test(ch)) continue;
+    if (expectKey && /[A-Za-z_$]/.test(ch)) {
+      let j = i;
+      while (j < end && /[\w$]/.test(source[j] ?? '')) j += 1;
+      let k = j;
+      while (k < end && /\s/.test(source[k] ?? '')) k += 1;
+      if (source[k] === ':') keys.push({ name: source.slice(i, j), offset: i });
+      i = j - 1;
+    }
+    expectKey = false;
+  }
+  return keys;
+}
 
 /** Every `{ ... }` span in the text, outermost first, strings and comments skipped. */
 function objectLiterals(source: string): Array<{ start: number; end: number }> {


### PR DESCRIPTION
## What

`contextMenuKeys` decided an object was a menu entry when it contained `callback` and `icon` or `condition` anywhere inside it. Two things went wrong on the first run over other people's code: a Dialog button (`icon`, `label`, `callback`, and `callback` stays on v14) was renamed, and a class body holding one real entry was treated as an entry itself, renaming every `name:` in it.

An entry is now an object whose **own** keys, read at depth one with strings, comments and nested brackets stepped over, include `callback` and `name` or `condition`. `icon` no longer counts.

## Checks

- 2 new tests: a Dialog button untouched; a class with a static `name` and an entry whose callback returns an object with a `name` key, where only the entry is renamed
- Re-run on the three repositories that showed the false positives: Cairn (Dialog buttons), world-explorer (DialogV2 buttons), pf2e-extempore-effects: none renamed now
- 433 CLI tests, typecheck, lint, knip green; changeset `cli` patch