### PR TITLE
chore: issue templates for a port request and for support

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,6 @@ contact_links:
   - name: FoundryVTT itself
     url: https://foundryvtt.com/community/contact/
     about: VTTForge is not affiliated with Foundry Gaming LLC. Issues with FoundryVTT itself should be reported to them.
-  - name: Discussion / question
+  - name: Discussion / design question
     url: https://github.com/vttforge/vttforge/discussions
     about: For open-ended design questions or "how do I do X?" — use Discussions, not issues.

--- a/.github/ISSUE_TEMPLATE/port_request.yml
+++ b/.github/ISSUE_TEMPLATE/port_request.yml
@@ -1,0 +1,73 @@
+name: Port request
+description: You maintain a system or module that is not on v14 yet, and want it on the SDK
+title: "[port] "
+labels: ["port", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is for maintainers who want their project moved to Foundry v14 on the SDK, or want help doing it. The work lands as a pull request on your repository; nothing is published on your behalf. Read the [migration recipe](https://vttforge.dev/recipes/migrating-to-v14) first if you want to see what the move looks like.
+
+  - type: input
+    id: repo
+    attributes:
+      label: Repository
+      description: The public repository of the system or module.
+      placeholder: "https://github.com/you/your-system"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What is it?
+      options:
+        - System
+        - Module
+    validations:
+      required: true
+
+  - type: dropdown
+    id: role
+    attributes:
+      label: Your relation to the project
+      description: A port needs someone who can merge and release. If that is not you, name who is.
+      options:
+        - I maintain it and can merge and release
+        - I contribute, the maintainer is on board
+        - I use it and would like it ported (the maintainer is not involved yet)
+    validations:
+      required: true
+
+  - type: input
+    id: foundry-version
+    attributes:
+      label: Last Foundry version it runs on
+      placeholder: "v13, v12, ..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: How far do you want to go?
+      description: The minimal fix keeps your code as it is and makes it load on v14. The port moves the sheets and data models onto the SDK, which is what makes the next core version cheap.
+      options:
+        - Minimal v14 fix only
+        - Full port onto the SDK
+        - Not sure, tell me what each one costs for this project
+    validations:
+      required: true
+
+  - type: textarea
+    id: audit
+    attributes:
+      label: Output of `npx @vttforge/cli audit`
+      description: Run it at the project root and paste the report. It runs without installing anything and tells us where the v14 breakages are.
+      render: text
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Parts you know are fragile, a release process to respect, data that must survive, worlds you can test on.

--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -1,0 +1,49 @@
+name: Support
+description: You are using the SDK or the CLI and something is unclear or does not work for you
+title: "[support] "
+labels: ["support", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a bug with a reproduction, use the bug report. For an open design question, use [Discussions](https://github.com/vttforge/vttforge/discussions). This one is for "I am doing X and I am stuck": a command that does not do what you expected, a sheet that does not render, a step in the docs that does not match what you see.
+
+  - type: input
+    id: version
+    attributes:
+      label: Package and version
+      description: The package you are using and its version, from `pnpm list @vttforge/core` (or the CLI, `npx vttforge --version`).
+      placeholder: "@vttforge/core@0.15.1, @vttforge/cli@0.13.0"
+    validations:
+      required: true
+
+  - type: input
+    id: foundry-version
+    attributes:
+      label: FoundryVTT version
+      placeholder: "v14.x"
+    validations:
+      required: true
+
+  - type: textarea
+    id: doing
+    attributes:
+      label: What are you trying to do?
+      description: The goal, and the command or code you ran. A link to the repository or a branch is the fastest way to get an answer.
+    validations:
+      required: true
+
+  - type: textarea
+    id: happened
+    attributes:
+      label: What happened instead?
+      description: The output, the console error, or a screenshot. If there is a `VTTF-NNNN` code, the [error reference](https://vttforge.dev/errors/) may already have the answer.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: audit
+    attributes:
+      label: Output of `vttforge audit`, if it is a system or module
+      render: text


### PR DESCRIPTION
Two issue templates, in the shape of the existing ones:

- **Port request**: a maintainer (or a user, with the maintainer named) asks for a system or module to be moved to v14 on the SDK. Asks for the repository, the kind, who can merge and release, the last Foundry version it runs on, how far they want to go (minimal fix or full port), the `vttforge audit` output, and what must survive.
- **Support**: "I am doing X and I am stuck", separate from bug reports and from design discussions. Asks for package and version, Foundry version, what they ran, what happened, and the audit output when it is a system or module.

Labels `port` and `support` created on the repository. The Discussions contact link is reworded to say design questions, so support requests do not land there.