### PR TITLE
fix(vite-plugin): copy the compendium packs into dist

### DIFF
--- a/.changeset/vite-plugin-copy-packs.md
+++ b/.changeset/vite-plugin-copy-packs.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/vite-plugin': patch
+---
+
+The build copies compendium packs. `packs` joins the default `staticAssets`, and the directory of every `packs[].path` the manifest declares is copied wherever the author put it. A system built without them shipped with empty compendia.

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -33,7 +33,7 @@ export default defineConfig({
 | `kind` | `'system'` | `'system'` or `'module'`. Sets the base path (`/systems/<id>/` vs `/modules/<id>/`) and the manifest filename |
 | `entry` | `'scripts/main.mjs'` | Entry script, relative to the project root |
 | `manifest` | `system.json` / `module.json` | Manifest path, relative to the project root |
-| `staticAssets` | `['template.json', 'lang', 'templates']` | Files and directories copied into `dist/` before each build |
+| `staticAssets` | `['template.json', 'lang', 'templates', 'packs']`, plus the directory of every `packs[].path` the manifest declares | Files and directories copied into `dist/` before each build |
 
 Peer: `vite ^8`. Node 26+.
 

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -22,7 +22,7 @@ export default defineConfig({
 - Keeps class names through minification, so a sheet registered by class name keeps its key between builds. Prefer `registerSystem({ sheets })` with an `id`; this is the safety net.
 - Bundles CSS into one stylesheet and rewrites the manifest's `styles` and `esmodules` to the emitted paths.
 - Copies the manifest under Foundry's filename (`system.json` / `module.json`) with `version` synced from `package.json`.
-- Copies `template.json`, `lang/` and `templates/` verbatim. Override the list with `staticAssets`.
+- Copies `template.json`, `lang/`, `templates/` and `packs/` verbatim, plus every directory the manifest's `packs[].path` names. Override the list with `staticAssets`.
 - Emits external source maps with the sources embedded.
 
 ## Options

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -241,6 +241,24 @@ describe('@vttforge/vite-plugin', () => {
       );
     });
 
+    it('copies the compendium packs the manifest declares, wherever they live', async () => {
+      mkdirSync(resolve(workdir, 'packs/armor'), { recursive: true });
+      writeFileSync(resolve(workdir, 'packs/armor/000001.ldb'), 'leveldb', 'utf8');
+      mkdirSync(resolve(workdir, 'data/tables'), { recursive: true });
+      writeFileSync(resolve(workdir, 'data/tables/000001.ldb'), 'leveldb', 'utf8');
+      const manifest = JSON.parse(readFileSync(resolve(workdir, 'system.json'), 'utf8'));
+      manifest.packs = [
+        { name: 'armor', label: 'Armor', path: 'packs/armor.db', type: 'Item' },
+        { name: 'tables', label: 'Tables', path: 'data/tables', type: 'RollTable' },
+      ];
+      writeFileSync(resolve(workdir, 'system.json'), JSON.stringify(manifest), 'utf8');
+
+      await build({ root: workdir, logLevel: 'silent', plugins: [vttforge(defaultOptions())] });
+
+      expect(existsSync(resolve(workdir, 'dist/packs/armor/000001.ldb'))).toBe(true);
+      expect(existsSync(resolve(workdir, 'dist/data/tables/000001.ldb'))).toBe(true);
+    });
+
     it('respects a custom staticAssets list', async () => {
       const plugin = mainPlugin(vttforge(defaultOptions({ staticAssets: ['lang'] })));
       await invokeConfigHook(plugin, workdir);

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -52,7 +52,8 @@ export interface VttforgeOptions {
   /**
    * Paths copied verbatim to `dist/` at the start of every build. Each entry
    * may be a file or a directory; directories are copied recursively.
-   * Default: `['template.json', 'lang', 'templates']`. The manifest is
+   * Default: `['template.json', 'lang', 'templates', 'packs']`, plus the
+   * directory of every `packs[].path` the manifest declares. The manifest is
    * always copied separately so the version sync hook can rewrite it.
    */
   staticAssets?: string[];
@@ -68,7 +69,7 @@ interface ResolvedOptions {
   outDir: string;
 }
 
-const DEFAULT_STATIC = ['template.json', 'lang', 'templates'];
+const DEFAULT_STATIC = ['template.json', 'lang', 'templates', 'packs'];
 
 const JS_ENTRY_FILENAME = 'main.mjs';
 
@@ -136,9 +137,31 @@ function extractStyleEntries(rawStyles: unknown): StyleEntry[] {
   return result;
 }
 
+/**
+ * The directories the manifest's `packs[].path` entries live in. A pack is
+ * data the system ships, and a build that drops it ships a system with
+ * empty compendia; so every declared pack directory is copied, wherever the
+ * author put it, on top of the `staticAssets` list.
+ */
+function packDirectories(opts: ResolvedOptions): string[] {
+  const manifest = readJsonSafe(resolve(opts.root, opts.manifest));
+  const packs = manifest?.packs;
+  if (!Array.isArray(packs)) return [];
+  const dirs = new Set<string>();
+  for (const pack of packs) {
+    const path = (pack as { path?: unknown })?.path;
+    if (typeof path !== 'string' || path.length === 0) continue;
+    // `packs/armor.db` and `packs/armor` both name the `packs` directory.
+    const top = path.replace(/^\.?\//, '').split('/')[0];
+    if (top) dirs.add(top);
+  }
+  return [...dirs];
+}
+
 async function copyStatic(opts: ResolvedOptions): Promise<void> {
   await mkdir(opts.outDir, { recursive: true });
-  for (const entry of opts.staticAssets) {
+  const entries = [...new Set([...opts.staticAssets, ...packDirectories(opts)])];
+  for (const entry of entries) {
     const src = resolve(opts.root, entry);
     if (!existsSync(src)) continue;
     const dest = resolve(opts.outDir, entry);


### PR DESCRIPTION
## What

`packs` joins the default `staticAssets` (`template.json`, `lang`, `templates`), and the directory of every `packs[].path` the manifest declares is copied too, wherever the author put it. `packs/armor.db` and `packs/armor` both name `packs`.

## Why

Building a real system with thirteen compendium packs through `vttforge build` produced a `dist/` with none of them. A system that ships without its packs ships with empty compendia, and nothing in the build said so.

## Checks

- 1 new test: two packs in two directories, both declared in the manifest, both present in `dist/`
- 27 vite-plugin tests, typecheck, lint, knip green; changeset `vite-plugin` patch