### PR TITLE
feat(cli): what seven v13 projects taught audit and migrate

### DIFF
--- a/.changeset/cli-learnings-from-seven.md
+++ b/.changeset/cli-learnings-from-seven.md
@@ -1,0 +1,10 @@
+---
+'@vttforge/cli': minor
+---
+
+What the first run over seven v13 projects taught the audit and the migrate command.
+
+- `audit` gains `VTTF-AUDIT-017` (the jQuery `renderChatMessage` hook, removed in v15) and `VTTF-AUDIT-018` (a class on an Application v1 base, removed in v16).
+- `VTTF-AUDIT-007` resolves the token attributes against `template.json` too, so a system that still declares its types there is not flagged for a bar that works.
+- Both commands skip minified bundles (`*.min.js`): a vendored library is not the author's to fix.
+- `migrate` rewrites `rollMode: <expression>` to `messageMode: Roll._mapLegacyRollMode(<expression>)` instead of asking, handles a template-literal deletion key such as `` [`flags.${id}.-=old`] ``, and notes every `renderChatMessage` handler.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -68,7 +68,7 @@ deprecation warning that turns into a removal two versions from now.
 | `VTTF-AUDIT-004` | MEDIUM | An `HTMLField` or `FilePathField` not listed in `documentTypes`; the server only sanitises declared paths |
 | `VTTF-AUDIT-005` | MEDIUM | A `TypeDataModel` without `prepareBaseData`; Active Effects apply between it and `prepareDerivedData` |
 | `VTTF-AUDIT-006` | LOW | An `_addDataFieldMigrations` override; the signature is not what it looks like |
-| `VTTF-AUDIT-007` | MEDIUM | `primaryTokenAttribute` / `secondaryTokenAttribute` not pointing at a `{ value, max }` field; the token bar degrades with no error |
+| `VTTF-AUDIT-007` | MEDIUM | `primaryTokenAttribute` / `secondaryTokenAttribute` not pointing at a `{ value, max }` field, in a data model or in `template.json`; the token bar degrades with no error |
 | `VTTF-AUDIT-008` | HIGH | A sheet template that opens its own `<form>` when the sheet base already is one; the fields belong to the inner form and every edit is dropped on close |
 | `VTTF-AUDIT-009` | MEDIUM | A subtype declared in `documentTypes` with no `TYPES` label; Foundry prints the raw key as the type's name |
 | `VTTF-AUDIT-010` | HIGH | A `template.json` listing a type whose `documentTypes` entry declares `htmlFields`, `filePathFields` or `gmOnlyFields`; Foundry replaces the entry and drops them |
@@ -78,8 +78,10 @@ deprecation warning that turns into a removal two versions from now.
 | `VTTF-AUDIT-014` | MEDIUM | `CONFIG.statusEffects = [...]`; the setter empties the collection first and drops what other packages added |
 | `VTTF-AUDIT-015` | MEDIUM | `legacyTransferral`; v14 removed the flag and applies Item effects in place |
 | `VTTF-AUDIT-016` | MEDIUM | `CONST.ACTIVE_EFFECT_MODES`; changes now live in `system.changes` with a string `type`, removed in v16 |
+| `VTTF-AUDIT-017` | MEDIUM | The jQuery `renderChatMessage` hook; removed in v15, `renderChatMessageHTML` hands the element |
+| `VTTF-AUDIT-018` | LOW | A class extending an Application v1 base (`Application`, `FormApplication`, `Dialog`, `ActorSheet`, `ItemSheet`); removed in v16 |
 
-Rules 011 to 016 blank out comments before they match, so a call quoted in a
+Rules 011 to 018 blank out comments before they match, so a call quoted in a
 JSDoc block is not a finding. Rules 004 and 007 read the schema whether it is a `static defineSchema()` or
 a function handed to `BaseTypeDataModel`, and scope it to the class
 registered for that document. Rule 008 only looks at templates a
@@ -104,9 +106,10 @@ with `--write`, then run `vttforge audit`.
 | Rewrite | Before | After |
 |---|---|---|
 | Removed globals | `mergeObject(a, b)`, `Math.clamped(x, 0, 1)` | `foundry.utils.mergeObject(a, b)`, `Math.clamp(x, 0, 1)` |
-| Data operators | `'-=system.bio': null`, `"==system.stats": {...}` | `'system.bio': _del`, `"system.stats": _replace({...})` |
+| Data operators | `'-=system.bio': null`, `` [`flags.${id}.-=old`]: null ``, `"==system.stats": {...}` | `'system.bio': _del`, `` [`flags.${id}.old`]: _del ``, `"system.stats": _replace({...})` |
 | | `performDeletions: true`, `foundry.utils.objectsEqual` | `applyOperators: true`, `foundry.utils.equals` |
 | Roll modes | `rollMode: 'gmroll'`, `game.settings.get('core', 'rollMode')` | `messageMode: 'gm'`, `game.settings.get('core', 'messageMode')` |
+| | `rollMode: chosen` | `messageMode: Roll._mapLegacyRollMode(chosen)` |
 | | `CONFIG.Dice.rollModes`, `CONST.DICE_ROLL_MODES.PRIVATE` | `CONFIG.ChatMessage.modes`, `"gm"` |
 | Context menus and header controls | `name`, `condition`, `callback` | `label`, `visible`, `onClick` |
 | Active Effects | `mode: CONST.ACTIVE_EFFECT_MODES.ADD` | `type: "add"` |
@@ -116,10 +119,12 @@ with `--write`, then run `vttforge audit`.
 
 What it will not decide, it reports as "needs a decision": a `game.template`
 read (which becomes `game.model` or a `documentTypes` lookup depending on what
-was read), a `rollMode` whose value is an expression, the parameter list of a
-renamed `callback` (`onClick` receives `(event, target)`), a root-level
+was read), the parameter list of a renamed `callback` (`onClick` receives
+`(event, target)`), a `renderChatMessage` handler (the hook is removed in v15
+and its replacement hands an element, not a jQuery object), a root-level
 `changes` array on an effect (now `system.changes`), a `compatibility.maximum`
-below 14, and the flat `gridDistance` / `gridUnits` keys.
+below 14, and the flat `gridDistance` / `gridUnits` keys. Minified bundles
+(`*.min.js`) are vendored libraries and are skipped, by the audit too.
 
 The rewrites are text-based, like the audit rules they mirror. Comments are
 left alone. A match inside a string literal is rewritten too; the preview is

--- a/packages/cli/src/__tests__/audit/rule007-template-json.test.ts
+++ b/packages/cli/src/__tests__/audit/rule007-template-json.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Rule 007 resolves the token attributes against template.json when the
+ * system still declares its types there: a v13 system on template.json has
+ * no TypeDataModel to read, and its bars still work.
+ */
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runSourceRules } from '../../audit/source-rules.js';
+
+let cwd: string;
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'vttf-007-'));
+  await writeFile(
+    join(cwd, 'system.json'),
+    JSON.stringify({
+      id: 's',
+      version: '1.0.0',
+      primaryTokenAttribute: 'abilities.STR',
+      secondaryTokenAttribute: 'hp',
+    }),
+    'utf8',
+  );
+});
+
+afterEach(async () => {
+  await rm(cwd, { recursive: true, force: true });
+});
+
+const template = (actor: Record<string, unknown>) =>
+  writeFile(join(cwd, 'template.json'), JSON.stringify({ Actor: actor }), 'utf8');
+const findings007 = async () =>
+  (await runSourceRules(cwd)).filter((f) => f.ruleId === 'VTTF-AUDIT-007');
+
+describe('VTTF-AUDIT-007 with template.json', () => {
+  it('resolves a path through the templates a type lists', async () => {
+    await template({
+      types: ['character'],
+      templates: { base: { hp: { value: 6, max: 6 }, abilities: { STR: { value: 10, max: 10 } } } },
+      character: { templates: ['base'], gold: 0 },
+    });
+    expect(await findings007()).toEqual([]);
+  });
+
+  it('still flags a path that no type declares with value and max', async () => {
+    await template({ types: ['character'], character: { hp: 6, abilities: { STR: 10 } } });
+    expect((await findings007()).map((f) => f.title)).toEqual([
+      'primaryTokenAttribute does not resolve to a {value, max} SchemaField',
+      'secondaryTokenAttribute does not resolve to a {value, max} SchemaField',
+    ]);
+  });
+});

--- a/packages/cli/src/__tests__/audit/v14-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/v14-rules.test.ts
@@ -20,7 +20,7 @@ afterEach(async () => {
 async function auditSource(source: string) {
   await writeFile(join(cwd, 'main.mjs'), source, 'utf8');
   const report = await runAudit({ cwd });
-  return report.findings.filter((f) => /VTTF-AUDIT-01[1-6]/.test(f.ruleId));
+  return report.findings.filter((f) => /VTTF-AUDIT-01[1-8]/.test(f.ruleId));
 }
 
 describe('VTTF-AUDIT-011: a global v14 removed', () => {
@@ -198,5 +198,42 @@ describe('a clean v14 file', () => {
         ].join('\n'),
       ),
     ).toEqual([]);
+  });
+});
+
+describe('VTTF-AUDIT-017: renderChatMessage', () => {
+  it('flags the jQuery hook and passes the HTML one', async () => {
+    const findings = await auditSource(
+      'Hooks.on("renderChatMessage", (m, html) => html.find("a"));\n',
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ ruleId: 'VTTF-AUDIT-017', severity: 'MEDIUM', line: 1 });
+    expect(
+      await auditSource(
+        'Hooks.on("renderChatMessageHTML", (m, html) => html.querySelector("a"));\n',
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('VTTF-AUDIT-018: Application v1 bases', () => {
+  it('flags the v1 bases, bare or namespaced, and passes the V2 ones', async () => {
+    expect(await auditSource('class S extends ActorSheet {}\n')).toHaveLength(1);
+    expect(
+      await auditSource('class M extends foundry.appv1.api.FormApplication {}\n'),
+    ).toHaveLength(1);
+    expect((await auditSource('class D extends Dialog {}\n'))[0]?.severity).toBe('LOW');
+    expect(
+      await auditSource(
+        'class S extends foundry.applications.sheets.ActorSheetV2 {}\nclass D extends DialogV2 {}\n',
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('vendored libraries', () => {
+  it('does not read a minified bundle', async () => {
+    await writeFile(join(cwd, 'jszip.min.js'), 'a({"-=x":null});mergeObject(a,b);\n', 'utf8');
+    expect(await auditSource('export const x = 1;\n')).toEqual([]);
   });
 });

--- a/packages/cli/src/__tests__/migrate/migrate-command.test.ts
+++ b/packages/cli/src/__tests__/migrate/migrate-command.test.ts
@@ -56,9 +56,9 @@ describe('vttforge migrate', () => {
     expect(await readFile(join(cwd, 'main.mjs'), 'utf8')).toBe(
       "const merged = foundry.utils.mergeObject(a, b);\nawait actor.update({ 'system.bio': _del });\nroll.toMessage({}, { messageMode: 'gm' });\n",
     );
-    const manifest = JSON.parse(await readFile(join(cwd, 'system.json'), 'utf8'));
-    expect(manifest.type).toBe('system');
-    expect(manifest.compatibility).toEqual({ minimum: '14', verified: '14' });
+    expect(await readFile(join(cwd, 'system.json'), 'utf8')).toBe(
+      '{\n  "id": "my-system",\n  "type": "system",\n  "title": "T",\n  "compatibility": { "minimum": "14", "verified": "14" }\n}\n',
+    );
 
     const audit = await runAudit({ cwd });
     expect(audit.findings.filter((f) => /VTTF-AUDIT-01[1-6]/.test(f.ruleId))).toEqual([]);

--- a/packages/cli/src/__tests__/migrate/transforms.test.ts
+++ b/packages/cli/src/__tests__/migrate/transforms.test.ts
@@ -206,16 +206,23 @@ describe('status effects and effect modes', () => {
 });
 
 describe('the manifest', () => {
-  it('declares the type next to the id and raises compatibility to 14', () => {
-    const r = transformManifest(
-      '{\n  "id": "my-system",\n  "title": "T",\n  "compatibility": { "minimum": "13", "verified": "13.341" }\n}\n',
-      'system',
+  it('declares the type on the line after id and raises compatibility, keeping the file as written', () => {
+    const raw =
+      '{\n    "id": "my-system",\n    "title": "T",\n    "styles": ["a.css", "b.css"],\n    "compatibility": { "minimum": "13", "verified": "13.341" }\n}';
+    const r = transformManifest(raw, 'system');
+    expect(r?.output).toBe(
+      '{\n    "id": "my-system",\n    "type": "system",\n    "title": "T",\n    "styles": ["a.css", "b.css"],\n    "compatibility": { "minimum": "14", "verified": "14" }\n}',
     );
-    expect(r).not.toBeNull();
-    const parsed = JSON.parse(r?.output ?? '{}');
-    expect(Object.keys(parsed).slice(0, 3)).toEqual(['id', 'type', 'title']);
-    expect(parsed.compatibility).toEqual({ minimum: '14', verified: '14' });
     expect(r?.changes).toHaveLength(3);
+  });
+
+  it('keeps tabs, a numeric minimum, and a missing trailing newline', () => {
+    const raw =
+      '{\n\t"id": "m",\n\t"compatibility": {\n\t\t"minimum": 13.336,\n\t\t"verified": 14\n\t}\n}';
+    const r = transformManifest(raw, 'module');
+    expect(r?.output).toBe(
+      '{\n\t"id": "m",\n\t"type": "module",\n\t"compatibility": {\n\t\t"minimum": "14",\n\t\t"verified": 14\n\t}\n}',
+    );
   });
 
   it('leaves a v14 manifest alone and notes a maximum below 14', () => {

--- a/packages/cli/src/__tests__/migrate/transforms.test.ts
+++ b/packages/cli/src/__tests__/migrate/transforms.test.ts
@@ -6,6 +6,7 @@ import {
   activeEffectModes,
   contextMenuKeys,
   dataOperators,
+  hookNotes,
   legacyTransferral,
   removedGlobals,
   rollMode,
@@ -48,6 +49,11 @@ describe('data operators', () => {
     expect(r.changes).toHaveLength(2);
   });
 
+  it('handles a template-literal key with a ${} segment in the prefix', () => {
+    const r = dataOperators('actor.update({ [`flags.${id}.-=item`]: null });\n');
+    expect(r.output).toBe('actor.update({ [`flags.${id}.item`]: _del });\n');
+  });
+
   it('wraps a replacement value of any shape in _replace', () => {
     const r = dataOperators(
       'await a.update({ "==system.stats": { str: 10, list: [1, 2] }, other: 1 });\n',
@@ -78,11 +84,14 @@ describe('roll mode', () => {
     expect(r.notes).toEqual([]);
   });
 
-  it('turns "roll" into undefined, and notes an expression', () => {
-    const r = rollMode('a({ rollMode: "roll" });\nb({ rollMode: chosen });\n');
-    expect(r.output).toBe('a({ messageMode: undefined });\nb({ messageMode: chosen });\n');
-    expect(r.notes).toHaveLength(1);
-    expect(r.notes[0]).toMatchObject({ line: 2 });
+  it('turns "roll" into undefined, and wraps an expression in the mapper', () => {
+    const r = rollMode(
+      'a({ rollMode: "roll" });\nb({ rollMode: chosen });\nc(undefined, { rollMode: secret ? \'gmroll\' : undefined }).then(x);\n',
+    );
+    expect(r.output).toBe(
+      "a({ messageMode: undefined });\nb({ messageMode: Roll._mapLegacyRollMode(chosen) });\nc(undefined, { messageMode: Roll._mapLegacyRollMode(secret ? 'gmroll' : undefined) }).then(x);\n",
+    );
+    expect(r.notes).toEqual([]);
   });
 
   it('replaces the constants and CONFIG.Dice.rollModes', () => {
@@ -269,5 +278,15 @@ describe('the whole pipeline', () => {
     expect(r.output).toBe(src);
     expect(r.changes).toEqual([]);
     expect(r.notes).toEqual([]);
+  });
+});
+
+describe('hook notes', () => {
+  it('notes renderChatMessage and changes nothing', () => {
+    const src = 'Hooks.on("renderChatMessage", (m, html) => html.find("a"));\n';
+    const r = hookNotes(src);
+    expect(r.output).toBe(src);
+    expect(r.changes).toEqual([]);
+    expect(r.notes[0]?.message).toContain('renderChatMessageHTML');
   });
 });

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -17,9 +17,9 @@
  * 30MB+ runtime dep for marginal gains.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { RuleResult } from './types.js';
 
 /** Directories we never descend into; they are not user source. */
@@ -43,6 +43,10 @@ function isSourceFile(name: string): boolean {
   if (name.endsWith('.d.ts') || name.endsWith('.d.mts') || name.endsWith('.d.cts')) {
     return false;
   }
+  // A minified bundle is a vendored library, not the project's source: the
+  // findings in it are not the author's to fix, and one line of it matches
+  // every pattern there is.
+  if (/\.min\.[cm]?js$/.test(name)) return false;
   return SOURCE_EXTENSIONS.some((ext) => name.endsWith(ext));
 }
 
@@ -624,7 +628,9 @@ async function rule007(
   for (const key of ['primaryTokenAttribute', 'secondaryTokenAttribute'] as const) {
     const value = manifestParsed[key];
     if (typeof value !== 'string' || value.length === 0) continue;
-    const matched = await sourceHasValueMaxSchemaAtPath(sourceFiles, value, actorClasses);
+    const matched =
+      (await sourceHasValueMaxSchemaAtPath(sourceFiles, value, actorClasses)) ||
+      templateJsonHasValueMax(manifestPath, value);
     if (!matched) {
       out.push({
         ruleId: 'VTTF-AUDIT-007',
@@ -638,6 +644,45 @@ async function rule007(
     }
   }
   return out;
+}
+
+/**
+ * The same check against `template.json`, for a system that still declares
+ * its types there. Each Actor type is the merge of the templates it lists and
+ * its own keys; the path resolves when any type has an object with `value`
+ * and `max` at it. Foundry reads the bar the same way, per actor.
+ */
+function templateJsonHasValueMax(manifestPath: string, path: string): boolean {
+  const file = join(dirname(manifestPath), 'template.json');
+  if (!existsSync(file)) return false;
+  let template: Record<string, unknown>;
+  try {
+    template = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return false;
+  }
+  const actor = template.Actor;
+  if (!actor || typeof actor !== 'object') return false;
+  const { types = [], templates = {} } = actor as {
+    types?: string[];
+    templates?: Record<string, Record<string, unknown>>;
+  };
+  for (const type of types) {
+    const own = (actor as Record<string, unknown>)[type];
+    if (!own || typeof own !== 'object') continue;
+    const merged: Record<string, unknown> = {};
+    for (const name of (own as { templates?: string[] }).templates ?? []) {
+      Object.assign(merged, templates[name] ?? {});
+    }
+    Object.assign(merged, own);
+    let node: unknown = merged;
+    for (const segment of path.split('.')) {
+      if (!node || typeof node !== 'object') break;
+      node = (node as Record<string, unknown>)[segment];
+    }
+    if (node && typeof node === 'object' && 'value' in node && 'max' in node) return true;
+  }
+  return false;
 }
 
 function lineOfInRaw(raw: string, key: string): number | undefined {

--- a/packages/cli/src/audit/v14-rules.ts
+++ b/packages/cli/src/audit/v14-rules.ts
@@ -7,6 +7,8 @@
  *   VTTF-AUDIT-014 (MEDIUM): `CONFIG.statusEffects = [...]`, which empties the collection first
  *   VTTF-AUDIT-015 (MEDIUM): `legacyTransferral`, a flag v14 no longer reads
  *   VTTF-AUDIT-016 (MEDIUM): numeric Active Effect modes, replaced by string change types
+ *   VTTF-AUDIT-017 (MEDIUM): the jQuery `renderChatMessage` hook, removed in v15
+ *   VTTF-AUDIT-018 (LOW)   : an Application v1 base class, removed in v16
  *
  * Regex heuristics like the rest of the source rules, for the same reason:
  * the patterns are short and a TypeScript AST would not make them more
@@ -236,6 +238,59 @@ function rule016(filePath: string, content: string): RuleResult[] {
   ];
 }
 
+/**
+ * VTTF-AUDIT-017 (MEDIUM): the `renderChatMessage` hook.
+ *
+ * Deprecated since v13 and removed in v15, one version earlier than the
+ * rest of this list. Its replacement, `renderChatMessageHTML`, hands the
+ * message element instead of a jQuery object, so the handler body changes
+ * too: `html.find(...)` becomes `html.querySelector(...)`.
+ */
+function rule017(filePath: string, content: string): RuleResult[] {
+  const pattern = /Hooks\.(?:on|once)\(\s*['"]renderChatMessage['"]/;
+  if (!pattern.test(content)) return [];
+  return [
+    {
+      ruleId: 'VTTF-AUDIT-017',
+      title: 'renderChatMessage is removed in v15',
+      severity: 'MEDIUM',
+      filePath,
+      line: _internal.lineOf(content, pattern),
+      message:
+        'The `renderChatMessage` hook is deprecated since v13 and removed in v15. It hands a jQuery object; `renderChatMessageHTML` hands the element.',
+      remediation:
+        'Listen to `renderChatMessageHTML(message, html, context)` and rewrite the handler against the DOM: `html.find(x)` → `html.querySelector(x)`, `.on("click", f)` → `.addEventListener("click", f)`.',
+    },
+  ];
+}
+
+/**
+ * VTTF-AUDIT-018 (LOW): an Application v1 base class.
+ *
+ * `Application`, `FormApplication`, `Dialog`, `ActorSheet`, `ItemSheet` and
+ * the rest of `foundry.appv1` are deprecated since v13 and removed in v16.
+ * Nothing breaks on v14, which is why this is LOW; it is the largest piece
+ * of work on the list, which is why it is on the list.
+ */
+function rule018(filePath: string, content: string): RuleResult[] {
+  const pattern =
+    /extends\s+(?:foundry\.appv1\.(?:api|sheets)\.)?(?:Application|FormApplication|Dialog|DocumentSheet|ActorSheet|ItemSheet)\b(?!V2)/;
+  if (!pattern.test(content)) return [];
+  return [
+    {
+      ruleId: 'VTTF-AUDIT-018',
+      title: 'An Application v1 base class',
+      severity: 'LOW',
+      filePath,
+      line: _internal.lineOf(content, pattern),
+      message:
+        'This class extends an Application v1 base, deprecated since v13 and removed in v16. It still works on v14.',
+      remediation:
+        'Move to `foundry.applications.api.ApplicationV2` with `HandlebarsApplicationMixin`, or `foundry.applications.sheets.ActorSheetV2` / `ItemSheetV2`; `DialogV2` for dialogs. `@vttforge/core` offers `BaseApplication`, `BaseActorSheet` and `BaseItemSheet` on top of those.',
+    },
+  ];
+}
+
 export async function runV14Rules(cwd: string): Promise<RuleResult[]> {
   const results: RuleResult[] = [];
   for await (const file of _internal.walkSourceFiles(cwd)) {
@@ -256,6 +311,8 @@ export async function runV14Rules(cwd: string): Promise<RuleResult[]> {
       ...rule014(file, content),
       ...rule015(file, content),
       ...rule016(file, content),
+      ...rule017(file, content),
+      ...rule018(file, content),
     );
   }
   return results;

--- a/packages/cli/src/migrate/transforms.ts
+++ b/packages/cli/src/migrate/transforms.ts
@@ -146,12 +146,15 @@ export const removedGlobals: Transform = (source) => {
 /**
  * `'-=key': null` → `key: _del`; `'==key': value` → `key: _replace(value)`;
  * `performDeletions` → `applyOperators`; `objectsEqual` → `equals`.
+ *
+ * The key may be a template literal with `${...}` segments in the prefix,
+ * which is how a flag deletion is usually written: `` [`flags.${id}.-=old`] ``.
  */
 export const dataOperators: Transform = (source) => {
   const deletions = rewrite(
     source,
-    /(['"])((?:[\w$]+\.)*)-=([\w$.]+)\1\s*:\s*null\b/g,
-    (_m, quote, prefix, key) => `${quote}${prefix}${key}${quote}: _del`,
+    /(['"`])((?:[\w$]+\.|\$\{[^}]*\}\.)*)-=([\w$.]+)\1(\]?)\s*:\s*null\b/g,
+    (_m, quote, prefix, key, bracket) => `${quote}${prefix}${key}${quote}${bracket}: _del`,
     'data-operators',
   );
   // `"==key": <value>` wraps a value of any shape, so the value is scanned to
@@ -175,7 +178,7 @@ export const dataOperators: Transform = (source) => {
 
 function wrapReplacementValues(source: string): TransformResult {
   const changes: Change[] = [];
-  const pattern = /(['"])((?:[\w$]+\.)*)==([\w$.]+)\1\s*:\s*/g;
+  const pattern = /(['"`])((?:[\w$]+\.|\$\{[^}]*\}\.)*)==([\w$.]+)\1(\]?)\s*:\s*/g;
   const code = maskComments(source);
   let out = '';
   let cursor = 0;
@@ -186,8 +189,8 @@ function wrapReplacementValues(source: string): TransformResult {
     const valueEnd = scanValueEnd(source, valueStart);
     if (valueEnd === -1) continue;
     const value = source.slice(valueStart, valueEnd).trimEnd();
-    const [, quote = '"', prefix = '', key = ''] = match;
-    const after = `${quote}${prefix}${key}${quote}: _replace(${value})`;
+    const [, quote = '"', prefix = '', key = '', bracket = ''] = match;
+    const after = `${quote}${prefix}${key}${quote}${bracket}: _replace(${value})`;
     out += source.slice(cursor, start) + after;
     cursor = valueStart + value.length;
     changes.push({
@@ -241,10 +244,11 @@ const ROLL_MODE_CONSTANTS: Record<string, string> = {
  *
  * `"roll"` meant "whatever the user's chat dropdown says", which is what an
  * absent `messageMode` means now, so it becomes `undefined`. A value that is
- * an expression is left for the reader, with a note.
+ * an expression is wrapped in `Roll._mapLegacyRollMode(...)`, which maps a
+ * v13 name and passes a v14 key or `undefined` through unchanged, so the
+ * wrap is safe whatever the expression yields.
  */
 export const rollMode: Transform = (source) => {
-  const notes: Note[] = [];
   const option = rewrite(
     source,
     /\brollMode\s*:\s*(['"])(publicroll|gmroll|blindroll|selfroll|roll)\1/g,
@@ -254,22 +258,9 @@ export const rollMode: Transform = (source) => {
         : `messageMode: ${quote}${ROLL_MODE_VALUES[value]}${quote}`,
     'roll-mode',
   );
-  const key = rewrite(
-    option.output,
-    /\brollMode\s*:/g,
-    (m) => m.replace('rollMode', 'messageMode'),
-    'roll-mode',
-  );
-  for (const change of key.changes) {
-    notes.push({
-      line: change.line,
-      rule: 'roll-mode',
-      message:
-        'The value is an expression. If it can be a v13 mode name, wrap it: `Roll._mapLegacyRollMode(value)`.',
-    });
-  }
+  const expressions = wrapRollModeExpressions(option.output);
   const setting = rewrite(
-    key.output,
+    expressions.output,
     /(['"])core\1\s*,\s*(['"])rollMode\2/g,
     (_m, q1, q2) => `${q1}core${q1}, ${q2}messageMode${q2}`,
     'roll-mode',
@@ -286,7 +277,55 @@ export const rollMode: Transform = (source) => {
     (_m, name) => `"${ROLL_MODE_CONSTANTS[name]}"`,
     'roll-mode',
   );
-  return { ...merge(option, key, setting, modes, constants), notes };
+  return merge(option, expressions, setting, modes, constants);
+};
+
+/** `rollMode: <expr>` → `messageMode: Roll._mapLegacyRollMode(<expr>)`. */
+function wrapRollModeExpressions(source: string): TransformResult {
+  const changes: Change[] = [];
+  const pattern = /\brollMode\s*:\s*/g;
+  const code = maskComments(source);
+  let out = '';
+  let cursor = 0;
+  for (const match of source.matchAll(pattern)) {
+    const start = match.index ?? 0;
+    if (code[start] === MASK) continue;
+    const valueStart = start + match[0].length;
+    const valueEnd = scanValueEnd(source, valueStart);
+    if (valueEnd === -1) continue;
+    const value = source.slice(valueStart, valueEnd).trimEnd();
+    const after = `messageMode: Roll._mapLegacyRollMode(${value})`;
+    out += source.slice(cursor, start) + after;
+    cursor = valueStart + value.length;
+    changes.push({
+      line: lineAt(source, start),
+      before: source.slice(start, cursor),
+      after,
+      rule: 'roll-mode',
+    });
+  }
+  out += source.slice(cursor);
+  return { output: out, changes, notes: [] };
+}
+
+/**
+ * Hooks that changed shape: noted, not rewritten. `renderChatMessage` is
+ * removed in v15 and its replacement hands an element where it handed a
+ * jQuery object, so the handler body is the reader's to change.
+ */
+export const hookNotes: Transform = (source) => {
+  const notes: Note[] = [];
+  const code = maskComments(source);
+  for (const match of source.matchAll(/Hooks\.(?:on|once)\(\s*['"]renderChatMessage['"]/g)) {
+    if (code[match.index ?? 0] === MASK) continue;
+    notes.push({
+      line: lineAt(source, match.index ?? 0),
+      rule: 'hooks',
+      message:
+        '`renderChatMessage` is removed in v15. Listen to `renderChatMessageHTML(message, html, context)`; `html` is the element, so `html.find(x)` becomes `html.querySelector(x)`.',
+    });
+  }
+  return { output: source, changes: [], notes };
 };
 
 /**
@@ -574,6 +613,7 @@ const SOURCE_TRANSFORMS: ReadonlyArray<readonly [string, Transform]> = [
   ['unregister-core-sheets', unregisterCoreSheets],
   ['status-effects', statusEffectsAssignment],
   ['active-effect-modes', activeEffectModes],
+  ['hooks', hookNotes],
 ];
 
 export function transformSource(source: string): TransformResult {

--- a/packages/cli/src/migrate/transforms.ts
+++ b/packages/cli/src/migrate/transforms.ts
@@ -626,6 +626,12 @@ export function transformSource(source: string): TransformResult {
 /**
  * The manifest: `type` declared, `compatibility` raised to 14 where it is
  * lower. Returns `null` when nothing needed to change.
+ *
+ * Edited as text, not re-serialised: a manifest carries its author's
+ * indentation, key order and one-line arrays, and a diff that reformats the
+ * whole file to add one key is a diff nobody merges. `type` goes on the line
+ * after `id`, with that line's indentation; the compatibility values are
+ * replaced in place.
  */
 export function transformManifest(
   raw: string,
@@ -634,23 +640,67 @@ export function transformManifest(
   const parsed = JSON.parse(raw) as Record<string, unknown>;
   const changes: Change[] = [];
   const notes: Note[] = [];
+  let output = raw;
+
   if (parsed.type !== kind) {
-    parsed.type = kind;
-    changes.push({ line: 1, before: '(no "type")', after: `"type": "${kind}"`, rule: 'manifest' });
+    const typeLine = /^([ \t]*)"type"\s*:\s*"[^"]*"/m.exec(output);
+    if (typeLine) {
+      output = output.replace(typeLine[0], `${typeLine[1]}"type": "${kind}"`);
+      changes.push({
+        line: lineAt(raw, typeLine.index),
+        before: typeLine[0].trim(),
+        after: `"type": "${kind}"`,
+        rule: 'manifest',
+      });
+    } else {
+      const idLine = /^([ \t]*)"id"\s*:\s*"[^"]*"\s*,?[ \t]*$/m.exec(output);
+      if (idLine) {
+        const indent = idLine[1] ?? '';
+        const insertAt = idLine.index + idLine[0].length;
+        output = `${output.slice(0, insertAt)}\n${indent}"type": "${kind}",${output.slice(insertAt)}`;
+        changes.push({
+          line: lineAt(raw, idLine.index) + 1,
+          before: '(no "type")',
+          after: `"type": "${kind}"`,
+          rule: 'manifest',
+        });
+      } else {
+        notes.push({
+          line: 1,
+          rule: 'manifest',
+          message: `Add \`"type": "${kind}"\` next to "id"; the key could not be placed by hand.`,
+        });
+      }
+    }
   }
+
   const compatibility = (parsed.compatibility ?? {}) as Record<string, unknown>;
+  const block = /"compatibility"\s*:\s*\{[^}]*\}/.exec(output);
   for (const field of ['minimum', 'verified'] as const) {
     const current = compatibility[field];
     const major = Number.parseInt(String(current ?? '0'), 10);
-    if (!Number.isFinite(major) || major < 14) {
-      compatibility[field] = '14';
-      changes.push({
-        line: 1,
-        before: `compatibility.${field}: ${JSON.stringify(current ?? null)}`,
-        after: `compatibility.${field}: "14"`,
-        rule: 'manifest',
-      });
+    if (Number.isFinite(major) && major >= 14) continue;
+    if (block && current !== undefined) {
+      const field_ = new RegExp(`("${field}"\\s*:\\s*)("[^"]*"|[\\d.]+)`);
+      const inBlock = field_.exec(block[0]);
+      if (inBlock) {
+        const replaced = block[0].replace(field_, '$1"14"');
+        output = output.replace(block[0], replaced);
+        block[0] = replaced;
+        changes.push({
+          line: lineAt(raw, raw.indexOf(`"${field}"`, raw.indexOf('"compatibility"'))),
+          before: `compatibility.${field}: ${JSON.stringify(current)}`,
+          after: `compatibility.${field}: "14"`,
+          rule: 'manifest',
+        });
+        continue;
+      }
     }
+    notes.push({
+      line: 1,
+      rule: 'manifest',
+      message: `Set compatibility.${field} to "14"; it is ${JSON.stringify(current ?? null)} and could not be edited in place.`,
+    });
   }
   const maximum = compatibility.maximum;
   if (maximum !== undefined && Number.parseInt(String(maximum), 10) < 14) {
@@ -668,15 +718,7 @@ export function transformManifest(
         'gridDistance / gridUnits are ignored on v14. Move them into `"grid": { "type", "distance", "units", "diagonals" }`.',
     });
   }
-  parsed.compatibility = compatibility;
   if (changes.length === 0) return notes.length ? { output: raw, changes, notes } : null;
-  // Keep `type` next to `id`, where the v14 manifests put it.
-  const ordered: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    if (key === 'type') continue;
-    ordered[key] = value;
-    if (key === 'id') ordered.type = parsed.type;
-  }
-  if (!('type' in ordered)) ordered.type = parsed.type;
-  return { output: `${JSON.stringify(ordered, null, 2)}\n`, changes, notes };
+  JSON.parse(output); // an edit that broke the file is a bug here, not the user's problem
+  return { output, changes, notes };
 }

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -14,7 +14,7 @@
     "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.10.0",
+    "@vttforge/cli": "^0.11.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -15,7 +15,7 @@
     "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.10.0",
+    "@vttforge/cli": "^0.11.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -15,7 +15,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.10.0",
+    "@vttforge/cli": "^0.11.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -16,7 +16,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.10.0",
+    "@vttforge/cli": "^0.11.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"


### PR DESCRIPTION
## What

The first run of `vttforge audit` and `vttforge migrate` over seven public v13 projects, and what each false positive or gap turned into:

- **Vendored libraries**: two projects ship `js-yaml.min.js` and `jszip.min.js`, and both commands flagged `-=` keys inside them. Minified bundles (`*.min.js`) are skipped now.
- **`template.json` systems**: rule 007 only read data models, so a system still on `template.json` was told its token bars do not resolve. It now merges the type's templates and checks the path there too.
- **`renderChatMessage`**: one project still listens to the jQuery hook, which is removed in v15, a version before everything else on the list. New `VTTF-AUDIT-017` (MEDIUM), and `migrate` notes each handler, since the body has to change from jQuery to the DOM.
- **Application v1 bases**: two projects extend `FormApplication` / `ActorSheet`. New `VTTF-AUDIT-018` (LOW): nothing breaks on v14, removed in v16, and it is the largest item on anyone's list.
- **`rollMode: <expression>`**: `migrate` asked for a decision; it now wraps the value in `Roll._mapLegacyRollMode(...)`, which maps a v13 name and passes a v14 key or `undefined` through, so the wrap is safe for any expression.
- **Template-literal deletion keys**: `` [`flags.${id}.-=item`]: null `` was missed; it is rewritten to `` [`flags.${id}.item`]: _del ``.

## Checks

- 9 new tests; 440 CLI tests, typecheck, lint, knip green
- Re-run over the seven projects: rule 007 no longer flags the `template.json` system, the vendored libraries produce nothing, the deletion key and the `rollMode` expression are rewritten, the two v1-base classes and the jQuery hook are reported
- templates pin `@vttforge/cli ^0.11.0` for the minor; changeset `cli` minor