### PR TITLE
feat(cli): migrate --sheets writes the V2 sheet next to each v1 sheet

### DIFF
--- a/.changeset/cli-migrate-sheets.md
+++ b/.changeset/cli-migrate-sheets.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/cli": minor
+---
+
+`vttforge migrate --sheets`: next to each Application v1 sheet class (`ActorSheet`, `ItemSheet`), write a file with the same class on `BaseActorSheet` / `BaseItemSheet`. `defaultOptions`, `tabs`, `dragDrop` and `template` become the V2 statics, `getData` becomes `_prepareContext`, each `html.find(sel).click(handler)` becomes an `actions` entry with the handler on the `(event, target)` signature, other events move to `_onRender`, the drop handlers take the resolved document, and the jQuery idioms with a DOM equivalent are rewritten. What cannot be decided is a `// TODO(migrate)` line, listed in the report. The templates the class names get the `data-action` and tab attributes the new class reads. Preview by default; `--write` writes the new files and the template edits and never touches the original class.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -201,13 +201,24 @@ the ids read from the template; `dragDrop` as `DRAG_DROP`; `template` as
 `actions` entry named after the selector, with the handler's signature
 changed to `(event, target)`; other events (`dblclick`, `change`, ...) as
 listeners in `_onRender`; `_onDropItem` / `_onDropActor` as `onDropItem` /
-`onDropActor`; `event.currentTarget`, `$(...)`, `.data(...)` and `html.find`
-as their DOM equivalents; `Dialog.confirm` as `DialogV2.confirm`.
+`onDropActor`, with the old payload argument read as `item.toDragData()` and
+the old `super._onDropItem` call as the `createEmbeddedDocuments` it used to
+make; `event.currentTarget`, `$(...)`, `.data(...)`, `.parents(...)` and `html.find`
+as their DOM equivalents (`html.find` becomes `this.element.querySelectorAll`, so
+`.length` and `[0]` keep working); `Dialog.confirm` as `DialogV2.confirm`.
 
 What is left as a `// TODO(migrate)` line, and listed in the report with its
 line number: `new Dialog({...})`, `_updateObject`, jQuery calls with no plain
 DOM equivalent, a `get template()` that picks the template at runtime, tab
-ids that were not found in the template.
+ids that were not found in the template, and the v1 lifecycle overrides
+(`setPosition`, `_getHeaderButtons`, `_render`, ...) that ApplicationV2
+replaces with its own hooks.
+
+The generated file is a draft to read, not code to trust: run
+`vttforge lint --fix` on it, then work through the `TODO(migrate)` lines. On
+a real v1 system the hand edits were the per-type template choice, the root
+`<form>` in each sheet template, and one `setPosition` override; everything
+else ran as generated.
 
 The templates the class names get `data-action="<name>"` on the elements
 that matched each selector, `data-action="vttforgeTab"` and `data-group` on

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -179,3 +179,37 @@ report ends with the `documentTypes` block to paste into the manifest and
 the registration to add at `init`. An existing file is never overwritten.
 Delete `template.json` once every type has a model: while it exists, Foundry
 resets each listed type's `documentTypes` entry on every start.
+
+### `--sheets`
+
+```bash
+vttforge migrate --sheets [--lang js|ts] [--write]
+```
+
+Application v1 sheets (`ActorSheet`, `ItemSheet`) still run on v14 and are
+removed in v16. `--sheets` writes, next to each such class, a file with the
+same name and `.v2` before the extension, holding the class on
+`BaseActorSheet` / `BaseItemSheet` from `@vttforge/core`. The original is
+not touched; the report says where to point `registerSheet` once you have
+read the result.
+
+What is carried over mechanically: `defaultOptions` (classes, size,
+`resizable`, `submitOnChange`) as `DEFAULT_OPTIONS`; `tabs` as `TABS` with
+the ids read from the template; `dragDrop` as `DRAG_DROP`; `template` as
+`PARTS`; `getData` as `_prepareContext` with `actor`/`item`, `system` and
+`items` set on the context; every `html.find(sel).click(handler)` as an
+`actions` entry named after the selector, with the handler's signature
+changed to `(event, target)`; other events (`dblclick`, `change`, ...) as
+listeners in `_onRender`; `_onDropItem` / `_onDropActor` as `onDropItem` /
+`onDropActor`; `event.currentTarget`, `$(...)`, `.data(...)` and `html.find`
+as their DOM equivalents; `Dialog.confirm` as `DialogV2.confirm`.
+
+What is left as a `// TODO(migrate)` line, and listed in the report with its
+line number: `new Dialog({...})`, `_updateObject`, jQuery calls with no plain
+DOM equivalent, a `get template()` that picks the template at runtime, tab
+ids that were not found in the template.
+
+The templates the class names get `data-action="<name>"` on the elements
+that matched each selector, `data-action="vttforgeTab"` and `data-group` on
+the tab links, and `data-group` on the panes. A root `<form>` is reported and
+left in place: the old class still renders that template.

--- a/apps/docs/recipes/migrating-to-v14.md
+++ b/apps/docs/recipes/migrating-to-v14.md
@@ -79,6 +79,12 @@ goes away in v16. Declare types in `documentTypes` and register a
 `TypeDataModel` per type; the SDK's `registerSystem` already does the second
 half.
 
+**Application v1 sheets are on borrowed time.** `ActorSheet` and `ItemSheet`
+still run on v14 and go away in v16. `vttforge migrate --sheets` writes the
+first draft of the move to `BaseActorSheet` / `BaseItemSheet` next to each
+class, with the `data-action` attributes its templates need; see the CLI
+reference for what it decides and what it leaves as a `TODO`.
+
 **Header controls and context menus** use `label`, `visible` and `onClick` in
 place of `name`, `condition` and `callback`. The old keys warn until v16.
 

--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,7 @@
     ".": {},
     "packages/*": {},
     "packages/cli": {
-      "ignore": ["templates/**"]
+      "ignore": ["templates/**", "src/__tests__/migrate/fixtures/**"]
     },
     "packages/create-vttforge": {},
     "packages/styles": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ vttforge dev   [--foundry-data <path>] [--port <n>]
 vttforge build
 vttforge lint  [dir] [--fix] [--no-audit] [--strict]
 vttforge audit [dir] [--json] [--strict]
-vttforge migrate [dir] [--write] [--json]
+vttforge migrate [dir] [--write] [--json] [--data-models] [--sheets]
 ```
 
 **`init`** writes a runnable system or module into `<name>/` from one of four templates (`system-ts`, `system-js`, `module-ts`, `module-js`). It asks for what you did not pass, or takes defaults with `--yes`, so it works in CI. It detects the package manager that invoked it (`pnpm`, `npm`, `bun`, `yarn`), installs, and runs `git init`.
@@ -28,7 +28,7 @@ vttforge migrate [dir] [--write] [--json]
 
 **`audit`** checks the manifest, the source and the templates against the v14 breakages that fail quietly: the `flags.hotReload` shape, the removed grid fields, the v12 `styles` shape, `HTMLField`/`FilePathField` paths missing from `documentTypes`, `TypeDataModel` without `prepareBaseData`, a bad `_addDataFieldMigrations` override, token attributes that do not point at a `{ value, max }` field, a sheet template that opens a `<form>` the sheet already is, a declared subtype with no name in any language file, a `template.json` that erases the metadata `system.json` declares for the same type, and the v13 code v14 broke or deprecated: bare `mergeObject`-style globals, `-=` update keys, `rollMode`, whole-array `CONFIG.statusEffects` assignment, `legacyTransferral`, numeric Active Effect modes. `--json` for machines; `--strict` exits non-zero on any finding rather than only on HIGH.
 
-**`migrate`** rewrites a v13 project for v14: the removed globals, `-=` keys, `rollMode`, context-menu keys, numeric effect modes, whole-array `CONFIG.statusEffects`, `legacyTransferral`, the core-sheet unregister lines, and the manifest's `type` and `compatibility`. It reports by default and writes with `--write`; what it will not decide it lists as needing one.
+**`migrate`** rewrites a v13 project for v14: the removed globals, `-=` keys, `rollMode`, context-menu keys, numeric effect modes, whole-array `CONFIG.statusEffects`, `legacyTransferral`, the core-sheet unregister lines, and the manifest's `type` and `compatibility`. It reports by default and writes with `--write`; what it will not decide it lists as needing one. `--data-models` writes a data model per `template.json` type; `--sheets` writes a V2 sheet file on the SDK bases next to each Application v1 sheet class, with the `data-action` attributes its templates need.
 
 ## As a library
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,6 +45,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
+    "@babel/parser": "catalog:",
     "@biomejs/biome": "catalog:",
     "@clack/prompts": "catalog:",
     "archiver": "catalog:",
@@ -52,6 +53,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@babel/types": "catalog:",
     "@types/archiver": "catalog:",
     "@types/node": "catalog:",
     "@vttforge/dev-module": "workspace:*",

--- a/packages/cli/src/__tests__/cli-args.test.ts
+++ b/packages/cli/src/__tests__/cli-args.test.ts
@@ -11,7 +11,7 @@
 import type { ArgsDef } from 'citty';
 import { parseArgs } from 'citty';
 import { describe, expect, it } from 'vitest';
-import { audit, dev, init, lint, main } from '../cli.js';
+import { audit, dev, init, lint, main, migrate } from '../cli.js';
 
 // `CommandDef.args` is declared as resolvable — it may be a function citty
 // awaits. Ours are always plain objects, so the cast is safe here and keeps
@@ -149,5 +149,14 @@ describe('lint args', () => {
 
   it('is in the command tree', () => {
     expect(Object.keys(main.subCommands ?? {})).toContain('lint');
+  });
+});
+
+describe('migrate args', () => {
+  it('--sheets is off by default and parses with --write', () => {
+    expect(parse(migrate, []).sheets).toBe(false);
+    const args = parse(migrate, ['--sheets', '--write']);
+    expect(args.sheets).toBe(true);
+    expect(args.write).toBe(true);
   });
 });

--- a/packages/cli/src/__tests__/migrate/__snapshots__/sheets.test.ts.snap
+++ b/packages/cli/src/__tests__/migrate/__snapshots__/sheets.test.ts.snap
@@ -43,8 +43,11 @@ export class HeroSheet extends BaseActorSheet() {
   async _prepareContext(options) {
     const data = await super._prepareContext(options);
     data.actor = this.document;
+    data.data = this.document;
     data.system = this.document.system;
     data.items = [...this.document.items];
+    data.editable = this.isEditable;
+    data.owner = this.document.isOwner;
     data.items = data.items.sort((a, b) => a.name.localeCompare(b.name));
     data.enrichedNotes = await TextEditor.enrichHTML(this.actor.system.notes, { async: true });
     return data;
@@ -58,7 +61,7 @@ export class HeroSheet extends BaseActorSheet() {
     }
     for (const el of this.element.querySelectorAll('[name="system.armed"]')) {
       el.addEventListener('change', (e) => {
-        if (e.target.checked) this.element.querySelector('[name="system.hidden"]')[0].checked = false;
+        if (e.target.checked) this.element.querySelectorAll('[name="system.hidden"]')[0].checked = false;
       });
     }
   }
@@ -87,12 +90,20 @@ export class HeroSheet extends BaseActorSheet() {
     this.actor.items.get(li.dataset.itemId).sheet.render(true);
   }
 
+  // TODO(migrate): setPosition is an Application v1 lifecycle override; ApplicationV2 sizes, submits and builds its header itself. Review it against the V2 method of the same job, or delete it
+  setPosition(options = {}) {
+    const position = super.setPosition(options);
+    // TODO(migrate): jQuery left here; use the DOM on \`target\` / \`this.element\`
+    this.element.querySelectorAll('.sheet-body').css('height', position.height - 100);
+    return position;
+  }
+
   _onDragStart(event) {
     const id = event.currentTarget.dataset.itemId;
     event.dataTransfer.setData('text/plain', JSON.stringify(this.actor.items.get(id).toDragData()));
   }
 
-  // TODO(migrate): the base hands the resolved Item as \`droppedItem\`; \`itemData\` no longer exists. The old super call created it on the actor, which is what the createEmbeddedDocuments line does now (a drop from the same actor used to re-sort instead). Return true when the drop was handled, undefined to let the base do its default
+  // TODO(migrate): the base hands the resolved Item as \`droppedItem\`; the old \`itemData\` payload is now \`droppedItem.toDragData()\`, read \`droppedItem\` directly where you can. The old super call created it on the actor, which is what the createEmbeddedDocuments line does now (a drop from the same actor used to re-sort instead). Return true when the drop was handled, undefined to let the base do its default
   async onDropItem(droppedItem, event) {
     const item = ((await this.document.createEmbeddedDocuments('Item', [droppedItem.toObject()])) || []).pop();
     if (item) helper(item);

--- a/packages/cli/src/__tests__/migrate/__snapshots__/sheets.test.ts.snap
+++ b/packages/cli/src/__tests__/migrate/__snapshots__/sheets.test.ts.snap
@@ -1,0 +1,108 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`planSheetFile > matches the snapshot 1`] = `
+"import { BaseActorSheet } from '@vttforge/core';
+import { helper } from '../utils.mjs';
+
+const { DialogV2 } = foundry.applications.api;
+
+export class HeroSheet extends BaseActorSheet() {
+  /** @override */
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    super.DEFAULT_OPTIONS,
+    {
+      classes: ['hero', 'sheet', 'actor'],
+      position: { width: 600, height: 750 },
+      form: { submitOnChange: true },
+      actions: {
+        itemCreate: HeroSheet.prototype._onItemCreate,
+        itemDelete: HeroSheet.prototype._onItemDelete,
+        restButton: HeroSheet.prototype._onRestButton,
+      },
+    },
+    { inplace: false },
+  );
+
+  /** @override */
+  static TABS = {
+    primary: { tabs: [{ id: 'items' }, { id: 'notes' }], initial: 'items' },
+  };
+
+  /** @override */
+  static DRAG_DROP = [{ dragSelector: '.item-row', dropSelector: null }];
+
+  /** @override */
+  static PARTS = {
+    sheet: { template: 'systems/hero/templates/actor-sheet.html' },
+  };
+
+  get actor() {
+    return this.document;
+  }
+
+  async _prepareContext(options) {
+    const data = await super._prepareContext(options);
+    data.actor = this.document;
+    data.system = this.document.system;
+    data.items = [...this.document.items];
+    data.items = data.items.sort((a, b) => a.name.localeCompare(b.name));
+    data.enrichedNotes = await TextEditor.enrichHTML(this.actor.system.notes, { async: true });
+    return data;
+  }
+
+  /** @override */
+  _onRender(context, options) {
+    super._onRender(context, options);
+    for (const el of this.element.querySelectorAll('.item-name')) {
+      el.addEventListener('dblclick', (event) => this._onItemEdit(event));
+    }
+  }
+
+  async _onItemCreate(event, target) {
+    event.preventDefault();
+    // TODO(migrate): Dialog v1 (removed in v16); rebuild with DialogV2.prompt / DialogV2.wait, buttons as { action, label, callback }
+    new Dialog({
+      title: 'New item',
+      content: '<input name="name">',
+      buttons: {
+        create: {
+          label: 'Create',
+          callback: (html) =>
+            this.actor.createEmbeddedDocuments('Item', [
+              // TODO(migrate): jQuery left here; use the DOM on \`target\` / \`this.element\`
+              { name: html.find('[name=name]').val(), type: 'item' },
+            ]),
+        },
+      },
+    }).render(true);
+  }
+
+  _onItemEdit(event) {
+    const li = event.currentTarget.closest('.item-row');
+    this.actor.items.get(li.dataset.itemId).sheet.render(true);
+  }
+
+  _onDragStart(event) {
+    const id = event.currentTarget.dataset.itemId;
+    event.dataTransfer.setData('text/plain', JSON.stringify(this.actor.items.get(id).toDragData()));
+  }
+
+  // TODO(migrate): the base hands the resolved Item as \`droppedItem\`; \`itemData\` no longer exists. The old super call created it on the actor, which is what the createEmbeddedDocuments line does now (a drop from the same actor used to re-sort instead). Return true when the drop was handled, undefined to let the base do its default
+  async onDropItem(droppedItem, event) {
+    const item = ((await this.document.createEmbeddedDocuments('Item', [droppedItem.toObject()])) || []).pop();
+    if (item) helper(item);
+    return item;
+  }
+
+  async _onItemDelete(ev, target) {
+    const li = target.closest('.item-row');
+    const ok = await DialogV2.confirm({ window: { title: 'Delete' }, content: '<p>Sure?</p>', yes: { callback: () => true }, no: { callback: () => false } });
+    if (ok) await this.actor.deleteEmbeddedDocuments('Item', [li.dataset.itemId]);
+  }
+
+  async _onRestButton(event, target) {
+    await this.actor.update({ 'system.hp.value': this.actor.system.hp.max });
+  }
+}
+"
+`;

--- a/packages/cli/src/__tests__/migrate/__snapshots__/sheets.test.ts.snap
+++ b/packages/cli/src/__tests__/migrate/__snapshots__/sheets.test.ts.snap
@@ -56,6 +56,11 @@ export class HeroSheet extends BaseActorSheet() {
     for (const el of this.element.querySelectorAll('.item-name')) {
       el.addEventListener('dblclick', (event) => this._onItemEdit(event));
     }
+    for (const el of this.element.querySelectorAll('[name="system.armed"]')) {
+      el.addEventListener('change', (e) => {
+        if (e.target.checked) this.element.querySelector('[name="system.hidden"]')[0].checked = false;
+      });
+    }
   }
 
   async _onItemCreate(event, target) {

--- a/packages/cli/src/__tests__/migrate/fixtures/v1-actor-sheet.mjs
+++ b/packages/cli/src/__tests__/migrate/fixtures/v1-actor-sheet.mjs
@@ -37,6 +37,9 @@ export class HeroSheet extends ActorSheet {
       if (ok) await this.actor.deleteEmbeddedDocuments('Item', [li.data('itemId')]);
     });
     html.find('.item-name').dblclick((event) => this._onItemEdit(event));
+    html.find('[name="system.armed"]').change((e) => {
+      if (e.target.checked) html.find('[name="system.hidden"]')[0].checked = false;
+    });
     html.find('#rest-button').click(async () => {
       await this.actor.update({ 'system.hp.value': this.actor.system.hp.max });
     });

--- a/packages/cli/src/__tests__/migrate/fixtures/v1-actor-sheet.mjs
+++ b/packages/cli/src/__tests__/migrate/fixtures/v1-actor-sheet.mjs
@@ -75,6 +75,13 @@ export class HeroSheet extends ActorSheet {
   }
 
   /** @override */
+  setPosition(options = {}) {
+    const position = super.setPosition(options);
+    this.element.find('.sheet-body').css('height', position.height - 100);
+    return position;
+  }
+
+  /** @override */
   _onDragStart(event) {
     const id = event.currentTarget.dataset.itemId;
     event.dataTransfer.setData('text/plain', JSON.stringify(this.actor.items.get(id).toDragData()));

--- a/packages/cli/src/__tests__/migrate/fixtures/v1-actor-sheet.mjs
+++ b/packages/cli/src/__tests__/migrate/fixtures/v1-actor-sheet.mjs
@@ -1,0 +1,79 @@
+import { helper } from '../utils.mjs';
+
+export class HeroSheet extends ActorSheet {
+  /** @override */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ['hero', 'sheet', 'actor'],
+      template: 'systems/hero/templates/actor-sheet.html',
+      width: 600,
+      height: 750,
+      tabs: [{ navSelector: '.tabs', contentSelector: '.content', initial: 'items' }],
+      dragDrop: [{ dragSelector: '.item-row', dropSelector: null }],
+    });
+  }
+
+  /** @override */
+  async getData() {
+    const data = await super.getData();
+    data.items = data.items.sort((a, b) => a.name.localeCompare(b.name));
+    data.enrichedNotes = await TextEditor.enrichHTML(this.actor.system.notes, { async: true });
+    return data;
+  }
+
+  /** @override */
+  activateListeners(html) {
+    super.activateListeners(html);
+    if (!this.options.editable) return;
+    html.find('.item-create').click(this._onItemCreate.bind(this));
+    html.find('.item-delete').click(async (ev) => {
+      const li = $(ev.currentTarget).closest('.item-row');
+      const ok = await Dialog.confirm({
+        title: 'Delete',
+        content: '<p>Sure?</p>',
+        yes: () => true,
+        no: () => false,
+      });
+      if (ok) await this.actor.deleteEmbeddedDocuments('Item', [li.data('itemId')]);
+    });
+    html.find('.item-name').dblclick((event) => this._onItemEdit(event));
+    html.find('#rest-button').click(async () => {
+      await this.actor.update({ 'system.hp.value': this.actor.system.hp.max });
+    });
+  }
+
+  async _onItemCreate(event) {
+    event.preventDefault();
+    new Dialog({
+      title: 'New item',
+      content: '<input name="name">',
+      buttons: {
+        create: {
+          label: 'Create',
+          callback: (html) =>
+            this.actor.createEmbeddedDocuments('Item', [
+              { name: html.find('[name=name]').val(), type: 'item' },
+            ]),
+        },
+      },
+    }).render(true);
+  }
+
+  _onItemEdit(event) {
+    const li = $(event.currentTarget).closest('.item-row');
+    this.actor.items.get(li.data('itemId')).sheet.render(true);
+  }
+
+  /** @override */
+  async _onDropItem(event, itemData) {
+    const item = ((await super._onDropItem(event, itemData)) || []).pop();
+    if (item) helper(item);
+    return item;
+  }
+
+  /** @override */
+  _onDragStart(event) {
+    const id = event.currentTarget.dataset.itemId;
+    event.dataTransfer.setData('text/plain', JSON.stringify(this.actor.items.get(id).toDragData()));
+  }
+}

--- a/packages/cli/src/__tests__/migrate/migrate-command.test.ts
+++ b/packages/cli/src/__tests__/migrate/migrate-command.test.ts
@@ -147,6 +147,37 @@ describe('vttforge migrate --sheets', () => {
     expect(out).toMatch(/Would edit templates:\n {2}templates\/actor-sheet\.html/);
   });
 
+  it('reads every template when the class builds its path at runtime', async () => {
+    await sheetProject();
+    const dynamic = FIXTURE.replace(
+      "template: 'systems/hero/templates/actor-sheet.html',",
+      '',
+    ).replace(
+      'static get defaultOptions() {',
+      'get template() {\n    return `systems/hero/templates/${this.actor.type}-sheet.html`;\n  }\n\n  static get defaultOptions() {',
+    );
+    await writeFile(join(cwd, 'module', 'actor-sheet.mjs'), dynamic, 'utf8');
+    const { report } = await runMigrateCommand({ cwd, sheets: true, out: () => {} });
+    expect(report.sheets?.templates.map((t) => t.file)).toEqual(['templates/actor-sheet.html']);
+    expect(report.sheets?.files[0]?.todos.some((t) => /chosen at runtime/.test(t.message))).toBe(
+      true,
+    );
+  });
+
+  it('reports a file it cannot parse instead of stopping', async () => {
+    await sheetProject();
+    await writeFile(
+      join(cwd, 'module', 'broken.mjs'),
+      'class B extends ActorSheet { static get x() { return { a: 1 b: 2 }; } }\n',
+      'utf8',
+    );
+    const { report } = await runMigrateCommand({ cwd, sheets: true, out: () => {} });
+    expect(report.sheets?.files.map((f) => f.to)).toEqual(['module/actor-sheet.v2.mjs']);
+    expect(
+      report.sheets?.notes.some((n) => /module\/broken\.mjs.*could not be parsed/.test(n)),
+    ).toBe(true);
+  });
+
   it('says so when there is no v1 sheet', async () => {
     const { report } = await runMigrateCommand({ cwd, sheets: true, out: () => {} });
     expect(report.sheets).toEqual({ files: [], templates: [], notes: [] });

--- a/packages/cli/src/__tests__/migrate/migrate-command.test.ts
+++ b/packages/cli/src/__tests__/migrate/migrate-command.test.ts
@@ -158,6 +158,24 @@ describe('vttforge migrate --sheets', () => {
     );
     await writeFile(join(cwd, 'module', 'actor-sheet.mjs'), dynamic, 'utf8');
     const { report } = await runMigrateCommand({ cwd, sheets: true, out: () => {} });
+    // An item template in the tree is not a candidate for an actor sheet; shared parts are.
+    await mkdir(join(cwd, 'templates', 'item'), { recursive: true });
+    await mkdir(join(cwd, 'templates', 'actor'), { recursive: true });
+    await writeFile(
+      join(cwd, 'templates', 'item', 'gear-sheet.html'),
+      '<a class="item-create">+</a>\n',
+      'utf8',
+    );
+    await writeFile(
+      join(cwd, 'templates', 'actor', 'npc-sheet.html'),
+      '<a class="item-create">+</a>\n',
+      'utf8',
+    );
+    const second = await runMigrateCommand({ cwd, sheets: true, out: () => {} });
+    expect(second.report.sheets?.templates.map((t) => t.file)).toEqual([
+      'templates/actor-sheet.html',
+      'templates/actor/npc-sheet.html',
+    ]);
     expect(report.sheets?.templates.map((t) => t.file)).toEqual(['templates/actor-sheet.html']);
     expect(report.sheets?.files[0]?.todos.some((t) => /chosen at runtime/.test(t.message))).toBe(
       true,

--- a/packages/cli/src/__tests__/migrate/migrate-command.test.ts
+++ b/packages/cli/src/__tests__/migrate/migrate-command.test.ts
@@ -1,9 +1,11 @@
 /**
  * The command over a real directory: preview by default, written on request.
  */
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { runAudit } from '../../audit/index.js';
 import { runMigrateCommand } from '../../commands/migrate.js';
@@ -85,5 +87,68 @@ describe('vttforge migrate', () => {
     await expect(runMigrateCommand({ cwd: join(cwd, 'nope'), out: () => {} })).rejects.toThrow(
       /not a directory/,
     );
+  });
+});
+
+describe('vttforge migrate --sheets', () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const FIXTURE = readFileSync(join(here, 'fixtures', 'v1-actor-sheet.mjs'), 'utf8');
+  const TEMPLATE =
+    '<form><nav class="tabs"><a data-tab="items">I</a></nav><div class="tab" data-tab="items"><a class="item-create">+</a></div></form>\n';
+
+  async function sheetProject(): Promise<void> {
+    await mkdir(join(cwd, 'module'), { recursive: true });
+    await mkdir(join(cwd, 'templates'), { recursive: true });
+    await writeFile(join(cwd, 'module', 'actor-sheet.mjs'), FIXTURE, 'utf8');
+    await writeFile(join(cwd, 'templates', 'actor-sheet.html'), TEMPLATE, 'utf8');
+  }
+
+  it('previews a V2 file and the template edits, then writes them', async () => {
+    await sheetProject();
+    const preview = await runMigrateCommand({ cwd, sheets: true, json: true, out: () => {} });
+    expect(preview.report.sheets?.files.map((f) => f.to)).toEqual(['module/actor-sheet.v2.mjs']);
+    expect(preview.report.sheets?.files[0]?.actions.map((a) => a.name)).toContain('itemCreate');
+    expect(preview.report.sheets?.templates[0]?.file).toBe('templates/actor-sheet.html');
+    expect(preview.report.sheets?.templates[0]?.edits.length).toBeGreaterThan(0);
+    expect(preview.report.sheets?.templates[0]?.formRoot).toBe(true);
+    expect(existsSync(join(cwd, 'module', 'actor-sheet.v2.mjs'))).toBe(false);
+    expect(await readFile(join(cwd, 'templates', 'actor-sheet.html'), 'utf8')).toBe(TEMPLATE);
+
+    await runMigrateCommand({ cwd, sheets: true, write: true, out: () => {} });
+    const generated = await readFile(join(cwd, 'module', 'actor-sheet.v2.mjs'), 'utf8');
+    expect(generated).toContain('extends BaseActorSheet()');
+    // The tab ids came from the template.
+    expect(generated).toContain("tabs: [{ id: 'items' }]");
+    const template = await readFile(join(cwd, 'templates', 'actor-sheet.html'), 'utf8');
+    expect(template).toContain('data-action="itemCreate"');
+    expect(template).toContain('data-action="vttforgeTab"');
+    const original = await readFile(join(cwd, 'module', 'actor-sheet.mjs'), 'utf8');
+    expect(original).toMatch(/extends (?:foundry\.appv1\.sheets\.)?ActorSheet \{/);
+    expect(original).toContain('activateListeners(html)');
+
+    const again = await runMigrateCommand({ cwd, sheets: true, write: true, out: () => {} });
+    expect(again.report.sheets?.notes.some((n) => /exists and was left alone/.test(n))).toBe(true);
+  });
+
+  it('prints the sheet section in the text report', async () => {
+    await sheetProject();
+    let out = '';
+    await runMigrateCommand({
+      cwd,
+      sheets: true,
+      out: (c) => {
+        out += c;
+      },
+    });
+    expect(out).toMatch(/Would write 1 sheet file/);
+    expect(out).toMatch(/module\/actor-sheet\.v2\.mjs: HeroSheet extends BaseActorSheet\(\)/);
+    expect(out).toMatch(/action itemCreate/);
+    expect(out).toMatch(/registerSheet/);
+    expect(out).toMatch(/Would edit templates:\n {2}templates\/actor-sheet\.html/);
+  });
+
+  it('says so when there is no v1 sheet', async () => {
+    const { report } = await runMigrateCommand({ cwd, sheets: true, out: () => {} });
+    expect(report.sheets).toEqual({ files: [], templates: [], notes: [] });
   });
 });

--- a/packages/cli/src/__tests__/migrate/parse.test.ts
+++ b/packages/cli/src/__tests__/migrate/parse.test.ts
@@ -39,7 +39,8 @@ describe('findSheetClasses', () => {
 
   it('finds a method by name, kind and staticness', () => {
     const ast = parseSource(SRC, 'js');
-    const hero = findSheetClasses(ast, SRC)[0]!;
+    const hero = findSheetClasses(ast, SRC)[0];
+    if (!hero) throw new Error('fixture has no sheet class');
     expect(methodOf(hero.node, 'defaultOptions', { static: true, kind: 'get' })?.kind).toBe('get');
     expect(methodOf(hero.node, 'getData')?.kind).toBe('method');
     expect(methodOf(hero.node, 'nope')).toBeNull();

--- a/packages/cli/src/__tests__/migrate/parse.test.ts
+++ b/packages/cli/src/__tests__/migrate/parse.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { findSheetClasses, methodOf, parseSource, unsupportedBases } from '../../migrate/parse.js';
+
+const SRC = `
+import { x } from './x.js';
+export class HeroSheet extends ActorSheet {
+  static get defaultOptions() { return foundry.utils.mergeObject(super.defaultOptions, { width: 1 }); }
+  async getData() { return super.getData(); }
+}
+export class GearSheet extends foundry.appv1.sheets.ItemSheet {}
+export class Picker extends FormApplication {}
+const Anon = class extends ActorSheet {};
+export default class extends ItemSheet {}
+`;
+
+describe('findSheetClasses', () => {
+  it('finds bare and namespaced ActorSheet / ItemSheet subclasses', () => {
+    const ast = parseSource(SRC, 'js');
+    const found = findSheetClasses(ast, SRC).map((c) => [c.name, c.base, c.superText]);
+    expect(found).toEqual([
+      ['HeroSheet', 'ActorSheet', 'ActorSheet'],
+      ['GearSheet', 'ItemSheet', 'foundry.appv1.sheets.ItemSheet'],
+      ['Anon', 'ActorSheet', 'ActorSheet'],
+      ['DefaultItemSheet', 'ItemSheet', 'ItemSheet'],
+    ]);
+  });
+
+  it('reports the v1 bases it does not convert', () => {
+    const ast = parseSource(SRC, 'js');
+    expect(unsupportedBases(ast, SRC)).toEqual([
+      { name: 'Picker', superText: 'FormApplication', line: 8 },
+    ]);
+  });
+
+  it('parses TypeScript when asked', () => {
+    const ts = 'export class S extends ActorSheet { private n: number = 1; }';
+    expect(findSheetClasses(parseSource(ts, 'ts'), ts)).toHaveLength(1);
+  });
+
+  it('finds a method by name, kind and staticness', () => {
+    const ast = parseSource(SRC, 'js');
+    const hero = findSheetClasses(ast, SRC)[0]!;
+    expect(methodOf(hero.node, 'defaultOptions', { static: true, kind: 'get' })?.kind).toBe('get');
+    expect(methodOf(hero.node, 'getData')?.kind).toBe('method');
+    expect(methodOf(hero.node, 'nope')).toBeNull();
+  });
+});

--- a/packages/cli/src/__tests__/migrate/sheet-bodies.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-bodies.test.ts
@@ -20,7 +20,7 @@ describe('rewriteHandlerBody', () => {
     expect(r.code).toContain('const id = li.dataset.itemId;');
     expect(r.code).toContain('const kind = li.dataset.itemKind;');
     expect(r.code).toContain('const el = target;');
-    expect(r.code).toContain('const name = this.element.querySelector(".name");');
+    expect(r.code).toContain('const name = this.element.querySelectorAll(".name");');
     expect(r.todos).toEqual([]);
   });
 
@@ -38,6 +38,12 @@ describe('rewriteHandlerBody', () => {
     const r = rewriteHandlerBody(`{ $(".a").val($(".b").text()); }`, null, null);
     expect(r.todos).toHaveLength(1);
     expect(r.code.match(/TODO\(migrate\)/g)).toHaveLength(1);
+  });
+
+  it('turns this.element.find into querySelector and flags css()', () => {
+    const r = rewriteHandlerBody("{ this.element.find('.body').css('height', h); }", null, null);
+    expect(r.code).toContain("this.element.querySelectorAll('.body').css('height', h);");
+    expect(r.todos).toHaveLength(1);
   });
 
   it('reads jQuery parents() as the nearest ancestor', () => {
@@ -66,6 +72,9 @@ describe('rewriteGetData', () => {
     expect(r.code).toContain('data.actor = this.document;');
     expect(r.code).toContain('data.system = this.document.system;');
     expect(r.code).toContain('data.items = [...this.document.items];');
+    expect(r.code).toContain('data.data = this.document;');
+    expect(r.code).toContain('data.editable = this.isEditable;');
+    expect(r.code).toContain('data.owner = this.document.isOwner;');
     expect(r.code.indexOf('data.actor = ')).toBeLessThan(
       r.code.indexOf('data.items = data.items.sort()'),
     );
@@ -104,6 +113,20 @@ describe('rewriteDropMethod', () => {
     expect(r.code).toContain(
       "this.document.createEmbeddedDocuments('Item', [droppedItem.toObject()])",
     );
+  });
+
+  it('replaces the old payload identifier with toDragData()', () => {
+    const src = `async _onDropItem(event, data) {
+    const { item } = await fromDropData(data);
+    return super._onDropItem(event, data);
+  }`;
+    const r = rewriteDropMethod(src, 'Item');
+    expect(r.code).toContain('await fromDropData(droppedItem.toDragData());');
+    expect(r.code).toContain(
+      "this.document.createEmbeddedDocuments('Item', [droppedItem.toObject()]);",
+    );
+    const codeLines = r.code.split('\n').filter((l) => !l.includes('TODO(migrate)'));
+    expect(codeLines.join('\n')).not.toMatch(/\bdata\b/);
     expect(r.todos.length).toBeGreaterThan(0);
   });
 

--- a/packages/cli/src/__tests__/migrate/sheet-bodies.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-bodies.test.ts
@@ -40,6 +40,12 @@ describe('rewriteHandlerBody', () => {
     expect(r.code.match(/TODO\(migrate\)/g)).toHaveLength(1);
   });
 
+  it('reads jQuery parents() as the nearest ancestor', () => {
+    const r = rewriteHandlerBody('{ const li = $(ev.currentTarget).parents(".row"); }', 'ev', null);
+    expect(r.code).toBe('{ const li = target.closest(".row"); }');
+    expect(r.todos).toEqual([]);
+  });
+
   it('leaves a body with no event param alone', () => {
     expect(rewriteHandlerBody('{ await this.actor.rest(); }', null, null).code).toBe(
       '{ await this.actor.rest(); }',

--- a/packages/cli/src/__tests__/migrate/sheet-bodies.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-bodies.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  rewriteDialogs,
+  rewriteDropMethod,
+  rewriteGetData,
+  rewriteHandlerBody,
+} from '../../migrate/sheet-bodies.js';
+
+describe('rewriteHandlerBody', () => {
+  it('replaces the event target and the jQuery helpers', () => {
+    const body = `{
+      const li = $(ev.currentTarget).closest(".item");
+      const id = li.data("itemId");
+      const kind = li.data("item-kind");
+      const el = ev.currentTarget;
+      const name = html.find(".name");
+    }`;
+    const r = rewriteHandlerBody(body, 'ev', 'html');
+    expect(r.code).toContain('const li = target.closest(".item");');
+    expect(r.code).toContain('const id = li.dataset.itemId;');
+    expect(r.code).toContain('const kind = li.dataset.itemKind;');
+    expect(r.code).toContain('const el = target;');
+    expect(r.code).toContain('const name = this.element.querySelector(".name");');
+    expect(r.todos).toEqual([]);
+  });
+
+  it('marks the jQuery it cannot translate', () => {
+    const body = `{
+      const v = $(ev.currentTarget).val();
+      $(".x").slideToggle();
+    }`;
+    const r = rewriteHandlerBody(body, 'ev', null);
+    expect(r.code).toContain('TODO(migrate)');
+    expect(r.todos).toHaveLength(2);
+  });
+
+  it('marks a line once however much jQuery it holds', () => {
+    const r = rewriteHandlerBody(`{ $(".a").val($(".b").text()); }`, null, null);
+    expect(r.todos).toHaveLength(1);
+    expect(r.code.match(/TODO\(migrate\)/g)).toHaveLength(1);
+  });
+
+  it('leaves a body with no event param alone', () => {
+    expect(rewriteHandlerBody('{ await this.actor.rest(); }', null, null).code).toBe(
+      '{ await this.actor.rest(); }',
+    );
+  });
+});
+
+describe('rewriteGetData', () => {
+  it('becomes _prepareContext and fills the context keys V2 does not', () => {
+    const src = `async getData() {
+    const data = await super.getData();
+    data.items = data.items.sort();
+    return data;
+  }`;
+    const r = rewriteGetData(src, 'ActorSheet');
+    expect(r.code).toContain('async _prepareContext(options) {');
+    expect(r.code).toContain('const data = await super._prepareContext(options);');
+    expect(r.code).toContain('data.actor = this.document;');
+    expect(r.code).toContain('data.system = this.document.system;');
+    expect(r.code).toContain('data.items = [...this.document.items];');
+    expect(r.code.indexOf('data.actor = ')).toBeLessThan(
+      r.code.indexOf('data.items = data.items.sort()'),
+    );
+  });
+
+  it('uses item for item sheets and skips keys the method sets itself', () => {
+    const src = `getData() { const context = super.getData(); context.system = context.item.system; return context; }`;
+    const r = rewriteGetData(src, 'ItemSheet');
+    expect(r.code).toContain('context.item = this.document;');
+    expect(r.code).not.toContain('context.system = this.document.system;');
+    expect(r.code).not.toContain('context.items');
+  });
+
+  it('asks for the context keys by hand when nothing takes the super result', () => {
+    const r = rewriteGetData('getData() { return { foo: 1 }; }', 'ActorSheet');
+    expect(r.todos).toHaveLength(1);
+    expect(r.code).toContain('TODO(migrate)');
+    expect(r.code).toContain('context.actor = this.document;');
+  });
+
+  it('flags a parameter the new signature drops', () => {
+    const r = rewriteGetData('async getData(opts) { return super.getData(opts); }', 'ItemSheet');
+    expect(r.code).toContain('async _prepareContext(options) {');
+    expect(r.todos.join(' ')).toContain('opts');
+  });
+});
+
+describe('rewriteDropMethod', () => {
+  it('renames the drop handler and its super call', () => {
+    const src = `async _onDropItem(event, itemData) {
+    const item = ((await super._onDropItem(event, itemData)) || []).pop();
+    return item;
+  }`;
+    const r = rewriteDropMethod(src, 'Item');
+    expect(r.code).toContain('async onDropItem(droppedItem, event) {');
+    expect(r.code).toContain(
+      "this.document.createEmbeddedDocuments('Item', [droppedItem.toObject()])",
+    );
+    expect(r.todos.length).toBeGreaterThan(0);
+  });
+
+  it('leaves a signature it cannot read alone', () => {
+    const src = 'async _onDropItem(event) { return true; }';
+    const r = rewriteDropMethod(src, 'Item');
+    expect(r.code).toBe(src);
+    expect(r.todos).toEqual([]);
+  });
+});
+
+describe('rewriteDialogs', () => {
+  it('moves Dialog.confirm to DialogV2.confirm', () => {
+    const src = `const ok = await Dialog.confirm({ title: t, content: c, yes: () => true, no: () => false, defaultYes: false });`;
+    const r = rewriteDialogs(src);
+    expect(r.code).toBe(
+      `const ok = await DialogV2.confirm({ window: { title: t }, content: c, yes: { callback: () => true }, no: { callback: () => false } });`,
+    );
+    expect(r.todos).toEqual([]);
+  });
+
+  it('marks new Dialog', () => {
+    const r = rewriteDialogs(`new Dialog({ title: "x", buttons: {} }).render(true);`);
+    expect(r.code).toMatch(/TODO\(migrate\).*DialogV2/);
+    expect(r.todos).toHaveLength(1);
+  });
+
+  it('leaves the call as written when the options defeat the pattern', () => {
+    const src = `const ok = await Dialog.confirm({ title: t, yes: () => this.actor.update({ dead: true }) });`;
+    const r = rewriteDialogs(src);
+    expect(r.code).toContain(src);
+    expect(r.code.startsWith('// TODO(migrate)')).toBe(true);
+    expect(r.todos).toHaveLength(1);
+  });
+
+  it('flags options it dropped on the floor', () => {
+    const r = rewriteDialogs('await Dialog.confirm({ ...base, content: c });');
+    expect(r.code).toContain('DialogV2.confirm({ content: c })');
+    expect(r.todos).toHaveLength(1);
+    expect(r.todos.join(' ')).toContain('spread');
+  });
+
+  it('ignores a dialog named inside a comment or a string', () => {
+    const src = `// new Dialog({}) was here\nconst s = 'new Dialog({})';`;
+    expect(rewriteDialogs(src)).toEqual({ code: src, todos: [] });
+  });
+});

--- a/packages/cli/src/__tests__/migrate/sheet-listeners.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-listeners.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { findSheetClasses, parseSource } from '../../migrate/parse.js';
+import { actionName, extractListeners } from '../../migrate/sheet-listeners.js';
+
+const SRC = `
+class S extends ActorSheet {
+  activateListeners(html) {
+    super.activateListeners(html);
+    if (!this.options.editable) return;
+    html.find(".item-create").click(this._onItemCreate.bind(this));
+    html.find(".item-edit").click((ev) => this._onItemEdit(ev));
+    html.find(".item-delete").click(async (ev) => {
+      const li = $(ev.currentTarget).closest(".item");
+      await this.actor.deleteEmbeddedDocuments("Item", [li.data("itemId")]);
+    });
+    html.find("#rest-button").click(async () => { await this.actor.rest(); });
+    html.find(".item-name").dblclick((event) => this._onItemEdit(event));
+    html.find(".qty").change(this._onQty.bind(this));
+    html.find(".tag").on("contextmenu", (ev) => this._onTag(ev));
+    html.find("input").click(this._onInput.bind(this));
+    html.on("click", ".late", (ev) => this._onLate(ev));
+  }
+}`;
+
+describe('actionName', () => {
+  it('camel-cases the first class or id', () => {
+    const taken = new Set<string>();
+    expect(actionName('.item-create', taken)).toBe('itemCreate');
+    expect(actionName('#rest-button', taken)).toBe('restButton');
+    expect(actionName('.item-toggle-equipped', taken)).toBe('itemToggleEquipped');
+    expect(actionName('li.item .item-edit', taken)).toBe('item');
+    expect(actionName('input', taken)).toBeNull();
+    expect(actionName('[data-x]', taken)).toBeNull();
+  });
+
+  it('suffixes a collision', () => {
+    const taken = new Set(['itemEdit']);
+    expect(actionName('.item-edit', taken)).toBe('itemEdit2');
+  });
+});
+
+describe('extractListeners', () => {
+  const [cls] = findSheetClasses(parseSource(SRC, 'js'), SRC);
+  if (!cls) throw new Error('fixture has no sheet class');
+  const l = extractListeners(cls, SRC);
+
+  it('turns click bindings into actions', () => {
+    expect(l.actions.map((a) => [a.name, a.kind, a.method])).toEqual([
+      ['itemCreate', 'method', '_onItemCreate'],
+      ['itemEdit', 'method', '_onItemEdit'],
+      ['itemDelete', 'inline', null],
+      ['restButton', 'inline', null],
+    ]);
+    const del = l.actions[2];
+    expect(del?.param).toBe('ev');
+    expect(del?.isAsync).toBe(true);
+    expect(del?.body).toContain('deleteEmbeddedDocuments');
+    expect(l.actions[3]?.param).toBeNull();
+  });
+
+  it('routes other events to _onRender listeners', () => {
+    expect(l.listeners.map((x) => [x.selector, x.event])).toEqual([
+      ['.item-name', 'dblclick'],
+      ['.qty', 'change'],
+      ['.tag', 'contextmenu'],
+    ]);
+    expect(l.listeners[1]?.handlerText).toBe('this._onQty.bind(this)');
+  });
+
+  it('lists what it did not translate', () => {
+    expect(l.leftovers.map((x) => x.text)).toEqual([
+      'html.find("input").click(this._onInput.bind(this));',
+      'html.on("click", ".late", (ev) => this._onLate(ev));',
+    ]);
+  });
+
+  it('is empty for a class without activateListeners', () => {
+    const src = 'class T extends ItemSheet {}';
+    const [t] = findSheetClasses(parseSource(src, 'js'), src);
+    if (!t) throw new Error('fixture has no sheet class');
+    expect(extractListeners(t, src)).toEqual({ actions: [], listeners: [], leftovers: [] });
+  });
+});
+
+describe('bindings under a condition', () => {
+  it('are still actions, and the lost condition is reported', () => {
+    const src = `class S extends ActorSheet {
+      activateListeners(html) {
+        super.activateListeners(html);
+        if (!this.isEditable) return;
+        if (this.actor.isOwner) {
+          html.find('.owner-only').click(this._onOwner.bind(this));
+        }
+      }
+    }`;
+    const cls = findSheetClasses(parseSource(src, 'js'), src)[0];
+    if (!cls) throw new Error('fixture has no sheet class');
+    const l = extractListeners(cls, src);
+    expect(l.actions.map((a) => a.name)).toEqual(['ownerOnly']);
+    expect(l.leftovers).toHaveLength(1);
+    expect(l.leftovers[0]?.text).toContain('this.actor.isOwner');
+  });
+});

--- a/packages/cli/src/__tests__/migrate/sheet-listeners.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-listeners.test.ts
@@ -78,7 +78,12 @@ describe('extractListeners', () => {
     const src = 'class T extends ItemSheet {}';
     const [t] = findSheetClasses(parseSource(src, 'js'), src);
     if (!t) throw new Error('fixture has no sheet class');
-    expect(extractListeners(t, src)).toEqual({ actions: [], listeners: [], leftovers: [] });
+    expect(extractListeners(t, src)).toEqual({
+      actions: [],
+      listeners: [],
+      leftovers: [],
+      htmlParam: 'html',
+    });
   });
 });
 

--- a/packages/cli/src/__tests__/migrate/sheet-options.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-options.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { findSheetClasses, parseSource } from '../../migrate/parse.js';
+import { extractOptions, renderStatics } from '../../migrate/sheet-options.js';
+
+const SRC = `
+export class HeroSheet extends ActorSheet {
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["hero", "sheet", "actor"],
+      template: "systems/hero/templates/actor-sheet.html",
+      width: 600,
+      height: 750,
+      resizable: true,
+      scrollY: [".items"],
+      tabs: [{ navSelector: ".tabs", contentSelector: ".content", initial: "items" }],
+      dragDrop: [{ dragSelector: ".item-row", dropSelector: null }],
+    });
+  }
+}`;
+
+function options(src: string) {
+  const cls = findSheetClasses(parseSource(src, 'js'), src)[0];
+  if (!cls) throw new Error('fixture has no sheet class');
+  return extractOptions(cls, src);
+}
+
+describe('extractOptions', () => {
+  it('reads the mergeObject literal', () => {
+    const o = options(SRC);
+    expect(o.classes).toBe('["hero", "sheet", "actor"]');
+    expect(o.template).toBe('systems/hero/templates/actor-sheet.html');
+    expect(o.width).toBe(600);
+    expect(o.height).toBe(750);
+    expect(o.resizable).toBe(true);
+    expect(o.tabs).toEqual([
+      { navSelector: '.tabs', contentSelector: '.content', initial: 'items' },
+    ]);
+    expect(o.dragDrop).toBe('[{ dragSelector: ".item-row", dropSelector: null }]');
+    expect(o.unknown).toEqual(['scrollY']);
+  });
+
+  it('keeps a dynamic template getter', () => {
+    const src = `class S extends ItemSheet {
+      static get defaultOptions() { return mergeObject(super.defaultOptions, { width: 1 }); }
+      get template() { return \`systems/x/\${this.item.type}.html\`; }
+    }`;
+    const o = options(src);
+    expect(o.template).toBeNull();
+    expect(o.templateGetter?.kind).toBe('get');
+  });
+
+  it('tolerates a class with no defaultOptions', () => {
+    const o = options('class S extends ActorSheet {}');
+    expect(o.width).toBeNull();
+    expect(o.tabs).toEqual([]);
+  });
+});
+
+describe('renderStatics', () => {
+  it('writes DEFAULT_OPTIONS, TABS, DRAG_DROP and PARTS', () => {
+    const o = options(SRC);
+    const out = renderStatics(o, { '.tabs': ['items', 'notes'] }, (m) => `// TODO(migrate): ${m}`);
+    expect(out).toContain('classes: ["hero", "sheet", "actor"],');
+    expect(out).toContain('position: { width: 600, height: 750 },');
+    expect(out).toContain('window: { resizable: true },');
+    expect(out).toContain('form: { submitOnChange: true },');
+    expect(out).toContain(
+      "static TABS = {\n    primary: { tabs: [{ id: 'items' }, { id: 'notes' }], initial: 'items' },\n  };",
+    );
+    expect(out).toContain(
+      'static DRAG_DROP = [{ dragSelector: ".item-row", dropSelector: null }];',
+    );
+    expect(out).toContain(
+      "static PARTS = {\n    sheet: { template: 'systems/hero/templates/actor-sheet.html' },\n  };",
+    );
+    expect(out).toContain('// TODO(migrate): scrollY');
+  });
+
+  it('marks tabs whose ids it could not read', () => {
+    const o = options(SRC);
+    const out = renderStatics(o, {}, (m) => `// TODO(migrate): ${m}`);
+    expect(out).toContain("primary: { tabs: [], initial: 'items' }");
+    expect(out).toContain('TODO(migrate): tab ids');
+  });
+});

--- a/packages/cli/src/__tests__/migrate/sheet-templates.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-templates.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The template half of `migrate --sheets`: attributes appear on opening tags
+ * and nothing else in the file moves.
+ */
+import { describe, expect, it } from 'vitest';
+import { editTemplate, readTabIds } from '../../migrate/sheet-templates.js';
+
+const TPL = `<form class="hero" autocomplete="off">
+  <button id="rest-button" type="button" class="strict">Rest</button>
+  <nav class="tabs" data-group="primary">
+    <a class="item" data-tab="items">Items</a>
+    <a class="item" data-tab="notes" data-action="vttforgeTab" data-group="primary">Notes</a>
+  </nav>
+  <div class="tab" data-tab="items">
+    <a class="item-create" title="Create"><i class="fas fa-plus"></i></a>
+    <li class="item-row" data-item-id="{{item._id}}"><a class="item-delete">x</a></li>
+  </div>
+  <section class="tab" data-group="primary" data-tab="notes"></section>
+</form>
+`;
+
+describe('readTabIds', () => {
+  it('reads the data-tab values under the nav', () => {
+    expect(readTabIds(TPL, '.tabs')).toEqual(['items', 'notes']);
+    expect(readTabIds(TPL, '.missing')).toEqual([]);
+  });
+});
+
+describe('editTemplate', () => {
+  const r = editTemplate(TPL, {
+    actions: [
+      { name: 'itemCreate', selector: '.item-create' },
+      { name: 'itemDelete', selector: '.item-delete' },
+      { name: 'restButton', selector: '#rest-button' },
+    ],
+    navSelectors: ['.tabs'],
+  });
+
+  it('adds data-action to the matching class and id elements', () => {
+    expect(r.output).toContain(
+      '<button id="rest-button" type="button" class="strict" data-action="restButton">',
+    );
+    expect(r.output).toContain('<a class="item-create" title="Create" data-action="itemCreate">');
+    expect(r.output).toContain('<a class="item-delete" data-action="itemDelete">');
+  });
+
+  it('wires the tabs nav and panes for the SDK tab action', () => {
+    expect(r.output).toContain(
+      '<a class="item" data-tab="items" data-action="vttforgeTab" data-group="primary">',
+    );
+    expect(r.output).toContain(
+      '<a class="item" data-tab="notes" data-action="vttforgeTab" data-group="primary">',
+    );
+    expect(r.output).toContain('<div class="tab" data-tab="items" data-group="primary">');
+    expect(r.output).toContain('<section class="tab" data-group="primary" data-tab="notes">');
+  });
+
+  it('reports each edit with its line and flags the form root', () => {
+    expect(r.edits.map((e) => e.line)).toEqual([2, 4, 7, 8, 9]);
+    expect(r.formRoot).toBe(true);
+  });
+
+  it('changes nothing else', () => {
+    const lines = TPL.split('\n');
+    const out = r.output.split('\n');
+    expect(out.length).toBe(lines.length);
+    for (const i of [0, 2, 5, 10, 11]) {
+      expect(out[i]).toBe(lines[i]);
+    }
+  });
+
+  it('is idempotent', () => {
+    const again = editTemplate(r.output, {
+      actions: [{ name: 'itemCreate', selector: '.item-create' }],
+      navSelectors: ['.tabs'],
+    });
+    expect(again.edits).toEqual([]);
+    expect(again.output).toBe(r.output);
+  });
+});
+
+const HBS = `<div class="sheet">
+  <nav class="sheet-tabs">
+    <a class="item" data-tab="{{id}}">Dynamic</a>
+    <a class="item" data-tab="gear">Gear</a>
+  </nav>
+  {{#if editable}}
+  <div class="tab {{cls}}" data-tab="gear">
+    <a class="item-create" data-tooltip="{{localize 'SHEET.Create'}}">+</a>
+  </div>
+  {{/if}}
+</div>
+`;
+
+describe('templates with expressions in attribute values', () => {
+  const r = editTemplate(HBS, {
+    actions: [{ name: 'itemCreate', selector: '.item-create' }],
+    navSelectors: ['.sheet-tabs'],
+  });
+
+  it('skips a tab id that is an expression', () => {
+    expect(readTabIds(HBS, '.sheet-tabs')).toEqual(['gear']);
+  });
+
+  it('still edits tags whose attribute values hold expressions', () => {
+    expect(r.output).toContain(
+      '<a class="item" data-tab="{{id}}" data-action="vttforgeTab" data-group="primary">',
+    );
+    expect(r.output).toContain('<div class="tab {{cls}}" data-tab="gear" data-group="primary">');
+    expect(r.output).toContain(
+      `<a class="item-create" data-tooltip="{{localize 'SHEET.Create'}}" data-action="itemCreate">`,
+    );
+    expect(r.edits.map((e) => e.line)).toEqual([3, 4, 7, 8]);
+    expect(r.formRoot).toBe(false);
+  });
+
+  it('leaves the block helper lines alone', () => {
+    const lines = HBS.split('\n');
+    const out = r.output.split('\n');
+    expect(out.length).toBe(lines.length);
+    for (const i of [0, 1, 5, 9, 10, 11]) {
+      expect(out[i]).toBe(lines[i]);
+    }
+  });
+});

--- a/packages/cli/src/__tests__/migrate/sheet-templates.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-templates.test.ts
@@ -46,17 +46,22 @@ describe('editTemplate', () => {
 
   it('wires the tabs nav and panes for the SDK tab action', () => {
     expect(r.output).toContain(
-      '<a class="item" data-tab="items" data-action="vttforgeTab" data-group="primary">',
+      '<a class="item {{tabs.items.cssClass}}" data-tab="items" data-action="vttforgeTab" data-group="primary">',
+    );
+    // Already wired for the action: only the active-class marker is added.
+    expect(r.output).toContain(
+      '<a class="item {{tabs.notes.cssClass}}" data-tab="notes" data-action="vttforgeTab" data-group="primary">',
     );
     expect(r.output).toContain(
-      '<a class="item" data-tab="notes" data-action="vttforgeTab" data-group="primary">',
+      '<div class="tab {{tabs.items.cssClass}}" data-tab="items" data-group="primary">',
     );
-    expect(r.output).toContain('<div class="tab" data-tab="items" data-group="primary">');
-    expect(r.output).toContain('<section class="tab" data-group="primary" data-tab="notes">');
+    expect(r.output).toContain(
+      '<section class="tab {{tabs.notes.cssClass}}" data-group="primary" data-tab="notes">',
+    );
   });
 
   it('reports each edit with its line and flags the form root', () => {
-    expect(r.edits.map((e) => e.line)).toEqual([2, 4, 7, 8, 9]);
+    expect(r.edits.map((e) => e.line)).toEqual([2, 4, 5, 7, 8, 9, 11]);
     expect(r.formRoot).toBe(true);
   });
 
@@ -64,7 +69,7 @@ describe('editTemplate', () => {
     const lines = TPL.split('\n');
     const out = r.output.split('\n');
     expect(out.length).toBe(lines.length);
-    for (const i of [0, 2, 5, 10, 11]) {
+    for (const i of [0, 2, 5, 11]) {
       expect(out[i]).toBe(lines[i]);
     }
   });
@@ -106,7 +111,9 @@ describe('templates with expressions in attribute values', () => {
     expect(r.output).toContain(
       '<a class="item" data-tab="{{id}}" data-action="vttforgeTab" data-group="primary">',
     );
-    expect(r.output).toContain('<div class="tab {{cls}}" data-tab="gear" data-group="primary">');
+    expect(r.output).toContain(
+      '<div class="tab {{cls}} {{tabs.gear.cssClass}}" data-tab="gear" data-group="primary">',
+    );
     expect(r.output).toContain(
       `<a class="item-create" data-tooltip="{{localize 'SHEET.Create'}}" data-action="itemCreate">`,
     );
@@ -121,5 +128,30 @@ describe('templates with expressions in attribute values', () => {
     for (const i of [0, 1, 5, 9, 10, 11]) {
       expect(out[i]).toBe(lines[i]);
     }
+  });
+});
+
+describe('mustaches inside the opening tag', () => {
+  const tpl = `<nav class="tabs">
+  <a class="item" data-tab="items" id="set-limit"
+    {{#if data.limit}}title="Double click"{{/if}}>Items</a>
+  <a class="item" data-tab="notes">Notes</a>
+</nav>
+<button id="rest-button" type="button" {{#if data.deprived}}disabled{{/if}}>Rest</button>
+`;
+
+  it('still reads the tab ids and edits the tag', () => {
+    expect(readTabIds(tpl, '.tabs')).toEqual(['items', 'notes']);
+    const r = editTemplate(tpl, {
+      actions: [{ name: 'restButton', selector: '#rest-button' }],
+      navSelectors: ['.tabs'],
+    });
+    expect(r.output).toContain(
+      '{{#if data.deprived}}disabled{{/if}} data-action="restButton">Rest</button>',
+    );
+    expect(r.output).toContain(
+      '{{#if data.limit}}title="Double click"{{/if}} data-action="vttforgeTab" data-group="primary">Items</a>',
+    );
+    expect(r.edits.map((e) => e.line)).toEqual([2, 4, 6]);
   });
 });

--- a/packages/cli/src/__tests__/migrate/sheets.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheets.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { planSheetFile } from '../../migrate/sheets.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = readFileSync(join(here, 'fixtures', 'v1-actor-sheet.mjs'), 'utf8');
+
+describe('planSheetFile', () => {
+  const plan = planSheetFile('module/actor-sheet.mjs', FIXTURE, {
+    lang: 'js',
+    tabIds: { '.tabs': ['items', 'notes'] },
+  });
+  const file = plan.files[0];
+  if (!file) throw new Error('the fixture produced no file');
+
+  it('writes the class next to the original, on the SDK base', () => {
+    expect(file.to).toBe('module/actor-sheet.v2.mjs');
+    expect(file.className).toBe('HeroSheet');
+    expect(file.base).toBe('BaseActorSheet');
+    expect(file.source).toContain(`import { BaseActorSheet } from '@vttforge/core';`);
+    expect(file.source).toContain(`import { helper } from '../utils.mjs';`);
+    expect(file.source).toContain('const { DialogV2 } = foundry.applications.api;');
+    expect(file.source).toContain('export class HeroSheet extends BaseActorSheet() {');
+    expect(file.source).toContain('  get actor() {\n    return this.document;\n  }');
+  });
+
+  it('declares the statics and the actions', () => {
+    expect(file.source).toContain(
+      "  static TABS = {\n    primary: { tabs: [{ id: 'items' }, { id: 'notes' }], initial: 'items' },\n  };",
+    );
+    expect(file.source).toContain(
+      "  static DRAG_DROP = [{ dragSelector: '.item-row', dropSelector: null }];",
+    );
+    expect(file.source).toContain("sheet: { template: 'systems/hero/templates/actor-sheet.html' }");
+    expect(file.source).toContain(
+      '      actions: {\n        itemCreate: HeroSheet.prototype._onItemCreate,\n        itemDelete: HeroSheet.prototype._onItemDelete,\n        restButton: HeroSheet.prototype._onRestButton,\n      },',
+    );
+    expect(file.actions.map((a) => [a.name, a.method])).toEqual([
+      ['itemCreate', '_onItemCreate'],
+      ['itemDelete', '_onItemDelete'],
+      ['restButton', '_onRestButton'],
+    ]);
+  });
+
+  it('carries the methods over with the V2 signatures', () => {
+    expect(file.source).toContain('  async _onItemCreate(event, target) {');
+    expect(file.source).toContain(
+      "  async _onItemDelete(ev, target) {\n    const li = target.closest('.item-row');",
+    );
+    expect(file.source).toContain(
+      "DialogV2.confirm({ window: { title: 'Delete' }, content: '<p>Sure?</p>', yes: { callback: () => true }, no: { callback: () => false } })",
+    );
+    expect(file.source).toContain('[li.dataset.itemId]');
+    expect(file.source).toContain('  async _onRestButton(event, target) {');
+    expect(file.source).toContain(
+      '  async _prepareContext(options) {\n    const data = await super._prepareContext(options);\n    data.actor = this.document;',
+    );
+    expect(file.source).toContain('  async onDropItem(droppedItem, event) {');
+    expect(file.source).toContain(
+      "this.document.createEmbeddedDocuments('Item', [droppedItem.toObject()])",
+    );
+    expect(file.source).toContain(
+      "  _onItemEdit(event) {\n    const li = event.currentTarget.closest('.item-row');\n    this.actor.items.get(li.dataset.itemId).sheet.render(true);",
+    );
+    expect(file.source).toContain('  _onDragStart(event) {');
+    expect(file.source).not.toContain('activateListeners');
+  });
+
+  it('adds the render listener for the dblclick', () => {
+    expect(file.source).toContain(
+      "  /** @override */\n  _onRender(context, options) {\n    super._onRender(context, options);\n    for (const el of this.element.querySelectorAll('.item-name')) {\n      el.addEventListener('dblclick', (event) => this._onItemEdit(event));\n    }\n  }",
+    );
+  });
+
+  it('leaves TODOs where it stopped, and lists them with their lines', () => {
+    expect(file.source).toContain('// TODO(migrate): Dialog v1');
+    expect(file.todos.length).toBeGreaterThanOrEqual(2);
+    const lines = file.source.split('\n');
+    for (const t of file.todos) expect(lines[t.line - 1]).toContain('TODO(migrate)');
+  });
+
+  it('records the templates and nav selectors for the template pass', () => {
+    expect(file.templates).toEqual(['systems/hero/templates/actor-sheet.html']);
+    expect(file.tabNavSelectors).toEqual(['.tabs']);
+  });
+
+  it('matches the snapshot', () => {
+    expect(file.source).toMatchSnapshot();
+  });
+
+  it('reports an unsupported base and ignores files with no sheet', () => {
+    const src = 'export class P extends FormApplication {}';
+    const p = planSheetFile('module/p.mjs', src, { lang: 'js', tabIds: {} });
+    expect(p.files).toEqual([]);
+    expect(p.notes[0]).toMatch(/FormApplication/);
+    expect(
+      planSheetFile('module/x.mjs', 'export const a = 1;', { lang: 'js', tabIds: {} }),
+    ).toEqual({
+      files: [],
+      notes: [],
+    });
+  });
+});

--- a/packages/cli/src/__tests__/migrate/sheets.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheets.test.ts
@@ -70,7 +70,7 @@ describe('planSheetFile', () => {
 
   it('rewrites the jQuery inside a render listener and keeps its indentation', () => {
     expect(file.source).toContain(
-      "    for (const el of this.element.querySelectorAll('[name=\"system.armed\"]')) {\n      el.addEventListener('change', (e) => {\n        if (e.target.checked) this.element.querySelector('[name=\"system.hidden\"]')[0].checked = false;\n      });\n    }",
+      "    for (const el of this.element.querySelectorAll('[name=\"system.armed\"]')) {\n      el.addEventListener('change', (e) => {\n        if (e.target.checked) this.element.querySelectorAll('[name=\"system.hidden\"]')[0].checked = false;\n      });\n    }",
     );
   });
 
@@ -87,6 +87,15 @@ describe('planSheetFile', () => {
   it('adds the render listener for the dblclick', () => {
     expect(file.source).toContain(
       "  /** @override */\n  _onRender(context, options) {\n    super._onRender(context, options);\n    for (const el of this.element.querySelectorAll('.item-name')) {\n      el.addEventListener('dblclick', (event) => this._onItemEdit(event));\n    }",
+    );
+  });
+
+  it('flags a v1 lifecycle override and rewrites the jQuery in it', () => {
+    expect(file.source).toContain(
+      '// TODO(migrate): setPosition is an Application v1 lifecycle override',
+    );
+    expect(file.source).toContain(
+      "this.element.querySelectorAll('.sheet-body').css('height', position.height - 100);",
     );
   });
 

--- a/packages/cli/src/__tests__/migrate/sheets.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheets.test.ts
@@ -68,9 +68,25 @@ describe('planSheetFile', () => {
     expect(file.source).not.toContain('activateListeners');
   });
 
+  it('rewrites the jQuery inside a render listener and keeps its indentation', () => {
+    expect(file.source).toContain(
+      "    for (const el of this.element.querySelectorAll('[name=\"system.armed\"]')) {\n      el.addEventListener('change', (e) => {\n        if (e.target.checked) this.element.querySelector('[name=\"system.hidden\"]')[0].checked = false;\n      });\n    }",
+    );
+  });
+
+  it('marks PARTS when a getter picks the template at runtime', () => {
+    const src = `export class S extends ItemSheet {
+      static get defaultOptions() { return mergeObject(super.defaultOptions, { template: 'systems/x/templates/a.html' }); }
+      get template() { return \`systems/x/templates/\${this.item.type}.html\`; }
+    }`;
+    const p = planSheetFile('s.mjs', src, { lang: 'js', tabIds: {} });
+    expect(p.files[0]?.source).toContain('TODO(migrate): the template is chosen at runtime');
+    expect(p.files[0]?.source).toContain('  get template() {');
+  });
+
   it('adds the render listener for the dblclick', () => {
     expect(file.source).toContain(
-      "  /** @override */\n  _onRender(context, options) {\n    super._onRender(context, options);\n    for (const el of this.element.querySelectorAll('.item-name')) {\n      el.addEventListener('dblclick', (event) => this._onItemEdit(event));\n    }\n  }",
+      "  /** @override */\n  _onRender(context, options) {\n    super._onRender(context, options);\n    for (const el of this.element.querySelectorAll('.item-name')) {\n      el.addEventListener('dblclick', (event) => this._onItemEdit(event));\n    }",
     );
   });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -249,7 +249,8 @@ export const audit = defineCommand({
 export const migrate = defineCommand({
   meta: {
     name: 'migrate',
-    description: 'Rewrite a v13 system or module for Foundry v14 (preview by default)',
+    description:
+      'Rewrite a v13 system or module for Foundry v14 (preview by default); --data-models and --sheets write the v16 replacements',
   },
   args: {
     path: {
@@ -281,7 +282,13 @@ export const migrate = defineCommand({
     lang: {
       type: 'string',
       default: 'js',
-      description: 'For --data-models: "js" writes .mjs, "ts" writes .ts',
+      description: 'For --data-models and --sheets: "js" writes .mjs, "ts" writes .ts',
+    },
+    sheets: {
+      type: 'boolean',
+      default: false,
+      description:
+        'Also write a V2 sheet file (on the SDK bases) next to each Application v1 sheet class, and the data-action attributes its templates need',
     },
   },
   async run({ args }) {
@@ -293,6 +300,7 @@ export const migrate = defineCommand({
         dataModels: Boolean(args['data-models']),
         style: String(args.style) === 'sdk' ? 'sdk' : 'plain',
         lang: String(args.lang) === 'ts' ? 'ts' : 'js',
+        sheets: Boolean(args.sheets),
       });
       process.exitCode = exitCode;
     } catch (error) {

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -17,6 +17,8 @@ export interface MigrateCommandOptions {
   dataModels?: boolean;
   style?: 'plain' | 'sdk';
   lang?: 'js' | 'ts';
+  /** Also generate a V2 sheet file per Application v1 sheet class. */
+  sheets?: boolean;
   /** Custom writer (tests). Defaults to process.stdout.write. */
   out?: (chunk: string) => void;
 }
@@ -36,6 +38,7 @@ export async function runMigrateCommand(
     dataModels: options.dataModels === true,
     style: options.style,
     lang: options.lang,
+    sheets: options.sheets === true,
   });
   out(options.json ? `${JSON.stringify(report, null, 2)}\n` : formatMigrateReport(report));
   return { report, exitCode: 0 };

--- a/packages/cli/src/migrate/index.ts
+++ b/packages/cli/src/migrate/index.ts
@@ -12,6 +12,8 @@ import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, relative } from 'node:path';
 import { _internal } from '../audit/source-rules.js';
 import { type EmitStyle, planDataModels } from './data-models.js';
+import { editTemplate, readTabIds, type TemplateEdit } from './sheet-templates.js';
+import { planSheetFile, type SheetPlanFile } from './sheets.js';
 import { type Change, type Note, transformManifest, transformSource } from './transforms.js';
 
 interface FileResult {
@@ -35,6 +37,12 @@ export interface MigrateReport {
     registration: string;
     notes: string[];
   };
+  /** Present when V2 sheet files were generated from Application v1 classes. */
+  sheets?: {
+    files: Array<Omit<SheetPlanFile, 'source'>>;
+    templates: Array<{ file: string; edits: TemplateEdit[]; formRoot: boolean }>;
+    notes: string[];
+  };
 }
 
 export interface MigrateOptions {
@@ -45,8 +53,10 @@ export interface MigrateOptions {
   dataModels?: boolean;
   /** How the generated models are written: bare Foundry classes, or on the SDK's bases. */
   style?: EmitStyle;
-  /** File extension of the generated models. */
+  /** File extension of the generated models and sheets. */
   lang?: 'js' | 'ts';
+  /** Also generate a V2 sheet file per Application v1 sheet class. */
+  sheets?: boolean;
 }
 
 export async function runMigrate(options: MigrateOptions): Promise<MigrateReport> {
@@ -139,13 +149,104 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
     }
   }
 
+  if (options.sheets) report.sheets = await planSheets(cwd, write, options.lang ?? 'js');
+
   return report;
+}
+
+/** Project-relative path for a Foundry template path such as `systems/<id>/templates/x.html`. */
+function localTemplate(cwd: string, foundryPath: string): string | null {
+  const m = /^(?:systems|modules)\/[^/]+\/(.+)$/.exec(foundryPath);
+  const rel = m?.[1] ?? foundryPath;
+  return existsSync(join(cwd, rel)) ? rel : null;
+}
+
+async function planSheets(
+  cwd: string,
+  write: boolean,
+  lang: 'js' | 'ts',
+): Promise<NonNullable<MigrateReport['sheets']>> {
+  const files: Array<Omit<SheetPlanFile, 'source'>> = [];
+  const templates: Array<{ file: string; edits: TemplateEdit[]; formRoot: boolean }> = [];
+  const notes: string[] = [];
+  const generated = new Map<string, string>();
+
+  for await (const path of _internal.walkSourceFiles(cwd)) {
+    const rel = relative(cwd, path);
+    if (/\.v2\.[cm]?[jt]s$/.test(rel)) continue;
+    let raw: string;
+    try {
+      raw = await readFile(path, 'utf8');
+    } catch {
+      continue;
+    }
+    if (!/\b(?:ActorSheet|ItemSheet)\b/.test(raw)) continue;
+    // The generated file starts from the v14 rewrite of the source, so the bare
+    // v13 aliases are already namespaced in it whether or not --write ran.
+    const source = transformSource(raw).output;
+
+    // First pass: which templates and nav selectors, so the tab ids can be read.
+    const probe = planSheetFile(rel, source, { lang, tabIds: {} });
+    notes.push(...probe.notes);
+    if (probe.files.length === 0) continue;
+    const templatePaths = [...new Set(probe.files.flatMap((f) => f.templates))]
+      .map((t) => localTemplate(cwd, t))
+      .filter((t): t is string => t !== null);
+    const navSelectors = [...new Set(probe.files.flatMap((f) => f.tabNavSelectors))];
+    const tabIds: Record<string, string[]> = {};
+    for (const t of templatePaths) {
+      const tpl = await readFile(join(cwd, t), 'utf8');
+      for (const nav of navSelectors) {
+        if (tabIds[nav]) continue;
+        const ids = readTabIds(tpl, nav);
+        if (ids.length > 0) tabIds[nav] = ids;
+      }
+    }
+
+    const plan = planSheetFile(rel, source, { lang, tabIds });
+    for (const f of plan.files) {
+      const { source: out, ...rest } = f;
+      files.push(rest);
+      generated.set(f.to, out);
+      notes.push(
+        `Point registerSheet at ${f.className} from ${f.to} (a written key such as "<id>.${f.base === 'BaseActorSheet' ? 'actor' : 'item'}"), then delete the old class.`,
+      );
+    }
+    const actions = plan.files.flatMap((f) =>
+      f.actions.map((a) => ({ name: a.name, selector: a.selector })),
+    );
+    for (const t of templatePaths) {
+      const tpl = await readFile(join(cwd, t), 'utf8');
+      const r = editTemplate(tpl, { actions, navSelectors });
+      if (r.edits.length === 0 && !r.formRoot) continue;
+      templates.push({ file: t, edits: r.edits, formRoot: r.formRoot });
+      if (r.formRoot) {
+        notes.push(
+          `${t} opens with <form>; the SDK sheet already is one. Remove it once the old class is gone (audit rule 008).`,
+        );
+      }
+      if (write && r.edits.length > 0) await writeFile(join(cwd, t), r.output, 'utf8');
+    }
+  }
+
+  for (const [to, out] of generated) {
+    const target = join(cwd, to);
+    if (existsSync(target)) {
+      notes.unshift(`${to} exists and was left alone.`);
+      continue;
+    }
+    if (write) {
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, out, 'utf8');
+    }
+  }
+  return { files, templates, notes: [...new Set(notes)] };
 }
 
 /** The report as text: one block per file, edits then notes. */
 export function formatMigrateReport(report: MigrateReport): string {
   const lines: string[] = [];
-  if (report.files.length === 0 && !report.dataModels) {
+  if (report.files.length === 0 && !report.dataModels && !report.sheets) {
     lines.push('Nothing to migrate. The project already reads as v14.');
     return `${lines.join('\n')}\n`;
   }
@@ -198,6 +299,34 @@ export function formatMigrateReport(report: MigrateReport): string {
         ...dm.registration.split('\n').map((l) => `  ${l}`),
       );
     for (const n of dm.notes) lines.push(`  needs a decision: ${n}`);
+  }
+  if (report.sheets) {
+    const s = report.sheets;
+    const targets = [...new Set(s.files.map((f) => f.to))];
+    lines.push(
+      '',
+      report.written
+        ? `Wrote ${targets.length} sheet file(s) on the SDK bases:`
+        : `Would write ${targets.length} sheet file(s) on the SDK bases:`,
+    );
+    for (const f of s.files) {
+      lines.push(`  ${f.to}: ${f.className} extends ${f.base}()`);
+      for (const a of f.actions) lines.push(`    action ${a.name} ← ${a.selector} (${a.method})`);
+      for (const t of f.todos) lines.push(`    ${t.line}: needs a decision: ${t.message}`);
+    }
+    if (s.templates.length > 0) {
+      lines.push('', report.written ? 'Edited templates:' : 'Would edit templates:');
+      for (const t of s.templates) {
+        lines.push(`  ${t.file}`);
+        for (const e of t.edits) {
+          lines.push(
+            `    ${e.line}: ${oneLine(e.before)}`,
+            `    ${' '.repeat(String(e.line).length)}  → ${oneLine(e.after)}`,
+          );
+        }
+      }
+    }
+    for (const n of s.notes) lines.push(`  needs a decision: ${n}`);
   }
   return `${lines.join('\n')}\n`;
 }

--- a/packages/cli/src/migrate/index.ts
+++ b/packages/cli/src/migrate/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, relative } from 'node:path';
 import { _internal } from '../audit/source-rules.js';
 import { type EmitStyle, planDataModels } from './data-models.js';
@@ -154,6 +154,22 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
   return report;
 }
 
+/** Every `.hbs` / `.html` under `templates/`, project-relative. */
+async function allTemplates(cwd: string): Promise<string[]> {
+  const root = join(cwd, 'templates');
+  if (!existsSync(root)) return [];
+  const out: string[] = [];
+  const visit = async (dir: string): Promise<void> => {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) await visit(full);
+      else if (/\.(?:hbs|html)$/.test(entry.name)) out.push(relative(cwd, full));
+    }
+  };
+  await visit(root);
+  return out.sort();
+}
+
 /** Project-relative path for a Foundry template path such as `systems/<id>/templates/x.html`. */
 function localTemplate(cwd: string, foundryPath: string): string | null {
   const m = /^(?:systems|modules)\/[^/]+\/(.+)$/.exec(foundryPath);
@@ -186,12 +202,22 @@ async function planSheets(
     const source = transformSource(raw).output;
 
     // First pass: which templates and nav selectors, so the tab ids can be read.
-    const probe = planSheetFile(rel, source, { lang, tabIds: {} });
+    let probe: ReturnType<typeof planSheetFile>;
+    try {
+      probe = planSheetFile(rel, source, { lang, tabIds: {} });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      notes.push(`${rel} could not be parsed and was skipped: ${reason}`);
+      continue;
+    }
     notes.push(...probe.notes);
     if (probe.files.length === 0) continue;
-    const templatePaths = [...new Set(probe.files.flatMap((f) => f.templates))]
+    let templatePaths = [...new Set(probe.files.flatMap((f) => f.templates))]
       .map((t) => localTemplate(cwd, t))
       .filter((t): t is string => t !== null);
+    // A `get template()` that builds the path at runtime names nothing; every
+    // sheet template in the project is a candidate then.
+    if (templatePaths.length === 0) templatePaths = await allTemplates(cwd);
     const navSelectors = [...new Set(probe.files.flatMap((f) => f.tabNavSelectors))];
     const tabIds: Record<string, string[]> = {};
     for (const t of templatePaths) {

--- a/packages/cli/src/migrate/index.ts
+++ b/packages/cli/src/migrate/index.ts
@@ -217,7 +217,14 @@ async function planSheets(
       .filter((t): t is string => t !== null);
     // A `get template()` that builds the path at runtime names nothing; every
     // sheet template in the project is a candidate then.
-    if (templatePaths.length === 0) templatePaths = await allTemplates(cwd);
+    if (templatePaths.length === 0) {
+      const every = await allTemplates(cwd);
+      // Leave out the other document's folder (item templates for an actor sheet and the
+      // reverse); shared parts and dialogs stay in, since a sheet's rows often live there.
+      const other =
+        probe.files[0]?.base === 'BaseItemSheet' ? /(?:^|\/)actors?\//i : /(?:^|\/)items?\//i;
+      templatePaths = every.filter((t) => !other.test(t));
+    }
     const navSelectors = [...new Set(probe.files.flatMap((f) => f.tabNavSelectors))];
     const tabIds: Record<string, string[]> = {};
     for (const t of templatePaths) {
@@ -244,7 +251,8 @@ async function planSheets(
     for (const t of templatePaths) {
       const tpl = await readFile(join(cwd, t), 'utf8');
       const r = editTemplate(tpl, { actions, navSelectors });
-      if (r.edits.length === 0 && !r.formRoot) continue;
+      // A template the class never touched (a dialog, a chat card) is not a sheet; its form is its own.
+      if (r.edits.length === 0) continue;
       templates.push({ file: t, edits: r.edits, formRoot: r.formRoot });
       if (r.formRoot) {
         notes.push(

--- a/packages/cli/src/migrate/parse.ts
+++ b/packages/cli/src/migrate/parse.ts
@@ -6,7 +6,7 @@
 import { parse } from '@babel/parser';
 import type { ClassDeclaration, ClassExpression, ClassMethod, File, Node } from '@babel/types';
 
-export type SheetBase = 'ActorSheet' | 'ItemSheet';
+type SheetBase = 'ActorSheet' | 'ItemSheet';
 
 export interface SheetClass {
   name: string;

--- a/packages/cli/src/migrate/parse.ts
+++ b/packages/cli/src/migrate/parse.ts
@@ -1,0 +1,125 @@
+/**
+ * The parse side of `migrate --sheets`: an AST for the class structure, and
+ * the few lookups the planner needs. Bodies are never re-printed from the
+ * tree; the planner slices the original text by node range.
+ */
+import { parse } from '@babel/parser';
+import type { ClassDeclaration, ClassExpression, ClassMethod, File, Node } from '@babel/types';
+
+export type SheetBase = 'ActorSheet' | 'ItemSheet';
+
+export interface SheetClass {
+  name: string;
+  base: SheetBase;
+  node: ClassDeclaration | ClassExpression;
+  /** The `extends` expression as written. */
+  superText: string;
+}
+
+const CONVERTED = new Set<string>(['ActorSheet', 'ItemSheet']);
+const UNSUPPORTED = new Set(['Application', 'FormApplication', 'Dialog', 'DocumentSheet']);
+
+export function parseSource(source: string, lang: 'js' | 'ts'): File {
+  return parse(source, {
+    sourceType: 'module',
+    errorRecovery: true,
+    attachComment: false,
+    plugins: lang === 'ts' ? ['typescript', 'decorators'] : ['decorators'],
+  });
+}
+
+export function text(source: string, node: Node): string {
+  return source.slice(node.start ?? 0, node.end ?? 0);
+}
+
+/** Depth-first over every child node. Return `false` from `visit` to skip a subtree. */
+export function walk(node: Node | null | undefined, visit: (n: Node) => undefined | false): void {
+  if (!node || typeof node.type !== 'string') return;
+  if (visit(node) === false) return;
+  for (const key of Object.keys(node)) {
+    if (key === 'loc' || key === 'leadingComments' || key === 'trailingComments') continue;
+    const value = (node as unknown as Record<string, unknown>)[key];
+    if (Array.isArray(value)) {
+      for (const v of value) walk(v as Node, visit);
+    } else if (value && typeof value === 'object' && 'type' in value) {
+      walk(value as Node, visit);
+    }
+  }
+}
+
+/** `foundry.appv1.sheets.ActorSheet` → the leaf name, or the identifier itself. */
+function superName(cls: ClassDeclaration | ClassExpression): string | null {
+  const s = cls.superClass;
+  if (!s) return null;
+  if (s.type === 'Identifier') return s.name;
+  if (s.type === 'MemberExpression' && s.property.type === 'Identifier') return s.property.name;
+  return null;
+}
+
+interface NamedClass {
+  name: string;
+  node: ClassDeclaration | ClassExpression;
+}
+
+function classesOf(ast: File): NamedClass[] {
+  const out: NamedClass[] = [];
+  walk(ast.program, (n) => {
+    if (n.type === 'ClassDeclaration') {
+      out.push({ name: n.id?.name ?? '', node: n });
+      return false;
+    }
+    if (n.type === 'ExportDefaultDeclaration' && n.declaration.type === 'ClassDeclaration') {
+      const base = superName(n.declaration) ?? 'Sheet';
+      out.push({ name: n.declaration.id?.name ?? `Default${base}`, node: n.declaration });
+      return false;
+    }
+    if (
+      n.type === 'VariableDeclarator' &&
+      n.init?.type === 'ClassExpression' &&
+      n.id.type === 'Identifier'
+    ) {
+      out.push({ name: n.id.name, node: n.init });
+      return false;
+    }
+    return undefined;
+  });
+  return out;
+}
+
+export function findSheetClasses(ast: File, source: string): SheetClass[] {
+  const found: SheetClass[] = [];
+  for (const { name, node } of classesOf(ast)) {
+    const base = superName(node);
+    if (!base || !CONVERTED.has(base) || !node.superClass) continue;
+    found.push({ name, base: base as SheetBase, node, superText: text(source, node.superClass) });
+  }
+  return found;
+}
+
+export function unsupportedBases(
+  ast: File,
+  source: string,
+): Array<{ name: string; superText: string; line: number }> {
+  const out: Array<{ name: string; superText: string; line: number }> = [];
+  for (const { name, node } of classesOf(ast)) {
+    const base = superName(node);
+    if (!base || !UNSUPPORTED.has(base) || !node.superClass) continue;
+    out.push({ name, superText: text(source, node.superClass), line: node.loc?.start.line ?? 0 });
+  }
+  return out;
+}
+
+export function methodOf(
+  cls: ClassDeclaration | ClassExpression,
+  name: string,
+  opts: { static?: boolean; kind?: 'get' | 'method' } = {},
+): ClassMethod | null {
+  for (const member of cls.body.body) {
+    if (member.type !== 'ClassMethod') continue;
+    if (member.key.type !== 'Identifier' || member.key.name !== name) continue;
+    if (opts.static !== undefined && Boolean(member.static) !== opts.static) continue;
+    if (opts.kind !== undefined && member.kind !== opts.kind) continue;
+    return member;
+  }
+  return null;
+}

--- a/packages/cli/src/migrate/sheet-bodies.ts
+++ b/packages/cli/src/migrate/sheet-bodies.ts
@@ -47,7 +47,7 @@ function todoAt(code: string, index: number, msg: string): string {
 
 /** The jQuery calls with no one-to-one DOM rewrite. */
 const LEFTOVER_JQUERY =
-  /\$\(|\.(?:val|text|html|prop|toggle|slideToggle|slideUp|slideDown|show|hide|addClass|removeClass|toggleClass|siblings|children|find)\(/g;
+  /\$\(|\.(?:val|text|html|prop|toggle|slideToggle|slideUp|slideDown|show|hide|addClass|removeClass|toggleClass|siblings|children|find|css)\(/g;
 
 const JQUERY_MSG = 'jQuery left here; use the DOM on `target` / `this.element`';
 
@@ -91,9 +91,12 @@ export function rewriteHandlerBody(
     code = replaceCode(
       code,
       new RegExp(`\\b${esc(htmlParam)}\\.find\\(`, 'g'),
-      () => 'this.element.querySelector(',
+      () => 'this.element.querySelectorAll(',
     );
   }
+  // `this.element` was jQuery on v1 and is an HTMLElement on V2.
+  // A jQuery collection reads as a NodeList: `.length`, `[0]` and `forEach` keep working.
+  code = replaceCode(code, /this\.element\.find\(/g, () => 'this.element.querySelectorAll(');
   // What is left of jQuery gets a marker, once per line however much it holds.
   const masked = maskComments(code, { strings: true });
   const lines = new Set<number>();
@@ -130,11 +133,19 @@ export function rewriteGetData(methodText: string, base: 'ActorSheet' | 'ItemShe
     /(?:const|let|var)\s+(\w+)\s*=\s*(?:await\s+)?super\._prepareContext\(options\)\s*;/.exec(code);
   const v = varMatch?.[1] ?? 'context';
   const own = base === 'ActorSheet' ? 'actor' : 'item';
+  // What v1's getData handed the template and V2's _prepareContext does not:
+  // the document under its own name and as `data`, its system, the items,
+  // and the two flags every v1 template gates on.
   const wanted: Array<[string, string]> = [
     [own, `${v}.${own} = this.document;`],
+    ['data', `${v}.data = this.document;`],
     ['system', `${v}.system = this.document.system;`],
   ];
   if (base === 'ActorSheet') wanted.push(['items', `${v}.items = [...this.document.items];`]);
+  wanted.push(
+    ['editable', `${v}.editable = this.isEditable;`],
+    ['owner', `${v}.owner = this.document.isOwner;`],
+  );
 
   const masked = maskComments(code, { strings: true });
   const inject = wanted
@@ -177,7 +188,9 @@ export function rewriteDropMethod(methodText: string, which: 'Item' | 'Actor'): 
   const eventName = m[1] ?? 'event';
   const dataName = m[2] ?? 'data';
   // The body may already declare `item` / `actor`; the parameter then takes another name.
-  const declares = new RegExp(`\\b(?:const|let|var)\\s+${lower}\\b`).test(methodText);
+  const declares = new RegExp(
+    `\\b(?:const|let|var)\\s+(?:${lower}\\b|\\{[^}]*\\b${lower}\\b[^}]*\\}|\\[[^\\]]*\\b${lower}\\b[^\\]]*\\])`,
+  ).test(methodText);
   const param = declares ? `dropped${which}` : lower;
   let code = methodText.replace(sig, `onDrop${which}(${param}, ${eventName})`);
   const todos: string[] = [];
@@ -195,10 +208,16 @@ export function rewriteDropMethod(methodText: string, which: 'Item' | 'Actor'): 
       () => `super.onDrop${which}(${param}, ${eventName})`,
     );
   }
+  // The v1 body read the drag payload; the resolved document reproduces it.
+  code = replaceCode(
+    code,
+    new RegExp(`\\b${esc(dataName)}\\b`, 'g'),
+    () => `${param}.toDragData()`,
+  );
   const msg =
     which === 'Item'
-      ? `the base hands the resolved Item as \`${param}\`; \`${dataName}\` no longer exists. The old super call created it on the actor, which is what the createEmbeddedDocuments line does now (a drop from the same actor used to re-sort instead). Return true when the drop was handled, undefined to let the base do its default`
-      : `the base hands the resolved Actor as \`${param}\`; \`${dataName}\` no longer exists. Read \`${param}\` directly and return true when the drop was handled`;
+      ? `the base hands the resolved Item as \`${param}\`; the old \`${dataName}\` payload is now \`${param}.toDragData()\`, read \`${param}\` directly where you can. The old super call created it on the actor, which is what the createEmbeddedDocuments line does now (a drop from the same actor used to re-sort instead). Return true when the drop was handled, undefined to let the base do its default`
+      : `the base hands the resolved Actor as \`${param}\`; the old \`${dataName}\` payload is now \`${param}.toDragData()\`, read \`${param}\` directly where you can. Return true when the drop was handled`;
   code = todoAt(code, code.indexOf('{') + 1, msg);
   todos.push(msg);
   return { code, todos };

--- a/packages/cli/src/migrate/sheet-bodies.ts
+++ b/packages/cli/src/migrate/sheet-bodies.ts
@@ -1,0 +1,335 @@
+/**
+ * Text rewrites applied to method bodies carried over from an Application v1
+ * sheet. Each one is scoped to the slice the planner hands it, so a pattern
+ * here never sees the rest of the file.
+ *
+ * Nothing is re-printed from a syntax tree: the bodies keep the author's
+ * spacing and comments, and every rewrite is a replacement the reader can
+ * find in the diff. What cannot be decided mechanically becomes a
+ * `// TODO(migrate)` line above the code that needs the decision, and the
+ * same message comes back in `todos` so the report can list it.
+ */
+
+import { MASK, maskComments } from '../audit/mask.js';
+
+export interface Rewritten {
+  code: string;
+  /** One message per `// TODO(migrate)` line placed in `code`. */
+  todos: string[];
+}
+
+export const TODO = (msg: string): string => `// TODO(migrate): ${msg}`;
+
+const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const camel = (s: string) => s.replace(/-+(\w)/g, (_m, c: string) => c.toUpperCase());
+
+/** Replace outside comments and strings; the mask keeps them out of reach. */
+function replaceCode(
+  code: string,
+  pattern: RegExp,
+  replacement: (match: string, ...groups: string[]) => string,
+): string {
+  const masked = maskComments(code, { strings: true });
+  return code.replace(pattern, (match: string, ...rest: unknown[]) => {
+    const offset = rest.find((r): r is number => typeof r === 'number') ?? 0;
+    if (masked[offset] === MASK) return match;
+    return replacement(match, ...rest.filter((r): r is string => typeof r === 'string'));
+  });
+}
+
+/** Put a TODO line above the line that holds `index`. */
+function todoAt(code: string, index: number, msg: string): string {
+  const lineStart = code.lastIndexOf('\n', index - 1) + 1;
+  const indent = /^[ \t]*/.exec(code.slice(lineStart))?.[0] ?? '';
+  return `${code.slice(0, lineStart)}${indent}${TODO(msg)}\n${code.slice(lineStart)}`;
+}
+
+/** The jQuery calls with no one-to-one DOM rewrite. */
+const LEFTOVER_JQUERY =
+  /\$\(|\.(?:val|text|html|prop|toggle|slideToggle|slideUp|slideDown|show|hide|addClass|removeClass|toggleClass|siblings|parents|children|find)\(/g;
+
+const JQUERY_MSG = 'jQuery left here; use the DOM on `target` / `this.element`';
+
+/**
+ * A handler body from `activateListeners`, with `event.currentTarget` folded
+ * into the `target` the action receives and the jQuery data readers turned
+ * into `dataset`.
+ */
+export function rewriteHandlerBody(
+  body: string,
+  eventParam: string | null,
+  htmlParam: string | null,
+  targetName = 'target',
+): Rewritten {
+  const todos: string[] = [];
+  let code = body;
+  if (eventParam) {
+    const ev = esc(eventParam);
+    code = replaceCode(
+      code,
+      new RegExp(`\\$\\(\\s*${ev}\\.currentTarget\\s*\\)`, 'g'),
+      () => targetName,
+    );
+    if (targetName !== `${eventParam}.currentTarget`) {
+      code = replaceCode(code, new RegExp(`\\b${ev}\\.currentTarget\\b`, 'g'), () => targetName);
+    }
+  }
+  code = replaceCode(
+    code,
+    /\.data\(\s*(['"])([\w-]+)\1\s*\)/g,
+    (_m, _q, key) => `.dataset.${camel(key)}`,
+  );
+  code = replaceCode(
+    code,
+    /\.attr\(\s*(['"])data-([\w-]+)\1\s*\)/g,
+    (_m, _q, key) => `.dataset.${camel(key)}`,
+  );
+  if (htmlParam) {
+    code = replaceCode(
+      code,
+      new RegExp(`\\b${esc(htmlParam)}\\.find\\(`, 'g'),
+      () => 'this.element.querySelector(',
+    );
+  }
+  // What is left of jQuery gets a marker, once per line however much it holds.
+  const masked = maskComments(code, { strings: true });
+  const lines = new Set<number>();
+  for (const m of code.matchAll(LEFTOVER_JQUERY)) {
+    const at = m.index ?? 0;
+    if (masked[at] === MASK) continue;
+    lines.add(code.lastIndexOf('\n', at - 1) + 1);
+  }
+  for (const lineStart of [...lines].sort((a, b) => b - a)) {
+    code = todoAt(code, lineStart, JQUERY_MSG);
+    todos.unshift(JQUERY_MSG);
+  }
+  return { code, todos };
+}
+
+/**
+ * `getData()` becomes `_prepareContext(options)`. V2 hands back a much
+ * smaller context, so the keys a v1 body expects to already be there are
+ * assigned right after the `super` call — unless the method assigns them
+ * itself without reading the old value first.
+ */
+export function rewriteGetData(methodText: string, base: 'ActorSheet' | 'ItemSheet'): Rewritten {
+  const todos: string[] = [];
+  const sig = /^(\s*)(async\s+)?getData\s*\(([^)]*)\)/.exec(methodText);
+  const params = sig?.[3]?.trim() ?? '';
+  let code = methodText.replace(
+    /^(\s*)(async\s+)?getData\s*\(([^)]*)\)/,
+    (_m, indent: string) => `${indent}async _prepareContext(options)`,
+  );
+  code = replaceCode(code, /super\.getData\(\s*[^)]*\)/g, () => 'super._prepareContext(options)');
+
+  // The variable that received super's result.
+  const varMatch =
+    /(?:const|let|var)\s+(\w+)\s*=\s*(?:await\s+)?super\._prepareContext\(options\)\s*;/.exec(code);
+  const v = varMatch?.[1] ?? 'context';
+  const own = base === 'ActorSheet' ? 'actor' : 'item';
+  const wanted: Array<[string, string]> = [
+    [own, `${v}.${own} = this.document;`],
+    ['system', `${v}.system = this.document.system;`],
+  ];
+  if (base === 'ActorSheet') wanted.push(['items', `${v}.items = [...this.document.items];`]);
+
+  const masked = maskComments(code, { strings: true });
+  const inject = wanted
+    .filter(([key]) => {
+      const assigned = new RegExp(`\\b${esc(v)}\\.${key}\\s*=(?!=)`).test(masked);
+      const read = new RegExp(`\\b${esc(v)}\\.${key}\\b(?!\\s*=(?!=))`).test(masked);
+      return !assigned || read;
+    })
+    .map(([, line]) => line);
+
+  if (varMatch) {
+    const at = varMatch.index + varMatch[0].length;
+    const indent =
+      /^[ \t]*/.exec(code.slice(code.lastIndexOf('\n', varMatch.index) + 1))?.[0] ?? '    ';
+    code = `${code.slice(0, at)}${inject.map((l) => `\n${indent}${l}`).join('')}${code.slice(at)}`;
+  } else if (inject.length > 0) {
+    const msg = `set ${inject.join(' ')} on the context before returning it`;
+    code = todoAt(code, code.indexOf('{') + 1, msg);
+    todos.push(msg);
+  }
+
+  if (params !== '' && params !== 'options') {
+    const msg = `\`getData(${params})\` took its own parameters; \`_prepareContext(options)\` does not. Read what the body needs from \`options\` or \`this.document\``;
+    code = todoAt(code, code.indexOf('{') + 1, msg);
+    todos.push(msg);
+  }
+  return { code, todos };
+}
+
+/**
+ * `_onDropItem(event, data)` becomes `onDropItem(item, event)`: the SDK base
+ * resolves the dropped document before it calls the hook, so the raw drop
+ * payload the v1 body read is gone.
+ */
+export function rewriteDropMethod(methodText: string, which: 'Item' | 'Actor'): Rewritten {
+  const lower = which.toLowerCase();
+  const sig = new RegExp(`_onDrop${which}\\s*\\(\\s*(\\w+)\\s*,\\s*(\\w+)\\s*\\)`);
+  const m = sig.exec(methodText);
+  if (!m) return { code: methodText, todos: [] };
+  const eventName = m[1] ?? 'event';
+  const dataName = m[2] ?? 'data';
+  // The body may already declare `item` / `actor`; the parameter then takes another name.
+  const declares = new RegExp(`\\b(?:const|let|var)\\s+${lower}\\b`).test(methodText);
+  const param = declares ? `dropped${which}` : lower;
+  let code = methodText.replace(sig, `onDrop${which}(${param}, ${eventName})`);
+  const todos: string[] = [];
+  if (which === 'Item') {
+    // v1's super created the item on the actor and returned the created documents.
+    code = replaceCode(
+      code,
+      /super\._onDropItem\([^)]*\)/g,
+      () => `this.document.createEmbeddedDocuments('Item', [${param}.toObject()])`,
+    );
+  } else {
+    code = replaceCode(
+      code,
+      new RegExp(`super\\._onDrop${which}\\([^)]*\\)`, 'g'),
+      () => `super.onDrop${which}(${param}, ${eventName})`,
+    );
+  }
+  const msg =
+    which === 'Item'
+      ? `the base hands the resolved Item as \`${param}\`; \`${dataName}\` no longer exists. The old super call created it on the actor, which is what the createEmbeddedDocuments line does now (a drop from the same actor used to re-sort instead). Return true when the drop was handled, undefined to let the base do its default`
+      : `the base hands the resolved Actor as \`${param}\`; \`${dataName}\` no longer exists. Read \`${param}\` directly and return true when the drop was handled`;
+  code = todoAt(code, code.indexOf('{') + 1, msg);
+  todos.push(msg);
+  return { code, todos };
+}
+
+/** `Dialog.confirm({ ... })`: the options literal is group 1. Non-greedy, so a nested `}` ends it early; `balanced` catches that. */
+const CONFIRM_CALL = /\bDialog\.confirm\(\s*\{([\s\S]*?)\}\s*\)/g;
+const NEW_DIALOG = /\bnew\s+Dialog\s*\(/g;
+const UNREADABLE_MSG =
+  'Dialog.confirm here could not be read (a nested object or a comma inside an option); rewrite it as DialogV2.confirm({ window: { title }, content, yes: { callback }, no: { callback } }) by hand';
+const NEW_DIALOG_MSG =
+  'Dialog v1 (removed in v16); rebuild with DialogV2.prompt / DialogV2.wait, buttons as { action, label, callback }';
+
+/** Whether every bracket opened in `text` (outside strings and comments) is closed. */
+function balanced(text: string): boolean {
+  const masked = maskComments(text, { strings: true });
+  const pairs = new Map<string, string>([
+    [')', '('],
+    [']', '['],
+    ['}', '{'],
+  ]);
+  const stack: string[] = [];
+  for (let i = 0; i < masked.length; i += 1) {
+    const ch = masked[i];
+    if (ch === undefined || ch === MASK) continue;
+    if (ch === '(' || ch === '[' || ch === '{') stack.push(ch);
+    else if (pairs.has(ch)) {
+      if (stack.pop() !== pairs.get(ch)) return false;
+    }
+  }
+  return stack.length === 0;
+}
+
+/** The top-level `key: value` pairs of an object literal's inner text. */
+function topLevelPairs(inner: string): Array<{ key: string; value: string; spread: boolean }> {
+  const masked = maskComments(inner, { strings: true });
+  const pairs: Array<{ key: string; value: string; spread: boolean }> = [];
+  let depth = 0;
+  let start = 0;
+  const flush = (end: number) => {
+    const raw = inner.slice(start, end).trim();
+    if (!raw) return;
+    if (raw.startsWith('...')) {
+      pairs.push({ key: raw, value: '', spread: true });
+      return;
+    }
+    const colon = raw.indexOf(':');
+    if (colon === -1) {
+      pairs.push({ key: raw, value: raw, spread: false });
+      return;
+    }
+    pairs.push({
+      key: raw.slice(0, colon).trim(),
+      value: raw.slice(colon + 1).trim(),
+      spread: false,
+    });
+  };
+  for (let i = 0; i < masked.length; i += 1) {
+    const ch = masked[i];
+    if (ch === MASK) continue;
+    if (ch === '(' || ch === '[' || ch === '{') depth += 1;
+    else if (ch === ')' || ch === ']' || ch === '}') depth -= 1;
+    else if (ch === ',' && depth === 0) {
+      flush(i);
+      start = i + 1;
+    }
+  }
+  flush(inner.length);
+  return pairs;
+}
+
+/**
+ * The DialogV2.confirm call for a Dialog.confirm options literal, or `null`
+ * when the literal could not be read. `missing` names what the rewrite left
+ * behind (a spread, an option with no V2 slot). `defaultYes` is dropped on
+ * purpose: DialogV2 has no equivalent.
+ */
+function readConfirmOptions(inner: string): { code: string | null; missing: string[] } {
+  if (!balanced(inner)) return { code: null, missing: [] };
+  const missing: string[] = [];
+  const found: Record<string, string> = {};
+  for (const pair of topLevelPairs(inner)) {
+    if (pair.spread) {
+      missing.push(`the spread ${pair.key}`);
+      continue;
+    }
+    const key = pair.key.replace(/^['"]|['"]$/g, '');
+    if (key === 'title' || key === 'content' || key === 'yes' || key === 'no')
+      found[key] = pair.value;
+    else if (key !== 'defaultYes' && key !== 'rejectClose' && key !== 'options') missing.push(key);
+  }
+  const parts = [
+    found.title ? `window: { title: ${found.title} }` : '',
+    found.content ? `content: ${found.content}` : '',
+    found.yes ? `yes: { callback: ${found.yes} }` : '',
+    found.no ? `no: { callback: ${found.no} }` : '',
+  ].filter(Boolean);
+  return { code: `DialogV2.confirm({ ${parts.join(', ')} })`, missing };
+}
+
+export function rewriteDialogs(code: string): Rewritten {
+  const todos: string[] = [];
+  const confirmMask = maskComments(code, { strings: true });
+  const hits: Array<{ start: number; end: number; code: string | null; missing: string[] }> = [];
+  for (const m of code.matchAll(CONFIRM_CALL)) {
+    const start = m.index ?? 0;
+    if (confirmMask[start] === MASK) continue;
+    const read = readConfirmOptions(m[1] ?? '');
+    hits.push({ start, end: start + m[0].length, code: read.code, missing: read.missing });
+  }
+
+  let out = code;
+  for (const hit of hits.reverse()) {
+    if (hit.code !== null) out = `${out.slice(0, hit.start)}${hit.code}${out.slice(hit.end)}`;
+    if (hit.code === null) {
+      out = todoAt(out, hit.start, UNREADABLE_MSG);
+      todos.unshift(UNREADABLE_MSG);
+    } else if (hit.missing.length > 0) {
+      const msg = `Dialog.confirm options left behind: ${hit.missing.join(', ')}; move them onto the DialogV2.confirm call by hand`;
+      out = todoAt(out, hit.start, msg);
+      todos.unshift(msg);
+    }
+  }
+
+  const dialogMask = maskComments(out, { strings: true });
+  const starts: number[] = [];
+  for (const m of out.matchAll(NEW_DIALOG)) {
+    const at = m.index ?? 0;
+    if (dialogMask[at] !== MASK) starts.push(at);
+  }
+  for (const at of starts.reverse()) {
+    out = todoAt(out, at, NEW_DIALOG_MSG);
+    todos.push(NEW_DIALOG_MSG);
+  }
+  return { code: out, todos };
+}

--- a/packages/cli/src/migrate/sheet-bodies.ts
+++ b/packages/cli/src/migrate/sheet-bodies.ts
@@ -47,7 +47,7 @@ function todoAt(code: string, index: number, msg: string): string {
 
 /** The jQuery calls with no one-to-one DOM rewrite. */
 const LEFTOVER_JQUERY =
-  /\$\(|\.(?:val|text|html|prop|toggle|slideToggle|slideUp|slideDown|show|hide|addClass|removeClass|toggleClass|siblings|parents|children|find)\(/g;
+  /\$\(|\.(?:val|text|html|prop|toggle|slideToggle|slideUp|slideDown|show|hide|addClass|removeClass|toggleClass|siblings|children|find)\(/g;
 
 const JQUERY_MSG = 'jQuery left here; use the DOM on `target` / `this.element`';
 
@@ -85,6 +85,8 @@ export function rewriteHandlerBody(
     /\.attr\(\s*(['"])data-([\w-]+)\1\s*\)/g,
     (_m, _q, key) => `.dataset.${camel(key)}`,
   );
+  // jQuery's `parents(sel)` is read for its nearest match everywhere a sheet uses it.
+  code = replaceCode(code, /\.parents\(/g, () => '.closest(');
   if (htmlParam) {
     code = replaceCode(
       code,

--- a/packages/cli/src/migrate/sheet-listeners.ts
+++ b/packages/cli/src/migrate/sheet-listeners.ts
@@ -20,7 +20,7 @@ export interface ActionBinding {
   isAsync: boolean;
 }
 
-export interface ListenerBinding {
+interface ListenerBinding {
   selector: string;
   event: string;
   handlerText: string;

--- a/packages/cli/src/migrate/sheet-listeners.ts
+++ b/packages/cli/src/migrate/sheet-listeners.ts
@@ -1,0 +1,264 @@
+/**
+ * `activateListeners(html)` → `actions` and `_onRender` listeners.
+ *
+ * A click bound through `html.find(SEL).click(H)` (or `.on('click', H)`)
+ * becomes an action named after the selector's first class or id. A bound
+ * method stays a method; an arrow that only forwards to a method is that
+ * method; any other function becomes a new method. Other events keep a real
+ * listener, added in `_onRender`. What does not fit either shape is listed.
+ */
+import type { Expression, Node, Statement } from '@babel/types';
+import { methodOf, type SheetClass, text } from './parse.js';
+
+export interface ActionBinding {
+  name: string;
+  selector: string;
+  kind: 'method' | 'inline';
+  method: string | null;
+  param: string | null;
+  body: string | null;
+  isAsync: boolean;
+}
+
+export interface ListenerBinding {
+  selector: string;
+  event: string;
+  handlerText: string;
+}
+
+export interface Listeners {
+  actions: ActionBinding[];
+  listeners: ListenerBinding[];
+  leftovers: Array<{ line: number; text: string }>;
+}
+
+const EVENTS = new Set([
+  'click',
+  'dblclick',
+  'change',
+  'contextmenu',
+  'input',
+  'keydown',
+  'keyup',
+  'focus',
+  'blur',
+  'mouseenter',
+  'mouseleave',
+  'submit',
+]);
+
+const FIRST_CLASS_OR_ID = /[.#]([A-Za-z_][\w-]*)/;
+const SEPARATOR = /[-_]+(\w)/g;
+
+export function actionName(selector: string, taken: Set<string>): string | null {
+  const match = FIRST_CLASS_OR_ID.exec(selector);
+  const captured = match?.[1];
+  if (!captured) return null;
+  const base = captured
+    .replace(SEPARATOR, (_, c: string) => c.toUpperCase())
+    .replace(/^[A-Z]/, (c) => c.toLowerCase());
+  let name = base;
+  let i = 2;
+  while (taken.has(name)) {
+    name = `${base}${i}`;
+    i += 1;
+  }
+  taken.add(name);
+  return name;
+}
+
+/** `html.find(SEL)` with `html` being the listener's parameter → the selector. */
+function findSelector(callee: Expression, htmlParam: string): string | null {
+  if (callee.type !== 'CallExpression') return null;
+  const c = callee.callee;
+  if (
+    c.type !== 'MemberExpression' ||
+    c.object.type !== 'Identifier' ||
+    c.object.name !== htmlParam
+  ) {
+    return null;
+  }
+  if (c.property.type !== 'Identifier' || c.property.name !== 'find') return null;
+  const [arg] = callee.arguments;
+  return arg && arg.type === 'StringLiteral' ? arg.value : null;
+}
+
+/** `this._onX.bind(this)` → `_onX`; `(ev) => this._onX(ev)` → `_onX`. */
+function forwardedMethod(handler: Node): string | null {
+  if (
+    handler.type === 'CallExpression' &&
+    handler.callee.type === 'MemberExpression' &&
+    handler.callee.property.type === 'Identifier' &&
+    handler.callee.property.name === 'bind' &&
+    handler.callee.object.type === 'MemberExpression' &&
+    handler.callee.object.object.type === 'ThisExpression' &&
+    handler.callee.object.property.type === 'Identifier'
+  ) {
+    return handler.callee.object.property.name;
+  }
+  if (handler.type === 'ArrowFunctionExpression') {
+    let call: Expression | null = null;
+    if (handler.body.type === 'CallExpression') call = handler.body;
+    else if (handler.body.type === 'BlockStatement' && handler.body.body.length === 1) {
+      const only = handler.body.body[0];
+      if (only?.type === 'ExpressionStatement' && only.expression.type === 'CallExpression') {
+        call = only.expression;
+      }
+      if (only?.type === 'ReturnStatement' && only.argument?.type === 'CallExpression') {
+        call = only.argument;
+      }
+    }
+    if (
+      call &&
+      call.callee.type === 'MemberExpression' &&
+      call.callee.object.type === 'ThisExpression' &&
+      call.callee.property.type === 'Identifier' &&
+      call.arguments.length <= 1
+    ) {
+      const [a] = call.arguments;
+      const p = handler.params[0];
+      if (!a || (a.type === 'Identifier' && p?.type === 'Identifier' && a.name === p.name)) {
+        return call.callee.property.name;
+      }
+    }
+  }
+  return null;
+}
+
+interface Bound {
+  selector: string;
+  event: string;
+  handler: Node;
+}
+
+/**
+ * `html.find(SEL).<event>(H)` or `html.find(SEL).on('<event>', H)` → the parts,
+ * or `null` when the statement is not a jQuery binding this can translate.
+ */
+function boundEvent(expr: Expression, htmlParam: string): Bound | null {
+  if (expr.type !== 'CallExpression') return null;
+  if (expr.callee.type !== 'MemberExpression' || expr.callee.property.type !== 'Identifier') {
+    return null;
+  }
+  const receiver = expr.callee.object;
+  if (receiver.type === 'Super') return null;
+  const selector = findSelector(receiver, htmlParam);
+  if (selector === null) return null;
+
+  const calleeName = expr.callee.property.name;
+  if (EVENTS.has(calleeName)) {
+    const handler = expr.arguments[0];
+    return handler ? { selector, event: calleeName, handler } : null;
+  }
+  if (calleeName === 'on' && expr.arguments.length === 2) {
+    const first = expr.arguments[0];
+    const handler = expr.arguments[1];
+    if (first?.type === 'StringLiteral' && handler) {
+      return { selector, event: first.value, handler };
+    }
+  }
+  return null;
+}
+
+export function extractListeners(cls: SheetClass, source: string): Listeners {
+  const out: Listeners = { actions: [], listeners: [], leftovers: [] };
+  const method = methodOf(cls.node, 'activateListeners');
+  if (!method) return out;
+  const p = method.params[0];
+  const htmlParam = p?.type === 'Identifier' ? p.name : 'html';
+  const taken = new Set<string>();
+
+  const leftover = (stmt: Statement): void => {
+    out.leftovers.push({ line: stmt.loc?.start.line ?? 0, text: text(source, stmt) });
+  };
+
+  const consider = (stmt: Statement): void => {
+    if (stmt.type !== 'ExpressionStatement') return;
+    const e = stmt.expression;
+    if (e.type === 'AwaitExpression') return;
+    // Anything that is not a method call, and super.activateListeners(html): dropped.
+    if (e.type !== 'CallExpression') return;
+    if (e.callee.type !== 'MemberExpression' || e.callee.property.type !== 'Identifier') return;
+    if (e.callee.object.type === 'Super') return;
+
+    const bound = boundEvent(e, htmlParam);
+    if (!bound) {
+      leftover(stmt);
+      return;
+    }
+    const { selector, event, handler } = bound;
+
+    if (event !== 'click') {
+      out.listeners.push({ selector, event, handlerText: text(source, handler) });
+      return;
+    }
+
+    const name = actionName(selector, taken);
+    if (name === null) {
+      leftover(stmt);
+      return;
+    }
+    const forwarded = forwardedMethod(handler);
+    if (forwarded) {
+      out.actions.push({
+        name,
+        selector,
+        kind: 'method',
+        method: forwarded,
+        param: null,
+        body: null,
+        isAsync: false,
+      });
+      return;
+    }
+    if (handler.type === 'ArrowFunctionExpression' || handler.type === 'FunctionExpression') {
+      const p0 = handler.params[0];
+      out.actions.push({
+        name,
+        selector,
+        kind: 'inline',
+        method: null,
+        param: p0?.type === 'Identifier' ? p0.name : null,
+        body: text(source, handler.body),
+        isAsync: Boolean(handler.async),
+      });
+      return;
+    }
+    leftover(stmt);
+  };
+
+  /** A guard such as `if (!this.options.editable) return;`: V2 sheets gate through isEditable. */
+  const isGuard = (stmt: Statement): boolean => {
+    if (stmt.type !== 'IfStatement' || stmt.alternate) return false;
+    const c = stmt.consequent;
+    if (c.type === 'ReturnStatement') return true;
+    return (
+      c.type === 'BlockStatement' && c.body.length === 1 && c.body[0]?.type === 'ReturnStatement'
+    );
+  };
+
+  const visit = (stmts: Statement[]): void => {
+    for (const stmt of stmts) {
+      if (isGuard(stmt)) continue;
+      if (stmt.type === 'IfStatement') {
+        // Bindings under a condition are still bindings; the condition itself is lost, so say so.
+        const branches = [stmt.consequent, stmt.alternate].filter((b): b is Statement =>
+          Boolean(b),
+        );
+        for (const b of branches) visit(b.type === 'BlockStatement' ? b.body : [b]);
+        out.leftovers.push({
+          line: stmt.loc?.start.line ?? 0,
+          text: `if (${text(source, stmt.test)}) guarded the bindings above it; V2 actions run regardless, gate inside the handler`,
+        });
+        continue;
+      }
+      if (stmt.type === 'BlockStatement') {
+        visit(stmt.body);
+        continue;
+      }
+      consider(stmt);
+    }
+  };
+  visit(method.body.body);
+  return out;
+}

--- a/packages/cli/src/migrate/sheet-listeners.ts
+++ b/packages/cli/src/migrate/sheet-listeners.ts
@@ -30,6 +30,8 @@ export interface Listeners {
   actions: ActionBinding[];
   listeners: ListenerBinding[];
   leftovers: Array<{ line: number; text: string }>;
+  /** The name `activateListeners` gave its jQuery root (`html` by convention). */
+  htmlParam: string;
 }
 
 const EVENTS = new Set([
@@ -161,11 +163,12 @@ function boundEvent(expr: Expression, htmlParam: string): Bound | null {
 }
 
 export function extractListeners(cls: SheetClass, source: string): Listeners {
-  const out: Listeners = { actions: [], listeners: [], leftovers: [] };
+  const out: Listeners = { actions: [], listeners: [], leftovers: [], htmlParam: 'html' };
   const method = methodOf(cls.node, 'activateListeners');
   if (!method) return out;
   const p = method.params[0];
   const htmlParam = p?.type === 'Identifier' ? p.name : 'html';
+  out.htmlParam = htmlParam;
   const taken = new Set<string>();
 
   const leftover = (stmt: Statement): void => {

--- a/packages/cli/src/migrate/sheet-options.ts
+++ b/packages/cli/src/migrate/sheet-options.ts
@@ -1,0 +1,200 @@
+/**
+ * `static get defaultOptions()` → the V2 statics.
+ *
+ * Reads the object literal handed to `mergeObject(super.defaultOptions, {...})`
+ * (or returned directly) and maps the keys the v1 sheets used: `classes`,
+ * `template`, `width`/`height`, `resizable`, `submitOnChange`, `tabs`,
+ * `dragDrop`. Anything else is listed so the reader decides.
+ */
+import type { ClassMethod, Expression, ObjectExpression, ObjectProperty } from '@babel/types';
+import { methodOf, type SheetClass, text, walk } from './parse.js';
+
+export interface SheetOptions {
+  classes: string | null;
+  width: number | null;
+  height: number | null;
+  resizable: boolean | null;
+  submitOnChange: boolean | null;
+  template: string | null;
+  templateGetter: ClassMethod | null;
+  tabs: Array<{ navSelector: string; contentSelector: string | null; initial: string | null }>;
+  dragDrop: string | null;
+  unknown: string[];
+}
+
+function keyName(p: ObjectProperty): string | null {
+  if (p.key.type === 'Identifier') return p.key.name;
+  if (p.key.type === 'StringLiteral') return p.key.value;
+  return null;
+}
+
+const NOT_A_VALUE = new Set(['ArrayPattern', 'ObjectPattern', 'AssignmentPattern', 'RestElement']);
+
+function props(obj: ObjectExpression): Array<[string, Expression]> {
+  const out: Array<[string, Expression]> = [];
+  for (const p of obj.properties) {
+    if (p.type !== 'ObjectProperty') continue;
+    const k = keyName(p);
+    if (k && !NOT_A_VALUE.has(p.value.type)) out.push([k, p.value as Expression]);
+  }
+  return out;
+}
+
+function str(e: Expression): string | null {
+  return e.type === 'StringLiteral' ? e.value : null;
+}
+function num(e: Expression): number | null {
+  return e.type === 'NumericLiteral' ? e.value : null;
+}
+function bool(e: Expression): boolean | null {
+  return e.type === 'BooleanLiteral' ? e.value : null;
+}
+
+/** The options literal: the last object argument of the returned call, or the returned object. */
+function optionsLiteral(method: ClassMethod): ObjectExpression | null {
+  let found: ObjectExpression | null = null;
+  walk(method.body, (n) => {
+    if (found) return false;
+    if (n.type !== 'ReturnStatement' || !n.argument) return undefined;
+    const arg = n.argument;
+    if (arg.type === 'ObjectExpression') {
+      found = arg;
+    } else if (arg.type === 'CallExpression') {
+      const last = [...arg.arguments].reverse().find((a) => a.type === 'ObjectExpression');
+      if (last?.type === 'ObjectExpression') found = last;
+    }
+    return false;
+  });
+  return found;
+}
+
+export function extractOptions(cls: SheetClass, source: string): SheetOptions {
+  const out: SheetOptions = {
+    classes: null,
+    width: null,
+    height: null,
+    resizable: null,
+    submitOnChange: null,
+    template: null,
+    templateGetter: methodOf(cls.node, 'template', { kind: 'get', static: false }),
+    tabs: [],
+    dragDrop: null,
+    unknown: [],
+  };
+  const method = methodOf(cls.node, 'defaultOptions', { static: true, kind: 'get' });
+  const literal = method ? optionsLiteral(method) : null;
+  if (!literal) return out;
+  for (const [key, value] of props(literal)) {
+    switch (key) {
+      case 'classes':
+        out.classes = text(source, value);
+        break;
+      case 'width':
+        out.width = num(value);
+        break;
+      case 'height':
+        out.height = num(value);
+        break;
+      case 'resizable':
+        out.resizable = bool(value);
+        break;
+      case 'submitOnChange':
+        out.submitOnChange = bool(value);
+        break;
+      case 'template':
+        out.template = str(value);
+        break;
+      case 'dragDrop':
+        out.dragDrop = text(source, value);
+        break;
+      case 'tabs':
+        out.tabs.push(...readTabs(value));
+        break;
+      default:
+        out.unknown.push(key);
+    }
+  }
+  return out;
+}
+
+function readTabs(value: Expression): SheetOptions['tabs'] {
+  if (value.type !== 'ArrayExpression') return [];
+  const tabs: SheetOptions['tabs'] = [];
+  for (const el of value.elements) {
+    if (el?.type !== 'ObjectExpression') continue;
+    const t = Object.fromEntries(props(el));
+    const nav = t.navSelector ? str(t.navSelector) : null;
+    if (!nav) continue;
+    tabs.push({
+      navSelector: nav,
+      contentSelector: t.contentSelector ? str(t.contentSelector) : null,
+      initial: t.initial ? str(t.initial) : null,
+    });
+  }
+  return tabs;
+}
+
+const q = (s: string) => `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+
+export function renderStatics(
+  opts: SheetOptions,
+  tabIds: Record<string, string[]>,
+  todo: (msg: string) => string,
+): string {
+  const lines: string[] = [];
+  lines.push('  /** @override */');
+  lines.push('  static DEFAULT_OPTIONS = foundry.utils.mergeObject(');
+  lines.push('    super.DEFAULT_OPTIONS,');
+  lines.push('    {');
+  if (opts.classes) lines.push(`      classes: ${opts.classes},`);
+  if (opts.width !== null || opts.height !== null) {
+    const parts = [
+      opts.width !== null ? `width: ${opts.width}` : '',
+      opts.height !== null ? `height: ${opts.height}` : '',
+    ].filter(Boolean);
+    lines.push(`      position: { ${parts.join(', ')} },`);
+  }
+  if (opts.resizable !== null) lines.push(`      window: { resizable: ${opts.resizable} },`);
+  lines.push(`      form: { submitOnChange: ${opts.submitOnChange ?? true} },`);
+  lines.push('      actions: {}, // filled below');
+  lines.push('    },');
+  lines.push('    { inplace: false },');
+  lines.push('  );');
+  for (const key of opts.unknown) {
+    lines.push(
+      `  ${todo(`${key} from defaultOptions has no V2 equivalent here; move it by hand or drop it`)}`,
+    );
+  }
+
+  if (opts.tabs.length > 0) {
+    lines.push('', '  /** @override */', '  static TABS = {');
+    for (const [i, tab] of opts.tabs.entries()) {
+      const group = i === 0 ? 'primary' : `group${i + 1}`;
+      const ids = tabIds[tab.navSelector] ?? [];
+      const initial = tab.initial ?? ids[0] ?? '';
+      if (ids.length === 0) {
+        lines.push(
+          `    ${todo(`tab ids for ${tab.navSelector} were not found in the template; list them here`)}`,
+        );
+      }
+      lines.push(
+        `    ${group}: { tabs: [${ids.map((id) => `{ id: ${q(id)} }`).join(', ')}], initial: ${q(initial)} },`,
+      );
+    }
+    lines.push('  };');
+  }
+  if (opts.dragDrop) {
+    lines.push('', '  /** @override */', `  static DRAG_DROP = ${opts.dragDrop};`);
+  }
+  lines.push('', '  /** @override */', '  static PARTS = {');
+  if (opts.template) {
+    lines.push(`    sheet: { template: ${q(opts.template)} },`);
+  } else {
+    lines.push(
+      `    ${todo('the template is chosen at runtime (get template); name one part per type here or override _configureRenderParts')}`,
+      `    sheet: { template: '' },`,
+    );
+  }
+  lines.push('  };');
+  return lines.join('\n');
+}

--- a/packages/cli/src/migrate/sheet-templates.ts
+++ b/packages/cli/src/migrate/sheet-templates.ts
@@ -1,0 +1,170 @@
+/**
+ * The template side of `migrate --sheets`: attribute insertions on opening
+ * tags, nothing else. A V2 sheet finds its handlers by `data-action`, and the
+ * SDK's tab action by `data-action="vttforgeTab"` plus `data-group` on the
+ * links and the panes. Handlebars blocks and expressions are left alone; only
+ * literal `class` / `id` / `data-tab` attributes are matched, and a tab id
+ * that is an expression is skipped when reading the ids.
+ */
+
+export interface TemplateEdit {
+  line: number;
+  before: string;
+  after: string;
+}
+
+export interface TemplateResult {
+  output: string;
+  edits: TemplateEdit[];
+  formRoot: boolean;
+}
+
+/**
+ * One opening tag: the name, the attribute run, and the self-closing slash.
+ * Exactly three capture groups — `editTemplate` reads the replacer's `offset`
+ * as the fourth argument, so a fourth group would shift every reported line.
+ * A fresh regex per call: a shared global one carries `lastIndex` between
+ * `readTabIds`, `elementRange` and `String#replace`.
+ */
+const tagRe = () =>
+  /<([a-zA-Z][\w-]*)((?:\s+[^\s=>/]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?)*)\s*(\/?)>/g;
+
+/** The value of one attribute in a tag's attribute run, or null when absent. */
+function attr(attrs: string, name: string): string | null {
+  const m = new RegExp(`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`).exec(attrs);
+  return m ? (m[1] ?? m[2] ?? m[3] ?? '') : null;
+}
+
+function hasClass(attrs: string, cls: string): boolean {
+  return (attr(attrs, 'class') ?? '').split(/\s+/).includes(cls);
+}
+
+/** Only `.class` and `#id` selectors match; anything else stays for `_onRender`. */
+function matches(attrs: string, selector: string): boolean {
+  const m = /^([.#])([A-Za-z_][\w-]*)/.exec(selector.trim());
+  if (!m) {
+    return false;
+  }
+  const [, kind = '', name = ''] = m;
+  if (!name) {
+    return false;
+  }
+  return kind === '.' ? hasClass(attrs, name) : attr(attrs, 'id') === name;
+}
+
+function lineOf(text: string, index: number): number {
+  let n = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (text[i] === '\n') {
+      n += 1;
+    }
+  }
+  return n;
+}
+
+/**
+ * Index range of the first element a selector opens, through its closing tag.
+ * Depth-aware on the tag name, so a nested `<div>` inside the match does not
+ * end it early.
+ */
+function elementRange(template: string, selector: string): [number, number] | null {
+  for (const m of template.matchAll(tagRe())) {
+    const [whole, name, attrs = ''] = m;
+    if (m.index === undefined || !name || !matches(attrs, selector)) {
+      continue;
+    }
+    const open = new RegExp(`<${name}\\b`, 'g');
+    const close = new RegExp(`</${name}\\s*>`, 'g');
+    let depth = 1;
+    let pos = m.index + whole.length;
+    while (depth > 0) {
+      open.lastIndex = pos;
+      close.lastIndex = pos;
+      const o = open.exec(template);
+      const c = close.exec(template);
+      if (!c) {
+        return [m.index, template.length];
+      }
+      if (o && o.index < c.index) {
+        depth += 1;
+        pos = o.index + o[0].length;
+      } else {
+        depth -= 1;
+        pos = c.index + c[0].length;
+      }
+    }
+    return [m.index, pos];
+  }
+  return null;
+}
+
+/**
+ * The `data-tab` values under a tabs nav, in document order. A value holding
+ * an expression is skipped: its id is only known at render time.
+ */
+export function readTabIds(template: string, navSelector: string): string[] {
+  const range = elementRange(template, navSelector);
+  if (!range) {
+    return [];
+  }
+  const nav = template.slice(range[0], range[1]);
+  const ids: string[] = [];
+  for (const m of nav.matchAll(tagRe())) {
+    const id = attr(m[2] ?? '', 'data-tab');
+    if (id && !id.includes('{{')) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Add the attributes the generated sheet needs, and report each opening tag
+ * that changed. Every other byte of the template is left where it was.
+ */
+export function editTemplate(
+  template: string,
+  opts: { actions: Array<{ name: string; selector: string }>; navSelectors: string[] },
+): TemplateResult {
+  const edits: TemplateEdit[] = [];
+  const navRanges = opts.navSelectors
+    .map((selector) => elementRange(template, selector))
+    .filter((range): range is [number, number] => range !== null);
+  const inNav = (index: number) => navRanges.some(([start, end]) => index >= start && index < end);
+
+  const output = template.replace(
+    tagRe(),
+    (whole: string, name: string, attrs: string, selfClose: string, offset: number) => {
+      const add: string[] = [];
+      const hasAction = attr(attrs, 'data-action') !== null;
+      if (!hasAction) {
+        for (const action of opts.actions) {
+          if (matches(attrs, action.selector)) {
+            add.push(`data-action="${action.name}"`);
+            break;
+          }
+        }
+      }
+      const tab = attr(attrs, 'data-tab');
+      const needsGroup = attr(attrs, 'data-group') === null;
+      if (tab !== null && inNav(offset)) {
+        if (!hasAction && !add.some((one) => one.startsWith('data-action='))) {
+          add.push('data-action="vttforgeTab"');
+        }
+        if (needsGroup) {
+          add.push('data-group="primary"');
+        }
+      } else if (tab !== null && needsGroup && hasClass(attrs, 'tab')) {
+        add.push('data-group="primary"');
+      }
+      if (add.length === 0) {
+        return whole;
+      }
+      const after = `<${name}${attrs.replace(/\s+$/, '')} ${add.join(' ')}${selfClose ? ' /' : ''}>`;
+      edits.push({ line: lineOf(template, offset), before: whole, after });
+      return after;
+    },
+  );
+
+  return { output, edits, formRoot: /^\s*<form\b/.test(template) };
+}

--- a/packages/cli/src/migrate/sheet-templates.ts
+++ b/packages/cli/src/migrate/sheet-templates.ts
@@ -26,8 +26,10 @@ export interface TemplateResult {
  * A fresh regex per call: a shared global one carries `lastIndex` between
  * `readTabIds`, `elementRange` and `String#replace`.
  */
+// An opening tag: the name, then attributes and Handlebars mustaches (`{{#if x}}disabled{{/if}}`
+// sits inside a tag as an opaque token), then an optional self-closing slash.
 const tagRe = () =>
-  /<([a-zA-Z][\w-]*)((?:\s+[^\s=>/]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?)*)\s*(\/?)>/g;
+  /<([a-zA-Z][\w-]*)((?:\s*\{\{[^{}]*\}\}|\s+[^\s=>/{]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?|(?<=\}\})[^\s=>/{]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?)*)\s*(\/?)>/g;
 
 /** The value of one attribute in a tag's attribute run, or null when absent. */
 function attr(attrs: string, name: string): string | null {
@@ -147,20 +149,39 @@ export function editTemplate(
       }
       const tab = attr(attrs, 'data-tab');
       const needsGroup = attr(attrs, 'data-group') === null;
-      if (tab !== null && inNav(offset)) {
+      let withClass = attrs;
+      const isNavLink = tab !== null && inNav(offset);
+      const isPane = tab !== null && !isNavLink && hasClass(attrs, 'tab');
+      if (isNavLink) {
         if (!hasAction && !add.some((one) => one.startsWith('data-action='))) {
           add.push('data-action="vttforgeTab"');
         }
         if (needsGroup) {
           add.push('data-group="primary"');
         }
-      } else if (tab !== null && needsGroup && hasClass(attrs, 'tab')) {
+      } else if (isPane && needsGroup) {
         add.push('data-group="primary"');
       }
-      if (add.length === 0) {
+      // The active tab comes from the context: `{{tabs.<id>.cssClass}}` on the link and the pane.
+      if (
+        (isNavLink || isPane) &&
+        tab !== null &&
+        !tab.includes('{{') &&
+        !/\{\{\s*tabs\./.test(attrs)
+      ) {
+        const marker = `{{tabs.${tab}.cssClass}}`;
+        withClass = /\sclass\s*=\s*"([^"]*)"/.test(attrs)
+          ? attrs.replace(
+              /(\sclass\s*=\s*")([^"]*)(")/,
+              (_m, open, value, close) => `${open}${value.trimEnd()} ${marker}${close}`,
+            )
+          : attrs;
+        if (withClass === attrs) add.push(`class="${marker}"`);
+      }
+      if (add.length === 0 && withClass === attrs) {
         return whole;
       }
-      const after = `<${name}${attrs.replace(/\s+$/, '')} ${add.join(' ')}${selfClose ? ' /' : ''}>`;
+      const after = `<${name}${withClass.replace(/\s+$/, '')}${add.length > 0 ? ` ${add.join(' ')}` : ''}${selfClose ? ' /' : ''}>`;
       edits.push({ line: lineOf(template, offset), before: whole, after });
       return after;
     },

--- a/packages/cli/src/migrate/sheets.ts
+++ b/packages/cli/src/migrate/sheets.ts
@@ -1,0 +1,323 @@
+/**
+ * One v1 sheet class → one file on the SDK base.
+ *
+ * Structure comes from the AST (which members exist, where each one starts
+ * and ends); every body is the original text with the scoped rewrites from
+ * `sheet-bodies.ts`. The result is meant to be read, not trusted: each place
+ * the planner could not decide carries a `// TODO(migrate)` line, and those
+ * lines are listed in the report with their line numbers.
+ */
+import type { ClassMethod } from '@babel/types';
+import {
+  findSheetClasses,
+  methodOf,
+  parseSource,
+  type SheetClass,
+  text,
+  unsupportedBases,
+} from './parse.js';
+import {
+  rewriteDialogs,
+  rewriteDropMethod,
+  rewriteGetData,
+  rewriteHandlerBody,
+  TODO,
+} from './sheet-bodies.js';
+import { type ActionBinding, extractListeners } from './sheet-listeners.js';
+import { extractOptions, renderStatics } from './sheet-options.js';
+
+export interface SheetPlanFile {
+  from: string;
+  to: string;
+  className: string;
+  base: 'BaseActorSheet' | 'BaseItemSheet';
+  source: string;
+  actions: Array<{ name: string; selector: string; method: string }>;
+  todos: Array<{ line: number; message: string }>;
+  /** Template paths the class names, for the template pass. */
+  templates: string[];
+  tabNavSelectors: string[];
+}
+
+export interface SheetPlan {
+  files: SheetPlanFile[];
+  notes: string[];
+}
+
+const HANDLED = new Set([
+  'defaultOptions',
+  'getData',
+  'activateListeners',
+  '_onDropItem',
+  '_onDropActor',
+]);
+const ACTIONS_PLACEHOLDER = '      actions: {}, // filled below';
+
+function methodName(m: ClassMethod): string | null {
+  return m.key.type === 'Identifier' ? m.key.name : null;
+}
+
+const pascal = (s: string) => s.replace(/^[a-z]/, (c) => c.toUpperCase());
+const single = (s: string) => `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+
+/** Re-indent a member slice so its first line sits at two spaces. */
+function reindent(memberText: string): string {
+  const lines = memberText.split('\n');
+  const first = lines[0] ?? '';
+  const rest = lines.slice(1);
+  const indents = rest
+    .filter((l) => l.trim().length > 0)
+    .map((l) => /^[ \t]*/.exec(l)?.[0].length ?? 0);
+  const min = indents.length > 0 ? Math.min(...indents) : 0;
+  // The body sits one level under the member; keep that level at four spaces.
+  const strip = Math.max(0, min - 4);
+  const body = rest.map((l) => {
+    if (l.trim().length === 0) return '';
+    const own = /^[ \t]*/.exec(l)?.[0].length ?? 0;
+    return l.slice(Math.min(strip, own));
+  });
+  return [`  ${first.trimStart()}`, ...body].join('\n');
+}
+
+/** Ensure `(event, target)` on a handler method, keeping the event name it used. */
+function handlerSignature(
+  methodText: string,
+  name: string,
+): { code: string; eventParam: string | null } {
+  const escaped = name.replace(/[$]/g, '\\$');
+  const sig = new RegExp(`^(\\s*(?:async\\s+)?${escaped}\\s*\\()([^)]*)(\\))`);
+  const m = sig.exec(methodText);
+  if (!m) return { code: methodText, eventParam: null };
+  const params = (m[2] ?? '')
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const eventParam = params[0] ?? null;
+  const first = eventParam ?? 'event';
+  return { code: methodText.replace(sig, `$1${first}, target$3`), eventParam };
+}
+
+/** The first parameter name of a method, from its signature text. */
+function firstParam(methodText: string, name: string): string | null {
+  const escaped = name.replace(/[$]/g, '\\$');
+  const m = new RegExp(`^\\s*(?:async\\s+)?${escaped}\\s*\\(([^)]*)\\)`).exec(methodText);
+  const first = (m?.[1] ?? '').split(',')[0]?.trim();
+  return first ? first : null;
+}
+
+/** A block body lifted out of `activateListeners`: inner lines at four spaces, the brace at two. */
+function dedentBlock(block: string): string {
+  const lines = block.split('\n');
+  if (lines.length < 2) return block;
+  const inner = lines.slice(1, -1);
+  const indents = inner
+    .filter((l) => l.trim().length > 0)
+    .map((l) => /^[ \t]*/.exec(l)?.[0].length ?? 0);
+  const min = indents.length > 0 ? Math.min(...indents) : 0;
+  const body = inner.map((l) =>
+    l.trim().length === 0
+      ? ''
+      : `    ${l.slice(Math.min(min, /^[ \t]*/.exec(l)?.[0].length ?? 0))}`,
+  );
+  return [lines[0] ?? '{', ...body, '  }'].join('\n');
+}
+
+function importLines(source: string, lang: 'js' | 'ts'): string[] {
+  const ast = parseSource(source, lang);
+  const lines: string[] = [];
+  for (const n of ast.program.body) if (n.type === 'ImportDeclaration') lines.push(text(source, n));
+  return lines;
+}
+
+function isExported(source: string, cls: SheetClass): boolean {
+  const start = cls.node.start ?? 0;
+  const before = source.slice(Math.max(0, start - 40), start);
+  return (
+    /export\s+(?:default\s+)?$/.test(before) ||
+    new RegExp(`export\\s+\\{[^}]*\\b${cls.name}\\b`).test(source)
+  );
+}
+
+interface ClassOutput {
+  block: string;
+  base: SheetPlanFile['base'];
+  actions: SheetPlanFile['actions'];
+  templates: string[];
+  navs: string[];
+  usesDialogV2: boolean;
+}
+
+function planClass(cls: SheetClass, source: string, tabIds: Record<string, string[]>): ClassOutput {
+  const base: SheetPlanFile['base'] =
+    cls.base === 'ActorSheet' ? 'BaseActorSheet' : 'BaseItemSheet';
+  const own = cls.base === 'ActorSheet' ? 'actor' : 'item';
+  const options = extractOptions(cls, source);
+  const listeners = extractListeners(cls, source);
+  const templates = new Set<string>();
+  const navs = new Set<string>();
+  let usesDialogV2 = false;
+
+  if (options.template) templates.add(options.template);
+  if (options.templateGetter) {
+    for (const m of text(source, options.templateGetter).matchAll(
+      /["'`]([^"'`$]+\.(?:hbs|html))["'`]/g,
+    )) {
+      if (m[1]) templates.add(m[1]);
+    }
+  }
+  for (const t of options.tabs) navs.add(t.navSelector);
+
+  const members: string[] = [];
+  const todo = (msg: string) => TODO(msg);
+
+  // 1. Statics, with the actions block filled in.
+  const actionEntries = listeners.actions.map((a) => ({
+    name: a.name,
+    selector: a.selector,
+    method: a.kind === 'method' && a.method ? a.method : `_on${pascal(a.name)}`,
+  }));
+  const actionsBlock =
+    actionEntries.length === 0
+      ? '      actions: {},'
+      : `      actions: {\n${actionEntries.map((a) => `        ${a.name}: ${cls.name}.prototype.${a.method},`).join('\n')}\n      },`;
+  members.push(renderStatics(options, tabIds, todo).replace(ACTIONS_PLACEHOLDER, actionsBlock));
+
+  // 2. The document getter.
+  if (!methodOf(cls.node, own, { kind: 'get' })) {
+    members.push(`  get ${own}() {\n    return this.document;\n  }`);
+  }
+
+  // 3. The template getter, when dynamic.
+  if (options.templateGetter) members.push(reindent(text(source, options.templateGetter)));
+
+  // 4. getData → _prepareContext.
+  const getData = methodOf(cls.node, 'getData');
+  if (getData) members.push(rewriteGetData(reindent(text(source, getData)), cls.base).code);
+
+  // 5. _onRender for the events that are not clicks.
+  if (listeners.listeners.length > 0) {
+    const body = listeners.listeners
+      .map(
+        (l) =>
+          `    for (const el of this.element.querySelectorAll(${single(l.selector)})) {\n      el.addEventListener(${single(l.event)}, ${l.handlerText});\n    }`,
+      )
+      .join('\n');
+    members.push(
+      `  /** @override */\n  _onRender(context, options) {\n    super._onRender(context, options);\n${body}\n  }`,
+    );
+  }
+
+  // 6. Every other member, rewritten by role.
+  const handlerNames = new Set(
+    listeners.actions.filter((a) => a.kind === 'method' && a.method).map((a) => a.method as string),
+  );
+  // Methods a render listener forwards to keep their event; jQuery on it still goes.
+  const listenerTargets = new Set(
+    listeners.listeners.flatMap((l) =>
+      [...l.handlerText.matchAll(/this\.(\w+)/g)].map((m) => m[1] ?? ''),
+    ),
+  );
+  const applyDialogs = (code: string): string => {
+    const d = rewriteDialogs(code);
+    if (/DialogV2\./.test(d.code)) usesDialogV2 = true;
+    return d.code;
+  };
+  for (const member of cls.node.body.body) {
+    if (
+      member.type !== 'ClassMethod' &&
+      member.type !== 'ClassProperty' &&
+      member.type !== 'ClassPrivateMethod'
+    )
+      continue;
+    const name = member.type === 'ClassMethod' ? methodName(member) : null;
+    if (name && HANDLED.has(name)) continue;
+    if (name === 'template' && member.type === 'ClassMethod' && member.kind === 'get') continue;
+    let code = reindent(text(source, member));
+    if (name && handlerNames.has(name)) {
+      const sig = handlerSignature(code, name);
+      code = rewriteHandlerBody(sig.code, sig.eventParam, null).code;
+    } else if (name && listenerTargets.has(name)) {
+      const ev = firstParam(code, name);
+      code = rewriteHandlerBody(code, ev, null, ev ? `${ev}.currentTarget` : 'target').code;
+    }
+    if (name === '_updateObject') {
+      code = `  ${todo('_updateObject is gone on V2; DocumentSheetV2 submits the form itself. Move any shaping into _prepareSubmitData or delete this')}\n${code}`;
+    }
+    members.push(applyDialogs(code));
+  }
+  for (const which of ['Item', 'Actor'] as const) {
+    const m = methodOf(cls.node, `_onDrop${which}`);
+    if (!m) continue;
+    members.push(applyDialogs(rewriteDropMethod(reindent(text(source, m)), which).code));
+  }
+
+  // 7. Inline handlers become methods.
+  const inline: ActionBinding[] = listeners.actions.filter((a) => a.kind === 'inline');
+  for (const a of inline) {
+    const method = `_on${pascal(a.name)}`;
+    const rewritten = applyDialogs(rewriteHandlerBody(a.body ?? '{}', a.param, null).code).trim();
+    const body = rewritten.startsWith('{')
+      ? dedentBlock(rewritten)
+      : `{\n    return ${rewritten};\n  }`;
+    members.push(`  ${a.isAsync ? 'async ' : ''}${method}(${a.param ?? 'event'}, target) ${body}`);
+  }
+  for (const l of listeners.leftovers) {
+    members.push(
+      `  ${todo(`from activateListeners, line ${l.line}: ${l.text.replace(/\s+/g, ' ')}`)}`,
+    );
+  }
+
+  const exported = isExported(source, cls);
+  const block = `${exported ? 'export ' : ''}class ${cls.name} extends ${base}() {\n${members.join('\n\n')}\n}`;
+  return {
+    block,
+    base,
+    actions: actionEntries,
+    templates: [...templates],
+    navs: [...navs],
+    usesDialogV2,
+  };
+}
+
+export function planSheetFile(
+  relPath: string,
+  source: string,
+  opts: { lang: 'js' | 'ts'; tabIds: Record<string, string[]> },
+): SheetPlan {
+  const lang: 'js' | 'ts' = relPath.endsWith('.ts') ? 'ts' : opts.lang;
+  const ast = parseSource(source, lang);
+  const classes = findSheetClasses(ast, source);
+  const notes = unsupportedBases(ast, source).map(
+    (u) =>
+      `${relPath}:${u.line} ${u.name} extends ${u.superText}; only ActorSheet and ItemSheet are converted, this one stays as it is`,
+  );
+  if (classes.length === 0) return { files: [], notes };
+
+  const dot = relPath.lastIndexOf('.');
+  const to = `${relPath.slice(0, dot)}.v2${relPath.slice(dot)}`;
+  const outputs = classes.map((cls) => ({ cls, out: planClass(cls, source, opts.tabIds) }));
+
+  const bases = [...new Set(outputs.map((o) => o.out.base))].join(', ');
+  const header = [`import { ${bases} } from '@vttforge/core';`, ...importLines(source, lang)];
+  if (outputs.some((o) => o.out.usesDialogV2))
+    header.push('', 'const { DialogV2 } = foundry.applications.api;');
+  const fileSource = `${header.join('\n')}\n\n${outputs.map((o) => o.out.block).join('\n\n')}\n`;
+  const marker = 'TODO(migrate): ';
+  const todos = fileSource.split('\n').flatMap((line, i) => {
+    const at = line.indexOf(marker);
+    return at === -1 ? [] : [{ line: i + 1, message: line.slice(at + marker.length).trim() }];
+  });
+
+  const files: SheetPlanFile[] = outputs.map(({ cls, out }) => ({
+    from: relPath,
+    to,
+    className: cls.name,
+    base: out.base,
+    source: fileSource,
+    actions: out.actions,
+    todos,
+    templates: out.templates,
+    tabNavSelectors: out.navs,
+  }));
+  return { files, notes };
+}

--- a/packages/cli/src/migrate/sheets.ts
+++ b/packages/cli/src/migrate/sheets.ts
@@ -105,6 +105,25 @@ function firstParam(methodText: string, name: string): string | null {
   return first ? first : null;
 }
 
+/** Lines after the first sit at `spaces`, keeping their relative indentation. */
+function indentTo(snippet: string, spaces: number): string {
+  const lines = snippet.split('\n');
+  const rest = lines.slice(1);
+  const indents = rest
+    .filter((l) => l.trim().length > 0)
+    .map((l) => /^[ \t]*/.exec(l)?.[0].length ?? 0);
+  const min = indents.length > 0 ? Math.min(...indents) : 0;
+  const pad = ' '.repeat(spaces);
+  return [
+    (lines[0] ?? '').trimStart(),
+    ...rest.map((l) =>
+      l.trim().length === 0
+        ? ''
+        : `${pad}${l.slice(Math.min(min, /^[ \t]*/.exec(l)?.[0].length ?? 0))}`,
+    ),
+  ].join('\n');
+}
+
 /** A block body lifted out of `activateListeners`: inner lines at four spaces, the brace at two. */
 function dedentBlock(block: string): string {
   const lines = block.split('\n');
@@ -180,7 +199,9 @@ function planClass(cls: SheetClass, source: string, tabIds: Record<string, strin
     actionEntries.length === 0
       ? '      actions: {},'
       : `      actions: {\n${actionEntries.map((a) => `        ${a.name}: ${cls.name}.prototype.${a.method},`).join('\n')}\n      },`;
-  members.push(renderStatics(options, tabIds, todo).replace(ACTIONS_PLACEHOLDER, actionsBlock));
+  // A runtime `get template()` decides the template; a static one next to it is not the whole story.
+  const statics = options.templateGetter ? { ...options, template: null } : options;
+  members.push(renderStatics(statics, tabIds, todo).replace(ACTIONS_PLACEHOLDER, actionsBlock));
 
   // 2. The document getter.
   if (!methodOf(cls.node, own, { kind: 'get' })) {
@@ -197,10 +218,22 @@ function planClass(cls: SheetClass, source: string, tabIds: Record<string, strin
   // 5. _onRender for the events that are not clicks.
   if (listeners.listeners.length > 0) {
     const body = listeners.listeners
-      .map(
-        (l) =>
-          `    for (const el of this.element.querySelectorAll(${single(l.selector)})) {\n      el.addEventListener(${single(l.event)}, ${l.handlerText});\n    }`,
-      )
+      .map((l) => {
+        const param = /^\s*(?:async\s+)?\(?\s*(\w+)/.exec(l.handlerText)?.[1] ?? null;
+        const isFunction = /^\s*(?:async\s+)?(?:\(|\w+\s*=>|function\b)/.test(l.handlerText);
+        const handler = isFunction
+          ? indentTo(
+              rewriteHandlerBody(
+                l.handlerText,
+                param,
+                listeners.htmlParam,
+                param ? `${param}.currentTarget` : 'target',
+              ).code,
+              6,
+            )
+          : l.handlerText;
+        return `    for (const el of this.element.querySelectorAll(${single(l.selector)})) {\n      el.addEventListener(${single(l.event)}, ${handler});\n    }`;
+      })
       .join('\n');
     members.push(
       `  /** @override */\n  _onRender(context, options) {\n    super._onRender(context, options);\n${body}\n  }`,

--- a/packages/cli/src/migrate/sheets.ts
+++ b/packages/cli/src/migrate/sheets.ts
@@ -44,6 +44,20 @@ export interface SheetPlan {
   notes: string[];
 }
 
+/** v1 lifecycle methods a sheet used to override; V2 has other hooks for the same jobs. */
+const V1_LIFECYCLE = new Set([
+  'setPosition',
+  '_getHeaderButtons',
+  '_render',
+  '_renderInner',
+  '_replaceHTML',
+  '_onSubmit',
+  '_getSubmitData',
+  '_onChangeInput',
+  'activateEditor',
+  'close',
+]);
+
 const HANDLED = new Set([
   'defaultOptions',
   'getData',
@@ -272,6 +286,12 @@ function planClass(cls: SheetClass, source: string, tabIds: Record<string, strin
     } else if (name && listenerTargets.has(name)) {
       const ev = firstParam(code, name);
       code = rewriteHandlerBody(code, ev, null, ev ? `${ev}.currentTarget` : 'target').code;
+    } else if (member.type === 'ClassMethod') {
+      // Any other method: the jQuery idioms with a DOM equivalent, the rest flagged.
+      code = rewriteHandlerBody(code, null, null).code;
+    }
+    if (name && V1_LIFECYCLE.has(name)) {
+      code = `  ${todo(`${name} is an Application v1 lifecycle override; ApplicationV2 sizes, submits and builds its header itself. Review it against the V2 method of the same job, or delete it`)}\n${code}`;
     }
     if (name === '_updateObject') {
       code = `  ${todo('_updateObject is gone on V2; DocumentSheetV2 submits the form itself. Move any shaping into _prepareSubmitData or delete this')}\n${code}`;

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -16,7 +16,7 @@
     "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.12.0",
+    "@vttforge/cli": "^0.13.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -17,7 +17,7 @@
     "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.12.0",
+    "@vttforge/cli": "^0.13.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -17,7 +17,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.12.0",
+    "@vttforge/cli": "^0.13.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -18,7 +18,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.12.0",
+    "@vttforge/cli": "^0.13.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,15 @@ catalogs:
     '@babel/core':
       specifier: ^8.0.1
       version: 8.0.1
+    '@babel/parser':
+      specifier: ^8.0.4
+      version: 8.0.4
     '@babel/plugin-proposal-decorators':
       specifier: ^8.0.2
       version: 8.0.2
+    '@babel/types':
+      specifier: ^8.0.4
+      version: 8.0.4
     '@biomejs/biome':
       specifier: ^2.5.11
       version: 2.5.11
@@ -210,6 +216,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@babel/parser':
+        specifier: 'catalog:'
+        version: 8.0.4
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 2.5.11
@@ -226,6 +235,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.5
+      '@babel/types':
+        specifier: 'catalog:'
+        version: 8.0.4
       '@types/archiver':
         specifier: 'catalog:'
         version: 8.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,8 @@ catalog:
   '@rolldown/plugin-babel': ^0.2.4
   '@babel/plugin-proposal-decorators': ^8.0.2
   '@babel/core': ^8.0.1
+  '@babel/parser': ^8.0.4
+  '@babel/types': ^8.0.4
 
 # pnpm 11 reads settings from here, not .npmrc — .npmrc keeps registry and auth
 # only. It does not warn when it finds them in the old place, so anything left


### PR DESCRIPTION
## What

`vttforge migrate --sheets [dir] [--lang js|ts] [--write]`.

Next to each Application v1 sheet class (`ActorSheet`, `ItemSheet`, bare or under `foundry.appv1.sheets`), it writes the same class on `BaseActorSheet` / `BaseItemSheet` from `@vttforge/core`, as `<name>.v2.<ext>`. The original is never touched. Preview by default; `--write` writes the new files and edits the templates the class uses.

Mechanical, from the AST for structure and the original text for bodies:

- `defaultOptions` → `DEFAULT_OPTIONS` (classes, `position`, `window.resizable`, `form.submitOnChange`), `tabs` → `TABS` with the ids read from the template, `dragDrop` → `DRAG_DROP`, `template` → `PARTS`.
- `getData` → `_prepareContext(options)`, with `actor`/`item`, `data`, `system`, `items`, `editable` and `owner` set on the context the way v1 handed them to the template.
- Every `html.find(sel).click(handler)` → an `actions` entry named after the selector; the handler moves to `(event, target)`. A bound method stays a method, an inline arrow becomes one. `dblclick`, `change` and the other events go to a generated `_onRender`. Bindings inside an `if` are kept and the lost condition is reported.
- `_onDropItem(event, data)` → `onDropItem(item, event)`; the old payload reads as `item.toDragData()` and the old `super._onDropItem` becomes the `createEmbeddedDocuments` it used to make.
- Bodies: `event.currentTarget` / `$(event.currentTarget)` → `target`, `.data("x")` and `.attr("data-x")` → `.dataset.x`, `.parents(sel)` → `.closest(sel)`, `html.find` / `this.element.find` → `this.element.querySelectorAll` (so `.length` and `[0]` keep working), `Dialog.confirm` → `DialogV2.confirm`.
- Templates: `data-action="<name>"` on the elements each selector matched, `data-action="vttforgeTab"`, `data-group` and `{{tabs.<id>.cssClass}}` on the tab links and panes. Attribute insertions on opening tags only; Handlebars inside a tag is stepped over.

Everything else is a `// TODO(migrate)` line in the file and a line-numbered entry in the report: `new Dialog({...})`, `_updateObject`, jQuery with no DOM equivalent, a runtime `get template()`, tab ids not found, and the v1 lifecycle overrides (`setPosition`, `_getHeaderButtons`, ...). A root `<form>` in a sheet template is reported, not removed, because the old class still renders it.

Parser: `@babel/parser` (pure JS, JS and TS). A file it cannot parse is reported and skipped.

## Verified

- 526 tests in the CLI: parse, options, listeners, bodies, templates, the planner (snapshot of the generated file from a synthetic fixture), the command. Typecheck, build, lint, publint green.
- Run on a real v13 system with two v1 sheets (an actor sheet with 19 click bindings, 2 double-clicks, 4 v1 dialogs, drag and drop, and a runtime template getter; an item sheet with two `change` listeners). Generated: 19 actions, the `_onRender` listeners, `TABS` with the four tab ids, the drop handlers, 28 TODO lines. Hand edits to make it run: the two `registerSheet` imports, `_configureRenderParts` for the per-type template in each class, the root `<form>` in eight sheet templates, and deleting one flagged `setPosition`; about 40 lines. Then, on a v14 world in the browser: render, tabs, item create through the kept v1 dialog, damage and ability rolls, fatigue add and remove, row expand, equip toggle, name and HP edits, delete through the rewritten `DialogV2.confirm`, rest, an item dragged between two sheets with the mouse, the item sheet with its edits and the moved `change` listener, the NPC sheet; 18 of 18, zero console errors, the only deprecation being the four v1 dialogs the report lists.

Changeset: `@vttforge/cli` minor. Template pins move to `^0.13.0`.
