### PR TITLE
fix(core): the tab action activates any .tab pane, not only a section

### DIFF
--- a/.changeset/core-tab-panes.md
+++ b/.changeset/core-tab-panes.md
@@ -1,0 +1,5 @@
+---
+'@vttforge/core': patch
+---
+
+The `vttforgeTab` action activates any element with the `tab` class, not only a `<section>`. A sheet whose panes are `<div class="tab">`, which is what most systems write, never switched tabs.

--- a/packages/core/src/__tests__/base-actor-sheet.test.ts
+++ b/packages/core/src/__tests__/base-actor-sheet.test.ts
@@ -171,6 +171,25 @@ describe('BaseActorSheet — default `tab` action', () => {
     expect(handler).toBeTypeOf('function');
   });
 
+  it('activates a <div class="tab"> pane too, which is what most systems use', () => {
+    const Sub = class extends BaseActorSheet() {};
+    const handler = (
+      Sub as unknown as {
+        DEFAULT_OPTIONS: { actions: { vttforgeTab: (event: Event, target: HTMLElement) => void } };
+      }
+    ).DEFAULT_OPTIONS.actions.vttforgeTab;
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <nav class="tabs"><a data-action="vttforgeTab" data-tab="a" data-group="primary" class="active"></a><a data-action="vttforgeTab" data-tab="b" data-group="primary"></a></nav>
+      <div class="tab active" data-tab="a" data-group="primary"></div>
+      <div class="tab" data-tab="b" data-group="primary"></div>`;
+    const sheet = { tabGroups: {} as Record<string, string>, element: root };
+    const target = root.querySelector('a[data-tab="b"]') as HTMLElement;
+    handler.call(sheet, new Event('click'), target);
+    expect(root.querySelector('div[data-tab="b"]')?.classList.contains('active')).toBe(true);
+    expect(root.querySelector('div[data-tab="a"]')?.classList.contains('active')).toBe(false);
+  });
+
   it('toggles .active on matching nav button and content section, updates tabGroups', () => {
     const Sub = BaseActorSheet();
     const handler = (

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -294,7 +294,10 @@ export function BaseActorSheet(): SheetBaseCtor {
         link.classList.toggle('active', link.dataset.tab === tab);
       }
       for (const section of root.querySelectorAll<HTMLElement>(
-        `section.tab[data-group="${group}"]`,
+        // Any element with the tab class: a pane is a <section> in the
+        // scaffold and a <div> in most systems, and Foundry's own changeTab
+        // accepts either.
+        `.tab[data-group="${group}"]`,
       )) {
         section.classList.toggle('active', section.dataset.tab === tab);
       }

--- a/packages/core/src/base-item-sheet.ts
+++ b/packages/core/src/base-item-sheet.ts
@@ -155,7 +155,10 @@ export function BaseItemSheet(): SheetBaseCtor {
         link.classList.toggle('active', link.dataset.tab === tab);
       }
       for (const section of root.querySelectorAll<HTMLElement>(
-        `section.tab[data-group="${group}"]`,
+        // Any element with the tab class: a pane is a <section> in the
+        // scaffold and a <div> in most systems, and Foundry's own changeTab
+        // accepts either.
+        `.tab[data-group="${group}"]`,
       )) {
         section.classList.toggle('active', section.dataset.tab === tab);
       }


### PR DESCRIPTION
## What

`BaseActorSheet` and `BaseItemSheet` register the `vttforgeTab` action. It toggled `.active` on `section.tab[data-group]` only, so a sheet whose panes are `<div class="tab">` (the markup most systems and Foundry's own docs use) never switched tabs. The selector is now `.tab[data-group]`, which is what Foundry's `changeTab` matches.

## Why

Found by clicking through a system ported onto the SDK: every tab click was a no-op. The scaffold and the example use `<section>`, so nothing here caught it.

## Checks

- 1 new test with `<div class="tab">` panes; 209 core tests, typecheck, lint green
- changeset `core` patch