### PR TITLE
chore(release): drop the changeset for the private web app

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -9,3 +9,8 @@ pnpm changeset
 ```
 
 The walkthrough asks which packages changed and at what semver level (patch / minor / major). Changesets are consumed by the release workflow (`.github/workflows/changesets.yml`) which opens a Version PR that bumps versions and updates each package's `CHANGELOG.md`.
+
+Only published packages get a changeset. A changeset that names a private
+package (`apps/*`, `examples/*`) is skipped by `changeset version` and
+never deleted, and the release workflow then opens an empty Version PR after
+every push until someone removes the file by hand.

--- a/.changeset/web-copy.md
+++ b/.changeset/web-copy.md
@@ -1,5 +1,0 @@
----
-"@vttforge/web": patch
----
-
-Landing page copy reworded. Package count, CLI command list and roadmap brought up to date.


### PR DESCRIPTION
`changeset version` skips private packages (`privatePackages.version` defaults to false in changesets 3), so `.changeset/web-copy.md`, which names only the private `@vttforge/web`, was never applied and never deleted. The release action saw a changeset on every push to main and opened an empty Version PR each time (#200, #202, #203).

This removes the file and writes the rule into `.changeset/README.md`: only published packages get a changeset. Close #203 after merging; nothing will reopen it.