### PR TITLE
feat(cli): vttforge lint runs the shipped Biome, then the audit

### DIFF
--- a/.changeset/cli-lint.md
+++ b/.changeset/cli-lint.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/cli": minor
+---
+
+`vttforge lint`: Biome over the project, then the v14 audit. Biome ships as a dependency of the CLI with `lint/vttforge-biome.json`, so a scaffolded project lints and formats without installing or configuring anything; a `biome.json` at the project root replaces the shipped config. `--fix` writes the safe fixes and formats, `--no-audit` skips the audit, `--strict` makes any audit finding fail. The templates gain `lint` and `format` scripts that call it.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -50,6 +50,27 @@ root, manifest at the top level, which is what foundryvtt.com expects.
 The scaffold's release workflow runs this on every tag and attaches the zip
 and the manifest to a GitHub Release.
 
+## `vttforge lint`
+
+```bash
+vttforge lint [dir] [--fix] [--no-audit] [--strict]
+```
+
+Biome over the project, then `vttforge audit`. Biome ships as a dependency
+of the CLI, so a scaffolded project lints and formats without installing or
+configuring anything: the templates' `lint` and `format` scripts call this.
+
+The config Biome runs with is `lint/vttforge-biome.json` in the CLI
+package (the recommended rules, the house formatting, and the Foundry
+globals such as `game`, `canvas`, `CONFIG`, `Hooks` declared). A
+`biome.json` or `biome.jsonc` at the project root replaces it outright, so a
+project that wants to change a rule copies the shipped file to `biome.json`
+and edits it.
+
+`--fix` writes the safe fixes and formats the files; without it the run only
+reports. `--no-audit` skips the audit; `--strict` passes through to it. The
+exit code is non-zero when either half fails.
+
 ## `vttforge audit`
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @vttforge/cli
 
-Scaffold, dev loop, release build and audit for Foundry VTT v14+ systems and modules.
+Scaffold, dev loop, release build, lint and audit for Foundry VTT v14+ systems and modules.
 
 ```bash
 pnpm create vttforge my-system        # same as: npx @vttforge/cli init my-system
@@ -13,6 +13,7 @@ vttforge init <name> [--type system|module] [--lang ts|js] [--id] [--title] [--d
                      [--author] [--license] [--yes] [--no-install] [--no-git]
 vttforge dev   [--foundry-data <path>] [--port <n>]
 vttforge build
+vttforge lint  [dir] [--fix] [--no-audit] [--strict]
 vttforge audit [dir] [--json] [--strict]
 vttforge migrate [dir] [--write] [--json]
 ```
@@ -22,6 +23,8 @@ vttforge migrate [dir] [--write] [--json]
 **`dev`** builds once, links `dist/` into Foundry's data directory under `Data/<systems|modules>/<id>/`, installs the `@vttforge/dev-module` companion, and watches. Save a template and the open sheet redraws in place; save a stylesheet and the CSS swaps. The first run asks where Foundry keeps its data and saves the answer to `.vttforge/config.json`; `--foundry-data` or `FOUNDRY_DATA_DIR` overrides it. If Foundry runs in a container it cannot follow the symlink, and the command prints the compose mount to use instead.
 
 **`build`** runs the production build and writes `<id>-<version>.zip` at the project root with the manifest at the top level, which is what foundryvtt.com expects. `LICENSE`, `README.md` and `CHANGELOG.md` go in when present.
+
+**`lint`** runs Biome, which ships with the CLI, over the project with a shipped config (a `biome.json` at the project root replaces it), then the audit. `--fix` writes the safe fixes and formats.
 
 **`audit`** checks the manifest, the source and the templates against the v14 breakages that fail quietly: the `flags.hotReload` shape, the removed grid fields, the v12 `styles` shape, `HTMLField`/`FilePathField` paths missing from `documentTypes`, `TypeDataModel` without `prepareBaseData`, a bad `_addDataFieldMigrations` override, token attributes that do not point at a `{ value, max }` field, a sheet template that opens a `<form>` the sheet already is, a declared subtype with no name in any language file, a `template.json` that erases the metadata `system.json` declares for the same type, and the v13 code v14 broke or deprecated: bare `mergeObject`-style globals, `-=` update keys, `rollMode`, whole-array `CONFIG.statusEffects` assignment, `legacyTransferral`, numeric Active Effect modes. `--json` for machines; `--strict` exits non-zero on any finding rather than only on HIGH.
 

--- a/packages/cli/lint/vttforge-biome.json
+++ b/packages/cli/lint/vttforge-biome.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**", "!**/dist", "!**/node_modules", "!**/packs", "!**/*.zip"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all",
+      "arrowParentheses": "always",
+      "bracketSpacing": true
+    },
+    "globals": [
+      "game",
+      "canvas",
+      "ui",
+      "foundry",
+      "CONFIG",
+      "CONST",
+      "Hooks",
+      "Handlebars",
+      "PIXI",
+      "ProseMirror",
+      "Actor",
+      "Item",
+      "ChatMessage",
+      "Combat",
+      "Combatant",
+      "Scene",
+      "Token",
+      "TokenDocument",
+      "Roll",
+      "Folder",
+      "Macro",
+      "Playlist",
+      "RollTable",
+      "JournalEntry",
+      "User",
+      "ActiveEffect",
+      "Cards",
+      "Card",
+      "Dialog",
+      "DialogV2",
+      "FormApplication",
+      "Application",
+      "fromUuid",
+      "fromUuidSync",
+      "_del",
+      "_replace"
+    ]
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "style": {
+        "useImportType": "error",
+        "useNodejsImportProtocol": "error"
+      },
+      "suspicious": {
+        "noConsole": {
+          "level": "warn",
+          "options": {
+            "allow": ["error", "warn"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vttforge/cli",
   "version": "0.11.0",
-  "description": "Scaffold, dev loop, release build and audit for Foundry VTT v14+ systems and modules.",
+  "description": "Scaffold, dev loop, release build, lint and audit for Foundry VTT v14+ systems and modules.",
   "type": "module",
   "license": "MIT",
   "homepage": "https://github.com/vttforge/vttforge#readme",
@@ -31,6 +31,7 @@
   "types": "./dist/index.d.mts",
   "files": [
     "dist",
+    "lint",
     "templates",
     "README.md",
     "CHANGELOG.md"
@@ -44,6 +45,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
+    "@biomejs/biome": "catalog:",
     "@clack/prompts": "catalog:",
     "archiver": "catalog:",
     "citty": "catalog:"

--- a/packages/cli/src/__tests__/cli-args.test.ts
+++ b/packages/cli/src/__tests__/cli-args.test.ts
@@ -11,7 +11,7 @@
 import type { ArgsDef } from 'citty';
 import { parseArgs } from 'citty';
 import { describe, expect, it } from 'vitest';
-import { audit, dev, init, main } from '../cli.js';
+import { audit, dev, init, lint, main } from '../cli.js';
 
 // `CommandDef.args` is declared as resolvable — it may be a function citty
 // awaits. Ours are always plain objects, so the cast is safe here and keeps
@@ -117,13 +117,37 @@ describe('audit args', () => {
 });
 
 describe('command tree', () => {
-  it('registers the five subcommands', () => {
+  it('registers the six subcommands', () => {
     expect(Object.keys(main.subCommands ?? {}).sort()).toEqual([
       'audit',
       'build',
       'dev',
       'init',
+      'lint',
       'migrate',
     ]);
+  });
+});
+
+describe('lint args', () => {
+  it('reports by default, with the audit on', () => {
+    const args = parse(lint, []);
+    expect(args.fix).toBe(false);
+    expect(args.audit).toBe(true);
+    expect(args.strict).toBe(false);
+  });
+
+  it('--fix writes, --no-audit skips the audit', () => {
+    const args = parse(lint, ['--fix', '--no-audit']);
+    expect(args.fix).toBe(true);
+    expect(args.audit).toBe(false);
+  });
+
+  it('takes a project path', () => {
+    expect(parse(lint, ['packages/my-system'])._[0]).toBe('packages/my-system');
+  });
+
+  it('is in the command tree', () => {
+    expect(Object.keys(main.subCommands ?? {})).toContain('lint');
   });
 });

--- a/packages/cli/src/__tests__/lint.test.ts
+++ b/packages/cli/src/__tests__/lint.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `vttforge lint` runs the Biome this package depends on. These cases spawn
+ * it for real against a throwaway project: a scaffolded project has no
+ * Biome of its own, so the shipped config and the resolved binary are the
+ * whole feature, and a mock would prove nothing.
+ */
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { biomeArgs, runLintCommand } from '../commands/lint.js';
+
+const UNFORMATTED = 'export const  hello = ( name ) => { return name }\n';
+const FORMATTED = 'export const hello = (name) => {\n  return name;\n};\n';
+
+describe('biomeArgs', () => {
+  it('reports with `ci` and fixes with `check --write`', () => {
+    expect(biomeArgs({ fix: false, configPath: null })).toEqual(['ci', '.']);
+    expect(biomeArgs({ fix: true, configPath: null })).toEqual(['check', '--write', '.']);
+  });
+
+  it('points Biome at the shipped config only when the project has none', () => {
+    expect(biomeArgs({ fix: false, configPath: '/cli/lint/vttforge-biome.json' })).toEqual([
+      'ci',
+      '.',
+      '--config-path=/cli/lint/vttforge-biome.json',
+    ]);
+  });
+});
+
+describe('runLintCommand', () => {
+  let cwd: string;
+  const silent = () => {};
+
+  beforeEach(async () => {
+    cwd = mkdtempSync(join(tmpdir(), 'vttforge-lint-'));
+    await writeFile(
+      join(cwd, 'package.json'),
+      `${JSON.stringify({ name: 'lint-fixture', type: 'module', private: true }, null, 2)}\n`,
+      'utf8',
+    );
+    await writeFile(
+      join(cwd, 'module.json'),
+      `${JSON.stringify(
+        {
+          id: 'lint-fixture',
+          type: 'module',
+          title: 'Lint fixture',
+          version: '0.0.1',
+          compatibility: { minimum: '14', verified: '14' },
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+    await mkdir(join(cwd, 'scripts'));
+    await writeFile(join(cwd, 'scripts', 'main.mjs'), UNFORMATTED, 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('refuses to run outside a project', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'vttforge-lint-empty-'));
+    try {
+      await expect(runLintCommand({ cwd: empty, write: silent })).rejects.toThrow(/package\.json/);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the shipped config and fails on an unformatted file', async () => {
+    const result = await runLintCommand({ cwd, write: silent });
+    expect(result.configPath).toMatch(/[\\/]lint[\\/]vttforge-biome\.json$/);
+    expect(result.biomeExitCode).not.toBe(0);
+    expect(result.exitCode).toBe(result.biomeExitCode);
+    // Untouched: a report-only run writes nothing.
+    expect(readFileSync(join(cwd, 'scripts', 'main.mjs'), 'utf8')).toBe(UNFORMATTED);
+  });
+
+  it('--fix formats the file and the run goes green', async () => {
+    const fixed = await runLintCommand({ cwd, fix: true, write: silent });
+    expect(fixed.biomeExitCode).toBe(0);
+    expect(readFileSync(join(cwd, 'scripts', 'main.mjs'), 'utf8')).toBe(FORMATTED);
+
+    const again = await runLintCommand({ cwd, write: silent });
+    expect(again.biomeExitCode).toBe(0);
+    expect(again.auditExitCode).toBe(0);
+    expect(again.exitCode).toBe(0);
+  });
+
+  it('a biome.json at the project root replaces the shipped config', async () => {
+    // Formatter off: the unformatted file is now fine by the project's own rules.
+    await writeFile(
+      join(cwd, 'biome.json'),
+      `${JSON.stringify({ formatter: { enabled: false }, linter: { enabled: false } }, null, 2)}\n`,
+      'utf8',
+    );
+    const result = await runLintCommand({ cwd, write: silent });
+    expect(result.configPath).toBeNull();
+    expect(result.biomeExitCode).toBe(0);
+  });
+
+  it('runs the audit after Biome and surfaces its exit code', async () => {
+    await writeFile(join(cwd, 'scripts', 'main.mjs'), FORMATTED, 'utf8');
+    // A bare v14-removed global: HIGH, so the audit fails the run.
+    await writeFile(
+      join(cwd, 'scripts', 'legacy.mjs'),
+      'export const merged = mergeObject({}, { a: 1 });\n',
+      'utf8',
+    );
+    const chunks: string[] = [];
+    const result = await runLintCommand({ cwd, write: (c) => chunks.push(c) });
+    expect(result.biomeExitCode).toBe(0);
+    expect(result.auditExitCode).toBe(1);
+    expect(result.exitCode).toBe(1);
+    expect(chunks.join('')).toMatch(/VTTF-AUDIT-011/);
+
+    const skipped = await runLintCommand({ cwd, audit: false, write: silent });
+    expect(skipped.auditExitCode).toBeNull();
+    expect(skipped.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/src/__tests__/public-surface.test.ts
+++ b/packages/cli/src/__tests__/public-surface.test.ts
@@ -38,6 +38,7 @@ const EXPERIMENTAL = new Set([
   'runBuild',
   'runDev',
   'runAuditCommand',
+  'runLintCommand',
   'readManifest',
   'emitZip',
 ]);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,6 +12,7 @@ import { runAuditCommand } from './commands/audit.js';
 import { runBuild } from './commands/build.js';
 import { runDev } from './commands/dev.js';
 import { runInit, ScaffoldError } from './commands/init.js';
+import { runLintCommand } from './commands/lint.js';
 import { runMigrateCommand } from './commands/migrate.js';
 import { VTTFORGE_CLI_VERSION } from './index.js';
 
@@ -158,6 +159,51 @@ export const build = defineCommand({
   },
 });
 
+export const lint = defineCommand({
+  meta: {
+    name: 'lint',
+    description: 'Run Biome (shipped with the CLI) over the project, then the v14 audit',
+  },
+  args: {
+    path: {
+      type: 'positional',
+      description: 'Project root to lint (defaults to the current directory)',
+      required: false,
+    },
+    fix: {
+      type: 'boolean',
+      default: false,
+      description: 'Write the safe fixes and format the files instead of only reporting',
+    },
+    // Affirmative flag with a true default, so `--no-audit` parses as
+    // `audit: false` (same pattern as `--no-install` on init).
+    audit: {
+      type: 'boolean',
+      default: true,
+      description: 'Run `vttforge audit` after Biome (use --no-audit to skip)',
+    },
+    strict: {
+      type: 'boolean',
+      default: false,
+      description: 'For the audit: exit non-zero on any finding, not only HIGH',
+    },
+  },
+  async run({ args }) {
+    try {
+      const result = await runLintCommand({
+        cwd: typeof args.path === 'string' ? args.path : undefined,
+        fix: args.fix === true,
+        audit: args.audit !== false,
+        strict: args.strict === true,
+      });
+      if (result.exitCode !== 0) process.exitCode = result.exitCode;
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+    }
+  },
+});
+
 export const audit = defineCommand({
   meta: {
     name: 'audit',
@@ -261,12 +307,13 @@ export const main = defineCommand({
     name: 'vttforge',
     version: VTTFORGE_CLI_VERSION,
     description:
-      'VTTForge CLI: scaffold, dev, build, audit and migrate for Foundry v14+ systems and modules',
+      'VTTForge CLI: scaffold, dev, build, lint, audit and migrate for Foundry v14+ systems and modules',
   },
   subCommands: {
     init,
     dev,
     build,
+    lint,
     audit,
     migrate,
   },

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,0 +1,149 @@
+/**
+ * `vttforge lint`: Biome over the project, then the v14 audit.
+ *
+ * Biome ships as a dependency of this package, so a scaffolded project has
+ * a linter and a formatter without installing or configuring one. The
+ * config it runs with is `<cli-pkg>/lint/vttforge-biome.json` unless the project
+ * has its own `biome.json` / `biome.jsonc` at its root, in which case that
+ * one wins and the shipped config is not read at all. A project that wants
+ * to tweak a rule copies the shipped file and edits it.
+ *
+ * `--fix` writes the safe fixes and formats the files; without it the run
+ * only reports. The audit runs after Biome either way (`--no-audit` skips
+ * it), and the exit code is non-zero when either half fails.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runAuditCommand } from './audit.js';
+
+export interface LintOptions {
+  /** Project root to lint. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Write the safe fixes and format the files. Default false: report only. */
+  fix?: boolean;
+  /** Run `vttforge audit` after Biome. Default true. */
+  audit?: boolean;
+  /** Passed to the audit: any finding fails, not only HIGH. Default false. */
+  strict?: boolean;
+  /** Custom writer for the audit report (tests). Defaults to process.stdout.write. */
+  write?: (chunk: string) => void;
+}
+
+export interface LintResult {
+  /** Exit code of the Biome run. */
+  biomeExitCode: number;
+  /** Exit code of the audit, or `null` when it was skipped. */
+  auditExitCode: 0 | 1 | null;
+  /** Non-zero when either half failed. */
+  exitCode: number;
+  /** The shipped Biome config file in use. `null` means the project's own. */
+  configPath: string | null;
+}
+
+/**
+ * @internal Implementation detail of the `vttforge` binary. Not supported for
+ * outside use, and going away in the next major.
+ */
+export class BiomeNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BiomeNotFoundError';
+  }
+}
+
+/**
+ * The Biome config shipped with the CLI, resolved from the built module.
+ *
+ * The file is not named `biome.json` on purpose: Biome treats a file with
+ * that name as a nested root config and refuses to run, which would break
+ * a project (or this monorepo) that holds the CLI inside another
+ * Biome-rooted tree. `--config-path` accepts any file path.
+ */
+export const SHIPPED_CONFIG_NAME = 'vttforge-biome.json';
+
+function shippedConfig(): string {
+  const here = fileURLToPath(import.meta.url);
+  // dist/bin.mjs → ../ = dist/, ../../ = package root. In tests the file
+  // is src/commands/lint.ts, so the same walk must also land at the root.
+  const fromDist = resolve(here, '..', '..', 'lint', SHIPPED_CONFIG_NAME);
+  if (existsSync(fromDist)) return fromDist;
+  return resolve(here, '..', '..', '..', 'lint', SHIPPED_CONFIG_NAME);
+}
+
+/** The project's own config wins when it has one. */
+function projectConfig(cwd: string): string | null {
+  for (const name of ['biome.json', 'biome.jsonc']) {
+    const file = join(cwd, name);
+    if (existsSync(file)) return file;
+  }
+  return null;
+}
+
+/** The Biome bin shim, resolved from this package's own dependency graph. */
+function biomeBin(): string {
+  const require = createRequire(import.meta.url);
+  try {
+    return require.resolve('@biomejs/biome/bin/biome');
+  } catch {
+    throw new BiomeNotFoundError(
+      'Could not resolve @biomejs/biome from @vttforge/cli. Reinstall the CLI (it ships Biome as a dependency).',
+    );
+  }
+}
+
+/** The argv for Biome: `ci .` to report, `check --write .` to fix. */
+export function biomeArgs(opts: { fix: boolean; configPath: string | null }): string[] {
+  const args = opts.fix ? ['check', '--write', '.'] : ['ci', '.'];
+  if (opts.configPath) args.push(`--config-path=${opts.configPath}`);
+  return args;
+}
+
+function runBiome(cwd: string, args: string[]): Promise<number> {
+  const bin = biomeBin();
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(process.execPath, [bin, ...args], {
+      cwd,
+      stdio: 'inherit',
+      env: process.env,
+      shell: false,
+    });
+    child.on('error', rejectRun);
+    child.on('exit', (code) => resolveRun(code ?? 1));
+  });
+}
+
+/**
+ * @experimental Shape is unproven: no consumer has asked for this yet. It can
+ * change in a minor.
+ */
+export async function runLintCommand(options: LintOptions = {}): Promise<LintResult> {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const fix = options.fix === true;
+  const audit = options.audit !== false;
+
+  if (!existsSync(join(cwd, 'package.json'))) {
+    throw new Error(
+      `No package.json found at ${cwd}. Run \`vttforge lint\` from inside a scaffolded project.`,
+    );
+  }
+
+  const configPath = projectConfig(cwd) === null ? shippedConfig() : null;
+  const biomeExitCode = await runBiome(cwd, biomeArgs({ fix, configPath }));
+
+  let auditExitCode: 0 | 1 | null = null;
+  if (audit) {
+    const result = await runAuditCommand({
+      cwd,
+      strict: options.strict === true,
+      write: options.write,
+    });
+    auditExitCode = result.exitCode;
+  }
+
+  const exitCode = biomeExitCode !== 0 ? biomeExitCode : (auditExitCode ?? 0);
+  return { biomeExitCode, auditExitCode, exitCode, configPath };
+}

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -44,11 +44,7 @@ export interface LintResult {
   configPath: string | null;
 }
 
-/**
- * @internal Implementation detail of the `vttforge` binary. Not supported for
- * outside use, and going away in the next major.
- */
-export class BiomeNotFoundError extends Error {
+class BiomeNotFoundError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'BiomeNotFoundError';
@@ -63,7 +59,7 @@ export class BiomeNotFoundError extends Error {
  * a project (or this monorepo) that holds the CLI inside another
  * Biome-rooted tree. `--config-path` accepts any file path.
  */
-export const SHIPPED_CONFIG_NAME = 'vttforge-biome.json';
+const SHIPPED_CONFIG_NAME = 'vttforge-biome.json';
 
 function shippedConfig(): string {
   const here = fileURLToPath(import.meta.url);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -42,6 +42,9 @@ export { runDev } from './commands/dev.js';
 export type { InitOptions, ResolvedInitOptions, TemplateVariant } from './commands/init.js';
 /** Supported: scaffold a project. This is what `create-vttforge` calls. */
 export { runInit, ScaffoldError } from './commands/init.js';
+export type { LintOptions, LintResult } from './commands/lint.js';
+/** @experimental The command wrapper around Biome plus the audit. */
+export { runLintCommand } from './commands/lint.js';
 export type { FoundryManifest, PackageType } from './manifest.js';
 /** @experimental Reads `system.json` / `module.json`. Useful, unproven. */
 export { readManifest } from './manifest.js';

--- a/packages/cli/templates/module-js/README.md
+++ b/packages/cli/templates/module-js/README.md
@@ -60,7 +60,9 @@ api.noteType; // "{{ID}}.note"
 ## Checks
 
 ```bash
-npx vttforge audit    # manifest + source against the v14 list of quiet breakages
+pnpm lint             # Biome (shipped with the CLI) over the project, then the v14 audit
+pnpm format           # the same, writing the safe fixes and formatting
+npx vttforge audit    # the audit alone: manifest + source against the v14 list of quiet breakages
 ```
 
 ## Releasing

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -8,13 +8,15 @@
   "author": "{{AUTHOR}}",
   "scripts": {
     "build": "vttforge build",
-    "dev": "vttforge dev"
+    "dev": "vttforge dev",
+    "lint": "vttforge lint",
+    "format": "vttforge lint --fix"
   },
   "dependencies": {
     "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.11.0",
+    "@vttforge/cli": "^0.12.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/README.md
+++ b/packages/cli/templates/module-ts/README.md
@@ -65,7 +65,9 @@ api.noteType; // "{{ID}}.note"
 
 ```bash
 pnpm typecheck        # tsc against the real @vttforge/core types
-npx vttforge audit    # manifest + source against the v14 list of quiet breakages
+pnpm lint             # Biome (shipped with the CLI) over the project, then the v14 audit
+pnpm format           # the same, writing the safe fixes and formatting
+npx vttforge audit    # the audit alone: manifest + source against the v14 list of quiet breakages
 ```
 
 ## Releasing

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -9,13 +9,15 @@
   "scripts": {
     "build": "vttforge build",
     "dev": "vttforge dev",
+    "lint": "vttforge lint",
+    "format": "vttforge lint --fix",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.11.0",
+    "@vttforge/cli": "^0.12.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/module-ts/scripts/enricher.ts
+++ b/packages/cli/templates/module-ts/scripts/enricher.ts
@@ -35,7 +35,9 @@ export const noteEnricher: EnricherRegistration = {
     link.className = '{{ID}}-note-link';
     link.dataset.noteId = id;
     link.draggable = false;
-    link.append(Object.assign(document.createElement('i'), { className: 'fa-solid fa-note-sticky' }));
+    link.append(
+      Object.assign(document.createElement('i'), { className: 'fa-solid fa-note-sticky' }),
+    );
     link.append(note.name);
     return link;
   },

--- a/packages/cli/templates/module-ts/tsconfig.json
+++ b/packages/cli/templates/module-ts/tsconfig.json
@@ -14,11 +14,6 @@
     "resolveJsonModule": true,
     "allowImportingTsExtensions": false
   },
-  "include": [
-    "scripts/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  "include": ["scripts/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/cli/templates/system-js/README.md
+++ b/packages/cli/templates/system-js/README.md
@@ -53,7 +53,9 @@ loses the sheet choice on every document already using it.
 ## Checks
 
 ```bash
-npx vttforge audit    # manifest + source against the v14 list of quiet breakages
+pnpm lint             # Biome (shipped with the CLI) over the project, then the v14 audit
+pnpm format           # the same, writing the safe fixes and formatting
+npx vttforge audit    # the audit alone: manifest + source against the v14 list of quiet breakages
 ```
 
 ## Releasing

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -8,14 +8,16 @@
   "author": "{{AUTHOR}}",
   "scripts": {
     "build": "vttforge build",
-    "dev": "vttforge dev"
+    "dev": "vttforge dev",
+    "lint": "vttforge lint",
+    "format": "vttforge lint --fix"
   },
   "dependencies": {
     "@vttforge/core": "^0.15.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.11.0",
+    "@vttforge/cli": "^0.12.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-js/scripts/data/character-data.mjs
+++ b/packages/cli/templates/system-js/scripts/data/character-data.mjs
@@ -60,12 +60,36 @@ const defineCharacterSchema = () => {
       cha: score(),
     }),
     health: new f.SchemaField({
-      value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
-      max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
+      value: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 10,
+      }),
+      max: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 10,
+      }),
     }),
     power: new f.SchemaField({
-      value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
-      max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
+      value: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 5,
+      }),
+      max: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 5,
+      }),
     }),
     biography: new f.HTMLField(),
   };

--- a/packages/cli/templates/system-js/scripts/sheets/character-sheet.mjs
+++ b/packages/cli/templates/system-js/scripts/sheets/character-sheet.mjs
@@ -123,7 +123,9 @@ export class CharacterSheet extends BaseActorSheet() {
   async onDropItem(item, _event) {
     if (item?.type !== 'gear') {
       ui.notifications?.warn(
-        game.i18n.format('{{LOCALE_PREFIX}}.Sheet.Drop.rejected', { type: item?.type ?? 'unknown' }),
+        game.i18n.format('{{LOCALE_PREFIX}}.Sheet.Drop.rejected', {
+          type: item?.type ?? 'unknown',
+        }),
       );
       return false;
     }

--- a/packages/cli/templates/system-js/scripts/sheets/gear-sheet.mjs
+++ b/packages/cli/templates/system-js/scripts/sheets/gear-sheet.mjs
@@ -58,10 +58,11 @@ export class GearSheet extends BaseItemSheet() {
     context.item = item;
     context.system = item.system;
     context.isEditable = this.isEditable;
-    context.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-      item.system.description,
-      { relativeTo: item, secrets: item.isOwner },
-    );
+    context.enrichedDescription =
+      await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.system.description, {
+        relativeTo: item,
+        secrets: item.isOwner,
+      });
     return context;
   }
 }

--- a/packages/cli/templates/system-ts/README.md
+++ b/packages/cli/templates/system-ts/README.md
@@ -53,7 +53,9 @@ for is yours to know. Each sheet here narrows it once in a getter (`actor`,
 
 ```bash
 pnpm typecheck        # tsc against the real @vttforge/core types
-npx vttforge audit    # manifest + source against the v14 list of quiet breakages
+pnpm lint             # Biome (shipped with the CLI) over the project, then the v14 audit
+pnpm format           # the same, writing the safe fixes and formatting
+npx vttforge audit    # the audit alone: manifest + source against the v14 list of quiet breakages
 ```
 
 ## Releasing

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "build": "vttforge build",
     "dev": "vttforge dev",
+    "lint": "vttforge lint",
+    "format": "vttforge lint --fix",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -16,7 +18,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.11.0",
+    "@vttforge/cli": "^0.12.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-ts/scripts/data/character-data.ts
+++ b/packages/cli/templates/system-ts/scripts/data/character-data.ts
@@ -62,12 +62,36 @@ const defineCharacterSchema = () => {
       cha: score(),
     }),
     health: new f.SchemaField({
-      value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
-      max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 10 }),
+      value: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 10,
+      }),
+      max: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 10,
+      }),
     }),
     power: new f.SchemaField({
-      value: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
-      max: new f.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 5 }),
+      value: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 5,
+      }),
+      max: new f.NumberField({
+        required: true,
+        nullable: false,
+        integer: true,
+        min: 0,
+        initial: 5,
+      }),
     }),
     biography: new f.HTMLField(),
   };

--- a/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
@@ -112,7 +112,9 @@ export class CharacterSheet extends BaseActorSheet() {
     },
   };
 
-  static override DRAG_DROP = [{ dragSelector: '.sh-item[draggable=true]', dropSelector: '.sh-body' }];
+  static override DRAG_DROP = [
+    { dragSelector: '.sh-item[draggable=true]', dropSelector: '.sh-body' },
+  ];
 
   /**
    * The actor this sheet is for.
@@ -173,7 +175,11 @@ export class CharacterSheet extends BaseActorSheet() {
   // ApplicationV2 declares action handlers static and calls them with `this`
   // bound to the sheet instance. `this: CharacterSheet` says so to TypeScript.
 
-  static async _onRollAbility(this: CharacterSheet, _event: Event, target: HTMLElement): Promise<void> {
+  static async _onRollAbility(
+    this: CharacterSheet,
+    _event: Event,
+    target: HTMLElement,
+  ): Promise<void> {
     const key = target.dataset.ability;
     if (!key) return;
     const { actor } = this;
@@ -195,7 +201,11 @@ export class CharacterSheet extends BaseActorSheet() {
     );
   }
 
-  static async _onDeleteItem(this: CharacterSheet, _event: Event, target: HTMLElement): Promise<void> {
+  static async _onDeleteItem(
+    this: CharacterSheet,
+    _event: Event,
+    target: HTMLElement,
+  ): Promise<void> {
     const id = target.closest<HTMLElement>('[data-item-id]')?.dataset.itemId;
     if (!id) return;
     await this.actor.items.get(id)?.delete();

--- a/packages/cli/templates/system-ts/scripts/sheets/gear-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/gear-sheet.ts
@@ -65,10 +65,11 @@ export class GearSheet extends BaseItemSheet() {
     context.item = item;
     context.system = item.system;
     context.isEditable = this.isEditable;
-    context.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-      item.system.description,
-      { relativeTo: item, secrets: item.isOwner },
-    );
+    context.enrichedDescription =
+      await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.system.description, {
+        relativeTo: item,
+        secrets: item.isOwner,
+      });
     return context;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.5.11
       '@clack/prompts':
         specifier: 'catalog:'
         version: 1.7.0


### PR DESCRIPTION
## What

`vttforge lint [dir] [--fix] [--no-audit] [--strict]`.

Biome ships as a dependency of `@vttforge/cli` with a config at `lint/vttforge-biome.json` (the recommended rules, the house formatting, the Foundry globals declared), so a scaffolded project lints and formats without installing or configuring anything. A `biome.json` or `biome.jsonc` at the project root replaces the shipped config outright. The audit runs after Biome; the exit code is non-zero when either half fails.

The shipped file is not named `biome.json` on purpose: Biome treats a file with that name as a nested root config and refuses to run when the CLI sits inside another Biome-rooted tree, this monorepo included. `--config-path` takes any file path.

The four templates gain `lint` and `format` scripts and are formatted the way the shipped config wants, so a fresh project is green on its first run. The CLI pin in the templates moves to `^0.12.0` for the minor.

## Verified

- `pnpm typecheck`, `pnpm test` (465 in the CLI, the new `lint.test.ts` spawns the real Biome), `pnpm build`, `pnpm lint`, `pnpm publint`.
- Scaffolded all four variants with the built CLI and ran `vttforge lint` in each: exit 0 with the audit report; a deliberately broken file fails, `--fix` repairs it, the next run is green.

Changeset: `@vttforge/cli` minor.