### PR TITLE
fix(cli): migrate codemods and audit 007 fixes from an end-to-end run on a v13 system

### DIFF
--- a/.changeset/cli-migrate-adoption-run.md
+++ b/.changeset/cli-migrate-adoption-run.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/cli": patch
+---
+
+Fixes found by running `vttforge migrate` end to end on a v13 system: `--data-models` now spreads a `base` template when the file defines one; `--sheets` awaits the `super._prepareContext` it writes for a sync `getData`, drops `{ async: false }` from `enrichHTML` and awaits the call, and moves a `new Dialog` opened from a render listener to `DialogV2` like one opened from a click. Audit rule 007 accepts a `{ value, max }` field declared in a shared schema fragment. The note about a root `<form>` now says to make it a `<div>`, since a part has to render one element.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -243,4 +243,6 @@ one `setPosition` override; everything else ran as generated.
 Each template the class names gets `data-action="<name>"` on the elements
 that matched each selector, `data-action="vttforgeTab"` and `data-group` on
 the tab links, and `data-group` on the panes. It reports a root `<form>` and
-leaves it in place: the old class still renders that template.
+leaves it in place: the old class still renders that template. Once the old
+class is gone, make that root a `<div>`, not nothing: a part has to render
+one element.

--- a/packages/cli/src/__tests__/audit/source-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/source-rules.test.ts
@@ -826,6 +826,39 @@ CONFIG.Actor.dataModels['other-module.vehicle'] = VehicleData;`,
   });
 
   describe('rule 007 actor scoping', () => {
+    it('accepts a SchemaField declared in a shared fragment several models spread', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', primaryTokenAttribute: 'hp' }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'templates.mjs'),
+        `export function baseFields(f) {
+  return {
+    hp: new f.SchemaField({
+      value: new f.NumberField({ integer: true, initial: 10 }),
+      max: new f.NumberField({ integer: true, initial: 10 }),
+    }),
+  };
+}`,
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `import { baseFields } from './templates.mjs';
+function defineCharacterSchema() {
+  const f = fields();
+  return { ...baseFields(f), level: new f.NumberField() };
+}
+class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
+CONFIG.Actor.dataModels.character = CharacterData;`,
+        'utf8',
+      );
+      const seven = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-007');
+      expect(seven).toHaveLength(0);
+    });
+
     it('does not accept an Item model as the token attribute source', async () => {
       await writeFile(
         join(cwd, 'system.json'),

--- a/packages/cli/src/__tests__/migrate/data-models.test.ts
+++ b/packages/cli/src/__tests__/migrate/data-models.test.ts
@@ -151,3 +151,19 @@ describe('vttforge migrate --data-models', () => {
     expect(again.report.dataModels?.notes[0]).toContain('exists and was left alone');
   });
 });
+
+describe('a template named base', () => {
+  it('is spread like any other when the file defines it', () => {
+    const plan = planDataModels({
+      Item: {
+        types: ['gear'],
+        templates: { base: { description: '' } },
+        gear: { templates: ['base'], weight: 1 },
+      },
+    });
+    const gear = plan.files.find((f) => f.path.endsWith('gear-data.mjs'))?.source ?? '';
+    expect(gear).toContain("import { baseFields } from './templates.mjs';");
+    expect(gear).toContain('...baseFields(f),');
+    expect(plan.notes.join(' ')).not.toMatch(/lists template "base"/);
+  });
+});

--- a/packages/cli/src/__tests__/migrate/sheet-bodies.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheet-bodies.test.ts
@@ -283,3 +283,22 @@ describe('enrichHTML on v14', () => {
     );
   });
 });
+
+describe('a sync getData', () => {
+  it('awaits the super call it now makes and the enrichHTML it called sync', () => {
+    const r = rewriteGetData(
+      'getData() { const context = super.getData(); context.bio = TextEditor.enrichHTML(this.actor.system.bio, { async: false }); return context; }',
+      'ActorSheet',
+    );
+    expect(r.code).toContain('const context = await super._prepareContext(options);');
+    expect(r.code).toContain('context.bio = await TextEditor.enrichHTML(this.actor.system.bio);');
+  });
+});
+
+describe('enrichHTML with async: false in a handler', () => {
+  it('loses the option and gets a TODO to await it', () => {
+    const r = rewriteHandlerBody('{ const html = enrichHTML(x, { async: false }); }', null, null);
+    expect(r.code).toContain('const html = enrichHTML(x);');
+    expect(r.todos.join(' ')).toMatch(/await it/);
+  });
+});

--- a/packages/cli/src/__tests__/migrate/sheets.test.ts
+++ b/packages/cli/src/__tests__/migrate/sheets.test.ts
@@ -186,3 +186,22 @@ describe('drops on an item sheet', () => {
     expect(p.files[0]?.source).not.toContain('onDropItem(item, event)');
   });
 });
+
+describe('a dialog opened from a render listener', () => {
+  it('is moved to DialogV2 like one opened from a click', () => {
+    const src = `export class S extends ActorSheet {
+      activateListeners(html) {
+        super.activateListeners(html);
+        html.find('.name').on('dblclick', (ev) => {
+          new Dialog({ title: 'T', content: '<p>x</p>', buttons: { ok: { label: 'OK' } }, default: 'ok' }).render(true);
+        });
+      }
+    }`;
+    const p = planSheetFile('s.mjs', src, { lang: 'js', tabIds: {} });
+    const out = p.files[0]?.source ?? '';
+    expect(out).toContain("DialogV2.wait({\n          window: { title: 'T' },");
+    expect(out).toContain("{ action: 'ok', label: 'OK', default: true }");
+    expect(out).toContain('const { DialogV2 } = foundry.applications.api;');
+    expect(out).not.toContain('new Dialog(');
+  });
+});

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -747,9 +747,11 @@ async function sourceHasValueMaxSchemaAtPath(
       // With none found there is no ground truth to narrow by, so every
       // declaration counts, the same fallback rule 004 takes when it cannot
       // resolve a class to its subtypes.
+      // A declaration outside any class is a shared fragment (a `baseFields(f)`
+      // several models spread); it is not an Item model, so it counts.
       if (actorClasses.size > 0) {
         const owner = classes.find((c) => decl.index > c.openIdx && decl.index < c.endIdx);
-        if (!owner || !actorClasses.has(owner.className)) continue;
+        if (owner && !actorClasses.has(owner.className)) continue;
       }
       const topKeys = extractTopLevelKeys(decl.body);
       if (topKeys.has('value') && topKeys.has('max')) return true;

--- a/packages/cli/src/audit/template-rules.ts
+++ b/packages/cli/src/audit/template-rules.ts
@@ -160,7 +160,7 @@ export async function runTemplateRules(cwd: string): Promise<RuleResult[]> {
       message:
         'This template is rendered by a sheet built on BaseActorSheet or BaseItemSheet, which set `tag: "form"`, so the application element already is a form. A nested form owns the fields inside it, so the submit reads the outer element and finds nothing. Every edit is dropped when the window closes, with no error.',
       remediation:
-        'Replace the `<form>` wrapper with a `<div>`, or drop it entirely. The fields belong to the application element, and `submitOnChange` saves them as they change.',
+        'Replace the `<form>` wrapper with a `<div>`. Keep one root element: a part that renders several top-level elements fails to render. The fields belong to the application element, and `submitOnChange` saves them as they change.',
     });
   }
   return [...results, ...removedHelpers];

--- a/packages/cli/src/migrate/data-models.ts
+++ b/packages/cli/src/migrate/data-models.ts
@@ -176,9 +176,10 @@ export function planDataModels(
     const modelNames: string[] = [];
     for (const type of types) {
       const own = (doc[type] ?? {}) as Record<string, unknown>;
-      const listed = ((own.templates as string[] | undefined) ?? []).filter((t) => t !== 'base');
+      const listed = (own.templates as string[] | undefined) ?? [];
       for (const t of listed) {
-        if (!(t in templates))
+        // Many files list a `base` the templates block never defines; that one is not worth a note.
+        if (!(t in templates) && t !== 'base')
           notes.push(
             `${document}.${type}: lists template "${t}", which template.json does not define; it was skipped.`,
           );

--- a/packages/cli/src/migrate/index.ts
+++ b/packages/cli/src/migrate/index.ts
@@ -285,7 +285,7 @@ async function planSheets(
       templates.push({ file: t, edits: r.edits, formRoot: r.formRoot });
       if (r.formRoot) {
         notes.push(
-          `${t} opens with <form>; the SDK sheet already is one. Remove it once the old class is gone (audit rule 008).`,
+          `${t} opens with <form>; the SDK sheet already is one. Make it a <div> once the old class is gone: a part needs one root element (audit rule 008).`,
         );
       }
       if (write && r.edits.length > 0) await writeFile(join(cwd, t), r.output, 'utf8');

--- a/packages/cli/src/migrate/sheet-bodies.ts
+++ b/packages/cli/src/migrate/sheet-bodies.ts
@@ -50,6 +50,7 @@ const LEFTOVER_JQUERY =
   /\$\(|\.(?:val|text|html|prop|toggle|slideToggle|slideUp|slideDown|show|hide|addClass|removeClass|toggleClass|siblings|children|find|css|each)\(/g;
 
 const JQUERY_MSG = 'jQuery left here; use the DOM on `target` / `this.element`';
+const ENRICH_MSG = 'enrichHTML returns a promise on v14; await it, and make this method async';
 
 /**
  * A handler body from `activateListeners`, with `event.currentTarget` folded
@@ -98,6 +99,14 @@ export function rewriteHandlerBody(
   code = replaceCode(code, /,\s*\{\s*async:\s*true\s*\}\s*\)/g, () => ')');
   code = replaceCode(code, /\basync:\s*true\s*,\s*/g, () => '');
   code = replaceCode(code, /,\s*async:\s*true\b/g, () => '');
+  // The sync form returned a string; on v14 it returns a promise, and this body may not be async.
+  if (/\basync:\s*false\b/.test(code)) {
+    code = replaceCode(code, /,\s*\{\s*async:\s*false\s*\}\s*\)/g, () => ')');
+    code = replaceCode(code, /\basync:\s*false\s*,\s*/g, () => '');
+    code = replaceCode(code, /,\s*async:\s*false\b/g, () => '');
+    todos.push(ENRICH_MSG);
+    code = todoAt(code, code.indexOf('{') + 1, ENRICH_MSG);
+  }
   // `this.element` was jQuery on v1 and is an HTMLElement on V2.
   // A jQuery collection reads as a NodeList: `.length`, `[0]` and `forEach` keep working.
   code = replaceCode(code, /this\.element\.find\(/g, () => 'this.element.querySelectorAll(');
@@ -135,6 +144,21 @@ export function rewriteGetData(
     (_m, indent: string) => `${indent}async _prepareContext(options)`,
   );
   code = replaceCode(code, /super\.getData\(\s*[^)]*\)/g, () => 'super._prepareContext(options)');
+  // getData was sync; _prepareContext is not, and this method is async now.
+  code = replaceCode(
+    code,
+    /(?<!await\s)super\._prepareContext\(options\)/g,
+    () => 'await super._prepareContext(options)',
+  );
+  // enrichHTML always returns a promise on v14, so the sync form must be awaited.
+  code = replaceCode(code, /,\s*\{\s*async:\s*false\s*\}\s*\)/g, () => ')');
+  code = replaceCode(code, /\basync:\s*false\s*,\s*/g, () => '');
+  code = replaceCode(code, /,\s*async:\s*false\b/g, () => '');
+  code = replaceCode(
+    code,
+    /(?<!await\s)(?<![\w$.])(?:[\w$]+\.)*enrichHTML\(/g,
+    (call) => `await ${call}`,
+  );
 
   // The variable that received super's result.
   const varMatch =

--- a/packages/cli/src/migrate/sheets.ts
+++ b/packages/cli/src/migrate/sheets.ts
@@ -259,6 +259,12 @@ function planClass(cls: SheetClass, source: string, tabIds: Record<string, strin
     members.push(rewriteGetData(reindent(text(source, getData)), cls.base, { usesObject }).code);
   }
 
+  const applyDialogs = (code: string): string => {
+    const d = rewriteDialogs(code);
+    if (/DialogV2\./.test(d.code)) usesDialogV2 = true;
+    return d.code;
+  };
+
   // 5. _onRender for the events that are not clicks.
   if (listeners.listeners.length > 0) {
     const body = listeners.listeners
@@ -268,7 +274,7 @@ function planClass(cls: SheetClass, source: string, tabIds: Record<string, strin
         const handler = isFunction
           ? indentTo(
               rewriteHandlerBody(
-                l.handlerText,
+                applyDialogs(l.handlerText),
                 param,
                 listeners.htmlParam,
                 param ? `${param}.currentTarget` : 'target',
@@ -294,11 +300,6 @@ function planClass(cls: SheetClass, source: string, tabIds: Record<string, strin
       [...l.handlerText.matchAll(/this\.(\w+)/g)].map((m) => m[1] ?? ''),
     ),
   );
-  const applyDialogs = (code: string): string => {
-    const d = rewriteDialogs(code);
-    if (/DialogV2\./.test(d.code)) usesDialogV2 = true;
-    return d.code;
-  };
   for (const member of cls.node.body.body) {
     if (
       member.type !== 'ClassMethod' &&


### PR DESCRIPTION
Running `audit`, `migrate`, `migrate --data-models` and `migrate --sheets` on a small v13 system, then building it and booting the result on v14, turned up five things:

- `--data-models` skipped a template named `base` even when the file defined it, so every type lost the shared fields.
- `--sheets` rewrote a sync `getData` into `_prepareContext` without awaiting the super call, so every context key landed on a promise.
- `enrichHTML(x, { async: false })` kept the dead option and was not awaited; on v14 the call always returns a promise.
- A `new Dialog` opened from a `dblclick` or `change` listener was moved into `_onRender` as written, while the same dialog from a click became `DialogV2`.
- Audit rule 007 rejected a `{ value, max }` field declared in a shared schema fragment outside any class, which is exactly what `--data-models` writes.

The form-root note and rule 008's fix now say to make the root a `<div>`, since a part that renders several top-level elements fails to render.

After the fixes the ported system audits clean, builds, and passes a browser run on v14: boot, derived data, one-form sheet, tabs, item create, edit, toggle, submit on change, roll, the dialog from the listener, delete confirm, drops, and the per-type template. No console errors, no deprecation warnings.