### PR TITLE
feat(cli): migrate --data-models writes a data model per template.json type

### DIFF
--- a/.changeset/cli-data-models.md
+++ b/.changeset/cli-data-models.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/cli': minor
+---
+
+`vttforge migrate --data-models` writes a data model per `template.json` type: one class per type, one function per shared template that the types spread, the `documentTypes` block for the manifest and the registration for `init`. `--style plain` needs nothing installed; `--style sdk` builds on `@vttforge/core`. What it guessed (empty arrays, nulls, a template a type lists that is not defined) it reports.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -131,3 +131,30 @@ below 14, and the flat `gridDistance` / `gridUnits` keys. Minified bundles
 The rewrites are text-based, like the audit rules they mirror. Comments are
 left alone. A match inside a string literal is rewritten too; the preview is
 where that is caught.
+
+### `--data-models`
+
+```bash
+vttforge migrate --data-models [--style plain|sdk] [--lang js|ts] [--write]
+```
+
+`template.json` is deprecated since v14 and removed in v16. Its replacement
+is a data model per type, registered on `CONFIG.<Document>.dataModels`, with
+the type names declared under `documentTypes` in the manifest. The template
+already says what each field is, so this reads it and writes the classes:
+one `scripts/data/<document>/<type>-data.mjs` per type, and a
+`templates.mjs` beside them with one function per shared template, which the
+types that listed it spread. A number becomes a `NumberField` (`integer`
+when the default is one), a boolean a `BooleanField`, a string a
+`StringField` (an `HTMLField` when the key reads like rich text), an object a
+`SchemaField`, an array an `ArrayField`. What it had to guess, it says: an
+empty array, a `null`, a template a type lists that the file does not
+define.
+
+`--style plain` writes classes on `foundry.abstract.TypeDataModel` and
+needs nothing installed; `--style sdk` writes them on `BaseTypeDataModel`
+from `@vttforge/core`, which types `this` inside `prepareDerivedData`. The
+report ends with the `documentTypes` block to paste into the manifest and
+the registration to add at `init`. An existing file is never overwritten.
+Delete `template.json` once every type has a model: while it exists, Foundry
+resets each listed type's `documentTypes` entry on every start.

--- a/packages/cli/src/__tests__/migrate/data-models.test.ts
+++ b/packages/cli/src/__tests__/migrate/data-models.test.ts
@@ -1,0 +1,153 @@
+/**
+ * template.json → data models: the shape a v13 system still declares there,
+ * turned into classes a reviewer can read.
+ */
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runMigrateCommand } from '../../commands/migrate.js';
+import { planDataModels } from '../../migrate/data-models.js';
+
+const TEMPLATE = {
+  Actor: {
+    types: ['character', 'npc'],
+    htmlFields: ['biography'],
+    templates: {
+      actorBase: { hp: { value: 6, max: 6 }, abilities: { STR: { value: 10, max: 10 } } },
+    },
+    character: {
+      templates: ['base', 'actorBase'],
+      biography: '',
+      deprived: false,
+      gold: 0,
+      containers: [],
+      features: [],
+    },
+    npc: { templates: ['base', 'actorBase', 'missing'], description: '', armor: 0.5 },
+  },
+  Item: {
+    types: ['weapon'],
+    templates: { withDamage: { damageFormula: '', blast: false } },
+    weapon: { templates: ['base', 'withDamage'], quantity: 1, cost: null },
+  },
+};
+
+describe('planDataModels', () => {
+  it('writes a fragment per template and a class per type that spreads them', () => {
+    const plan = planDataModels(TEMPLATE);
+    expect(plan.files.map((f) => f.path)).toEqual([
+      'scripts/data/actor/templates.mjs',
+      'scripts/data/actor/character-data.mjs',
+      'scripts/data/actor/npc-data.mjs',
+      'scripts/data/item/templates.mjs',
+      'scripts/data/item/weapon-data.mjs',
+    ]);
+    const character = plan.files[1]?.source ?? '';
+    expect(character).toContain("import { actorBaseFields } from './templates.mjs';");
+    expect(character).toContain(
+      'export class CharacterData extends foundry.abstract.TypeDataModel {',
+    );
+    expect(character).toContain('...actorBaseFields(f),');
+    expect(character).toContain(
+      'biography: new f.HTMLField({ required: true, blank: true, initial: "" }),',
+    );
+    expect(character).toContain(
+      'deprived: new f.BooleanField({ required: true, nullable: false, initial: false }),',
+    );
+    expect(character).toContain(
+      'gold: new f.NumberField({ required: true, nullable: false, integer: true, initial: 0 }),',
+    );
+    expect(character).toContain('containers: new f.ArrayField(new f.ObjectField()),');
+    const fragments = plan.files[0]?.source ?? '';
+    expect(fragments).toContain('export function actorBaseFields(f) {');
+    expect(fragments).toContain('hp: new f.SchemaField({');
+    expect(fragments).toContain(
+      'value: new f.NumberField({ required: true, nullable: false, integer: true, initial: 6 }),',
+    );
+    const npc = plan.files[2]?.source ?? '';
+    expect(npc).toContain(
+      'armor: new f.NumberField({ required: true, nullable: false, initial: 0.5 }),',
+    );
+  });
+
+  it('carries htmlFields into documentTypes and writes the registration', () => {
+    const plan = planDataModels(TEMPLATE);
+    expect(plan.documentTypes).toEqual({
+      Actor: { character: { htmlFields: ['biography'] }, npc: {} },
+      Item: { weapon: {} },
+    });
+    expect(plan.registration).toContain(
+      'Object.assign(CONFIG.Actor.dataModels, { character: CharacterData, npc: NpcData })',
+    );
+  });
+
+  it('notes what it guessed: empty arrays, null values, a missing template, and the file to delete', () => {
+    const { notes } = planDataModels(TEMPLATE);
+    expect(notes.some((n) => n.startsWith('Actor.character.containers: an empty array'))).toBe(
+      true,
+    );
+    expect(notes.some((n) => n.startsWith('Item.weapon.cost: null'))).toBe(true);
+    expect(notes.some((n) => n.includes('lists template "missing"'))).toBe(true);
+    expect(notes.at(-1)).toContain('delete template.json');
+  });
+
+  it('emits SDK classes on request, in TypeScript on request', () => {
+    const plan = planDataModels(TEMPLATE, { style: 'sdk', lang: 'ts' });
+    const weapon =
+      plan.files.find((f) => f.path === 'scripts/data/item/weapon-data.ts')?.source ?? '';
+    expect(weapon).toContain("import { BaseTypeDataModel, fields } from '@vttforge/core';");
+    expect(weapon).toContain("import { withDamageFields } from './templates.js';");
+    expect(weapon).toContain(
+      'export class WeaponData extends BaseTypeDataModel(defineWeaponDataSchema) {',
+    );
+    expect(weapon).toContain('const f = fields();');
+    expect(plan.registration).toContain(
+      'registerSystem({ itemDataModels: { weapon: WeaponData } })',
+    );
+  });
+});
+
+describe('vttforge migrate --data-models', () => {
+  let cwd: string;
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'vttf-dm-'));
+    await writeFile(
+      join(cwd, 'system.json'),
+      '{"id":"s","type":"system","compatibility":{"minimum":"14","verified":"14"}}',
+      'utf8',
+    );
+    await writeFile(join(cwd, 'template.json'), JSON.stringify(TEMPLATE), 'utf8');
+  });
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('lists the files in preview and writes them with --write, never over an existing one', async () => {
+    let out = '';
+    const preview = await runMigrateCommand({
+      cwd,
+      dataModels: true,
+      out: (c) => {
+        out += c;
+      },
+    });
+    expect(preview.report.dataModels?.files).toHaveLength(5);
+    expect(out).toContain('Would write 5 data model file(s)');
+    await expect(
+      readFile(join(cwd, 'scripts/data/actor/character-data.mjs'), 'utf8'),
+    ).rejects.toThrow();
+
+    await writeFile(join(cwd, 'scripts'), '', 'utf8').catch(() => {});
+    await rm(join(cwd, 'scripts'), { force: true });
+    const written = await runMigrateCommand({ cwd, dataModels: true, write: true, out: () => {} });
+    expect(written.report.dataModels?.files).toHaveLength(5);
+    expect(await readFile(join(cwd, 'scripts/data/actor/character-data.mjs'), 'utf8')).toContain(
+      'class CharacterData',
+    );
+
+    const again = await runMigrateCommand({ cwd, dataModels: true, write: true, out: () => {} });
+    expect(again.report.dataModels?.files).toEqual([]);
+    expect(again.report.dataModels?.notes[0]).toContain('exists and was left alone');
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -221,6 +221,22 @@ export const migrate = defineCommand({
       default: false,
       description: 'Emit the report as JSON',
     },
+    'data-models': {
+      type: 'boolean',
+      default: false,
+      description:
+        'Also generate a data model per template.json type (template.json is deprecated since v14)',
+    },
+    style: {
+      type: 'string',
+      default: 'plain',
+      description: 'For --data-models: "plain" Foundry classes, or "sdk" classes on @vttforge/core',
+    },
+    lang: {
+      type: 'string',
+      default: 'js',
+      description: 'For --data-models: "js" writes .mjs, "ts" writes .ts',
+    },
   },
   async run({ args }) {
     try {
@@ -228,6 +244,9 @@ export const migrate = defineCommand({
         cwd: args.path ? String(args.path) : undefined,
         write: Boolean(args.write),
         json: Boolean(args.json),
+        dataModels: Boolean(args['data-models']),
+        style: String(args.style) === 'sdk' ? 'sdk' : 'plain',
+        lang: String(args.lang) === 'ts' ? 'ts' : 'js',
       });
       process.exitCode = exitCode;
     } catch (error) {

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -13,6 +13,10 @@ export interface MigrateCommandOptions {
   cwd?: string;
   write?: boolean;
   json?: boolean;
+  /** Also generate a data model per template.json type. */
+  dataModels?: boolean;
+  style?: 'plain' | 'sdk';
+  lang?: 'js' | 'ts';
   /** Custom writer (tests). Defaults to process.stdout.write. */
   out?: (chunk: string) => void;
 }
@@ -26,7 +30,13 @@ export async function runMigrateCommand(
     ((chunk: string) => {
       process.stdout.write(chunk);
     });
-  const report = await runMigrate({ cwd, write: options.write === true });
+  const report = await runMigrate({
+    cwd,
+    write: options.write === true,
+    dataModels: options.dataModels === true,
+    style: options.style,
+    lang: options.lang,
+  });
   out(options.json ? `${JSON.stringify(report, null, 2)}\n` : formatMigrateReport(report));
   return { report, exitCode: 0 };
 }

--- a/packages/cli/src/migrate/data-models.ts
+++ b/packages/cli/src/migrate/data-models.ts
@@ -12,7 +12,7 @@
  * What is inferred, and what is guessed:
  * - a number is a `NumberField` (`integer` when the default is one), a
  *   boolean a `BooleanField`, a string a `StringField` (`HTMLField` when the
- *   key reads like rich text: description, biography, notes), an object a
+ *   key reads like rich text: description, biography, notes, details), an object a
  *   `SchemaField`, an array an `ArrayField` of whatever its first element is
  *   (`ObjectField` when it is empty or holds objects), `null` an
  *   `ObjectField` marked for review.
@@ -24,7 +24,7 @@
 
 export type EmitStyle = 'plain' | 'sdk';
 
-export interface DataModelFile {
+interface DataModelFile {
   /** Project-relative path to write. */
   path: string;
   source: string;
@@ -49,7 +49,7 @@ interface DocumentTemplate {
   [type: string]: unknown;
 }
 
-const RICH_TEXT_KEYS = /^(description|biography|bio|notes|details|background|text)$/i;
+const RICH_TEXT_KEYS = /^(description|biography|bio|notes|details)$/i;
 
 function fieldFor(
   key: string,

--- a/packages/cli/src/migrate/data-models.ts
+++ b/packages/cli/src/migrate/data-models.ts
@@ -1,0 +1,227 @@
+/**
+ * `template.json` → one data model per type.
+ *
+ * v14 deprecates `template.json` and removes it in v16; the replacement is a
+ * `TypeDataModel` per type registered on `CONFIG.<Document>.dataModels`,
+ * with the type names declared under `documentTypes` in the manifest. The
+ * shape is already in the template: every default value says what field it
+ * is, and every `templates` entry is a fragment several types share. This
+ * reads that and writes the classes, so the move is a review of generated
+ * code rather than a transcription.
+ *
+ * What is inferred, and what is guessed:
+ * - a number is a `NumberField` (`integer` when the default is one), a
+ *   boolean a `BooleanField`, a string a `StringField` (`HTMLField` when the
+ *   key reads like rich text: description, biography, notes), an object a
+ *   `SchemaField`, an array an `ArrayField` of whatever its first element is
+ *   (`ObjectField` when it is empty or holds objects), `null` an
+ *   `ObjectField` marked for review.
+ * - a `templates` fragment becomes a function returning a partial schema, so
+ *   each type's schema spreads the fragments it listed, in the order the
+ *   template listed them, then its own keys. Foundry's implicit `base`
+ *   template is skipped.
+ */
+
+export type EmitStyle = 'plain' | 'sdk';
+
+export interface DataModelFile {
+  /** Project-relative path to write. */
+  path: string;
+  source: string;
+}
+
+export interface DataModelPlan {
+  files: DataModelFile[];
+  /** The `documentTypes` block the manifest needs, per document. */
+  documentTypes: Record<string, Record<string, Record<string, unknown>>>;
+  /** The registration a system adds in `init`, as source text. */
+  registration: string;
+  /** Things the reader has to decide. */
+  notes: string[];
+}
+
+interface DocumentTemplate {
+  types?: string[];
+  templates?: Record<string, Record<string, unknown>>;
+  htmlFields?: string[];
+  filePathFields?: string[];
+  gmOnlyFields?: string[];
+  [type: string]: unknown;
+}
+
+const RICH_TEXT_KEYS = /^(description|biography|bio|notes|details|background|text)$/i;
+
+function fieldFor(
+  key: string,
+  value: unknown,
+  path: string,
+  notes: string[],
+  indent: string,
+): string {
+  const next = `${indent}  `;
+  if (typeof value === 'number') {
+    const integer = Number.isInteger(value);
+    return `new f.NumberField({ required: true, nullable: false${integer ? ', integer: true' : ''}, initial: ${value} })`;
+  }
+  if (typeof value === 'boolean') {
+    return `new f.BooleanField({ required: true, nullable: false, initial: ${value} })`;
+  }
+  if (typeof value === 'string') {
+    const literal = JSON.stringify(value);
+    if (RICH_TEXT_KEYS.test(key))
+      return `new f.HTMLField({ required: true, blank: true, initial: ${literal} })`;
+    return `new f.StringField({ required: true, blank: true, initial: ${literal} })`;
+  }
+  if (Array.isArray(value)) {
+    const first = value[0];
+    if (first === undefined || (typeof first === 'object' && first !== null)) {
+      if (first === undefined)
+        notes.push(
+          `${path}: an empty array in the template; it is an ArrayField of ObjectField. Name the element's shape if it has one.`,
+        );
+      return 'new f.ArrayField(new f.ObjectField())';
+    }
+    return `new f.ArrayField(${fieldFor(key, first, `${path}[]`, notes, indent)})`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+      notes.push(
+        `${path}: an empty object in the template; it is an ObjectField. Give it a SchemaField if it has a shape.`,
+      );
+      return 'new f.ObjectField()';
+    }
+    const inner = entries
+      .map(([k, v]) => `${next}${safeKey(k)}: ${fieldFor(k, v, `${path}.${k}`, notes, next)},`)
+      .join('\n');
+    return `new f.SchemaField({\n${inner}\n${indent}})`;
+  }
+  notes.push(`${path}: null in the template; it is an ObjectField. Pick the real field.`);
+  return 'new f.ObjectField()';
+}
+
+function safeKey(key: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(key) ? key : JSON.stringify(key);
+}
+
+function pascal(name: string): string {
+  return name
+    .replace(/(^|[^A-Za-z0-9])([a-z0-9])/g, (_m, _s, c: string) => c.toUpperCase())
+    .replace(/[^A-Za-z0-9]/g, '');
+}
+
+function camel(name: string): string {
+  const p = pascal(name);
+  return p.charAt(0).toLowerCase() + p.slice(1);
+}
+
+function schemaBody(data: Record<string, unknown>, path: string, notes: string[]): string {
+  return Object.entries(data)
+    .filter(([k]) => k !== 'templates')
+    .map(([k, v]) => `    ${safeKey(k)}: ${fieldFor(k, v, `${path}.${k}`, notes, '    ')},`)
+    .join('\n');
+}
+
+function header(style: EmitStyle): string {
+  if (style === 'sdk') return "import { BaseTypeDataModel, fields } from '@vttforge/core';\n";
+  return '';
+}
+
+function fieldsLine(style: EmitStyle): string {
+  return style === 'sdk' ? '  const f = fields();' : '  const f = foundry.data.fields;';
+}
+
+export function planDataModels(
+  template: Record<string, unknown>,
+  {
+    style = 'plain',
+    lang = 'js',
+    dir = 'scripts/data',
+  }: { style?: EmitStyle; lang?: 'js' | 'ts'; dir?: string } = {},
+): DataModelPlan {
+  const ext = lang === 'ts' ? 'ts' : 'mjs';
+  const files: DataModelFile[] = [];
+  const notes: string[] = [];
+  const documentTypes: DataModelPlan['documentTypes'] = {};
+  const registrations: string[] = [];
+
+  for (const [document, raw] of Object.entries(template)) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const doc = raw as DocumentTemplate;
+    const types = doc.types ?? [];
+    const templates = doc.templates ?? {};
+    const docDir = `${dir}/${document.toLowerCase()}`;
+
+    // One fragment per template, so the sharing the template expressed is
+    // kept, and a type that lists three fragments spreads three functions.
+    const fragmentNames = Object.keys(templates);
+    if (fragmentNames.length > 0) {
+      const fns = fragmentNames
+        .map((name) => {
+          const body = schemaBody(templates[name] ?? {}, `${document}.templates.${name}`, notes);
+          return `/** The \`${name}\` template, as the types that listed it spread it. */\nexport function ${camel(name)}Fields(f) {\n  return {\n${body}\n  };\n}`;
+        })
+        .join('\n\n');
+      const tsHint =
+        lang === 'ts'
+          ? '// @ts-nocheck: the field constructors are typed by the runtime, not by this file\n'
+          : '';
+      files.push({
+        path: `${docDir}/templates.${ext}`,
+        source: `${tsHint}/**\n * The \`templates\` of the old template.json for ${document}, each as a\n * function of the fields bag. A type spreads the ones it listed.\n */\n\n${fns}\n`,
+      });
+    }
+
+    documentTypes[document] = {};
+    const modelNames: string[] = [];
+    for (const type of types) {
+      const own = (doc[type] ?? {}) as Record<string, unknown>;
+      const listed = ((own.templates as string[] | undefined) ?? []).filter((t) => t !== 'base');
+      for (const t of listed) {
+        if (!(t in templates))
+          notes.push(
+            `${document}.${type}: lists template "${t}", which template.json does not define; it was skipped.`,
+          );
+      }
+      const spreads = listed
+        .filter((t) => t in templates)
+        .map((t) => `    ...${camel(t)}Fields(f),`)
+        .join('\n');
+      const body = schemaBody(own, `${document}.${type}`, notes);
+      const className = `${pascal(type)}Data`;
+      const importLine = listed.length
+        ? `import { ${listed
+            .filter((t) => t in templates)
+            .map((t) => `${camel(t)}Fields`)
+            .join(', ')} } from './templates.${ext === 'ts' ? 'js' : 'mjs'}';\n`
+        : '';
+      const schemaFn = `${fieldsLine(style)}\n  return {\n${[spreads, body].filter(Boolean).join('\n')}\n  };`;
+      const classSource =
+        style === 'sdk'
+          ? `${header(style)}${importLine}\n/** The \`${type}\` ${document}, as template.json declared it. */\nfunction define${className}Schema() {\n${schemaFn}\n}\n\nexport class ${className} extends BaseTypeDataModel(define${className}Schema) {\n  prepareDerivedData() {\n    // Derived values go here. Nothing here writes to the database.\n  }\n}\n`
+          : `${importLine}\n/** The \`${type}\` ${document}, as template.json declared it. */\nexport class ${className} extends foundry.abstract.TypeDataModel {\n  static defineSchema() {\n${schemaFn.replace(/^/gm, '  ')}\n  }\n\n  prepareDerivedData() {\n    // Derived values go here. Nothing here writes to the database.\n  }\n}\n`;
+      files.push({ path: `${docDir}/${type}-data.${ext}`, source: classSource });
+      const meta: Record<string, unknown> = {};
+      const html = (doc.htmlFields ?? []).filter(
+        (k) => k in own || listed.some((t) => k in (templates[t] ?? {})),
+      );
+      if (html.length) meta.htmlFields = html;
+      documentTypes[document][type] = meta;
+      modelNames.push(`${type}: ${className}`);
+      registrations.push(
+        `import { ${className} } from './${docDir.replace(/^scripts\//, '')}/${type}-data.${ext === 'ts' ? 'js' : 'mjs'}';`,
+      );
+    }
+    if (types.length) {
+      registrations.push(
+        style === 'sdk'
+          ? `// registerSystem({ ${document === 'Actor' ? 'actorDataModels' : document === 'Item' ? 'itemDataModels' : `${camel(document)}DataModels`}: { ${modelNames.join(', ')} } })`
+          : `// Hooks.once('init', () => Object.assign(CONFIG.${document}.dataModels, { ${modelNames.join(', ')} }));`,
+      );
+    }
+  }
+  notes.push(
+    "When every type has a model, delete template.json: while it exists, Foundry resets each listed type's documentTypes entry on every start.",
+  );
+  return { files, documentTypes, registration: registrations.join('\n'), notes };
+}

--- a/packages/cli/src/migrate/index.ts
+++ b/packages/cli/src/migrate/index.ts
@@ -8,9 +8,10 @@
  */
 
 import { existsSync } from 'node:fs';
-import { readFile, stat, writeFile } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
 import { _internal } from '../audit/source-rules.js';
+import { type EmitStyle, planDataModels } from './data-models.js';
 import { type Change, type Note, transformManifest, transformSource } from './transforms.js';
 
 interface FileResult {
@@ -27,12 +28,25 @@ export interface MigrateReport {
   /** Whether the edits were written to disk. */
   written: boolean;
   counts: { files: number; changes: number; notes: number };
+  /** Present when data models were generated from template.json. */
+  dataModels?: {
+    files: string[];
+    documentTypes: Record<string, Record<string, Record<string, unknown>>>;
+    registration: string;
+    notes: string[];
+  };
 }
 
 export interface MigrateOptions {
   cwd: string;
   /** Write the edits. Default false: report only. */
   write?: boolean;
+  /** Also generate a data model per template.json type. */
+  dataModels?: boolean;
+  /** How the generated models are written: bare Foundry classes, or on the SDK's bases. */
+  style?: EmitStyle;
+  /** File extension of the generated models. */
+  lang?: 'js' | 'ts';
 }
 
 export async function runMigrate(options: MigrateOptions): Promise<MigrateReport> {
@@ -77,7 +91,7 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
   }
 
   files.sort((a, b) => a.file.localeCompare(b.file));
-  return {
+  const report: MigrateReport = {
     cwd,
     files,
     written: write,
@@ -87,20 +101,62 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
       notes: files.reduce((n, f) => n + f.notes.length, 0),
     },
   };
+
+  if (options.dataModels) {
+    const templatePath = join(cwd, 'template.json');
+    if (!existsSync(templatePath)) {
+      report.dataModels = {
+        files: [],
+        documentTypes: {},
+        registration: '',
+        notes: ['No template.json here; nothing to generate.'],
+      };
+    } else {
+      const template = JSON.parse(await readFile(templatePath, 'utf8')) as Record<string, unknown>;
+      const plan = planDataModels(template, {
+        style: options.style ?? 'plain',
+        lang: options.lang ?? 'js',
+      });
+      const written: string[] = [];
+      for (const file of plan.files) {
+        const target = join(cwd, file.path);
+        if (existsSync(target)) {
+          plan.notes.unshift(`${file.path} exists and was left alone.`);
+          continue;
+        }
+        if (write) {
+          await mkdir(dirname(target), { recursive: true });
+          await writeFile(target, file.source, 'utf8');
+        }
+        written.push(file.path);
+      }
+      report.dataModels = {
+        files: written,
+        documentTypes: plan.documentTypes,
+        registration: plan.registration,
+        notes: plan.notes,
+      };
+    }
+  }
+
+  return report;
 }
 
 /** The report as text: one block per file, edits then notes. */
 export function formatMigrateReport(report: MigrateReport): string {
   const lines: string[] = [];
-  if (report.files.length === 0) {
+  if (report.files.length === 0 && !report.dataModels) {
     lines.push('Nothing to migrate. The project already reads as v14.');
     return `${lines.join('\n')}\n`;
   }
-  lines.push(
-    report.written
-      ? `Rewrote ${report.counts.changes} place(s) in ${report.counts.files} file(s).`
-      : `Would rewrite ${report.counts.changes} place(s) in ${report.counts.files} file(s). Run again with --write to apply.`,
-  );
+  if (report.files.length === 0) lines.push('Nothing to rewrite in the source or the manifest.');
+  else {
+    lines.push(
+      report.written
+        ? `Rewrote ${report.counts.changes} place(s) in ${report.counts.files} file(s).`
+        : `Would rewrite ${report.counts.changes} place(s) in ${report.counts.files} file(s). Run again with --write to apply.`,
+    );
+  }
   for (const file of report.files) {
     lines.push('', `${file.file}`);
     for (const change of file.changes) {
@@ -118,6 +174,30 @@ export function formatMigrateReport(report: MigrateReport): string {
       '',
       `${report.counts.notes} place(s) need a decision. Run \`vttforge audit\` after editing them.`,
     );
+  }
+  if (report.dataModels) {
+    const dm = report.dataModels;
+    lines.push(
+      '',
+      report.written
+        ? `Wrote ${dm.files.length} data model file(s) from template.json:`
+        : `Would write ${dm.files.length} data model file(s) from template.json:`,
+    );
+    for (const f of dm.files) lines.push(`  ${f}`);
+    if (Object.keys(dm.documentTypes).length > 0) {
+      lines.push(
+        '',
+        'Declare the types in the manifest:',
+        `  "documentTypes": ${JSON.stringify(dm.documentTypes)}`,
+      );
+    }
+    if (dm.registration)
+      lines.push(
+        '',
+        'Register the models at init:',
+        ...dm.registration.split('\n').map((l) => `  ${l}`),
+      );
+    for (const n of dm.notes) lines.push(`  needs a decision: ${n}`);
   }
   return `${lines.join('\n')}\n`;
 }


### PR DESCRIPTION
## What

`vttforge migrate --data-models [--style plain|sdk] [--lang js|ts] [--write]`

`template.json` is deprecated since v14 and removed in v16. The template already says what each field is, so this reads it and writes the classes:

- one `scripts/data/<document>/<type>-data.mjs` per type, spreading the shared templates it listed
- one `templates.mjs` per document with a function per shared template
- the `documentTypes` block for the manifest (with `htmlFields` carried over) and the registration for `init`, in the report
- `--style plain` writes classes on `foundry.abstract.TypeDataModel` and needs nothing installed; `--style sdk` writes them on `BaseTypeDataModel` from `@vttforge/core`

Inference: number → `NumberField` (`integer` when the default is one), boolean → `BooleanField`, string → `StringField` (`HTMLField` for description/biography/notes keys), object → `SchemaField`, array → `ArrayField`. Empty arrays, nulls, and a template a type lists that the file does not define are reported as needing a decision. An existing file is never overwritten.

## Why

Two of the seven projects on the adoption list still declare their types in `template.json`, and every system in the wider list of 45 that has no `TypeDataModel` does. The move is mechanical for most of the file, and this makes it a review instead of a transcription.

## Checks

- 6 new tests (fragments and classes, documentTypes and registration, the notes, SDK/TypeScript output, the command's preview/write/never-overwrite); 454 CLI tests, typecheck, lint, knip green
- Run on a real 8-type system next; changeset `cli` minor