### PR TITLE
feat(cli): migrate --strict, and --write computes every file before the first write

### DIFF
--- a/.changeset/cli-migrate-strict.md
+++ b/.changeset/cli-migrate-strict.md
@@ -2,4 +2,4 @@
 "@vttforge/cli": minor
 ---
 
-`vttforge migrate --strict` exits 1 when the run leaves anything that needs a decision, for CI. With `--write`, every file is now rewritten in memory before the first one is written, so a run that throws on one file leaves the tree untouched. A one-line manifest no longer breaks when `"type"` is inserted after `"id"`.
+`vttforge migrate --strict` exits 1 when the run leaves anything that needs a decision, for CI. With `--write`, every file is now rewritten in memory before the first one is written, so a run that throws on one file leaves the tree untouched. A one-line manifest no longer breaks when `"type"` is inserted after `"id"`. The JSON report's `dataModels` and `sheets` blocks gain a `decisions` list next to `notes`: `notes` say what happened, `decisions` what still needs a hand, and only the second fails `--strict`.

--- a/.changeset/cli-migrate-strict.md
+++ b/.changeset/cli-migrate-strict.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/cli": minor
+---
+
+`vttforge migrate --strict` exits 1 when the run leaves anything that needs a decision, for CI. With `--write`, every file is now rewritten in memory before the first one is written, so a run that throws on one file leaves the tree untouched. A one-line manifest no longer breaks when `"type"` is inserted after `"id"`.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -121,13 +121,20 @@ fail, for CI. `--json` prints the report as data.
 ## `vttforge migrate`
 
 ```bash
-vttforge migrate [dir] [--write] [--json]
+vttforge migrate [dir] [--write] [--strict] [--json]
 ```
 
 Rewrites a v13 project for v14. Without `--write` it only reports what it
 would change, one line per edit, so you catch a rewrite that landed in a
 string or a comment before it reaches the file. Run it, read the report, run
 it again with `--write`, then run `vttforge audit`.
+
+A rewrite it cannot make safely is never attempted: it becomes a "needs a
+decision" line and the run goes on. With `--write`, every file is rewritten
+in memory before the first one is written, so a run that throws on one file
+leaves the tree as it was. `--strict` exits 1 when any decision is left,
+which is what a CI step wants: the build fails instead of shipping code
+that still needs a hand.
 
 | Rewrite | Before | After |
 |---|---|---|

--- a/apps/docs/recipes/adopting-an-existing-system.md
+++ b/apps/docs/recipes/adopting-an-existing-system.md
@@ -218,7 +218,7 @@ Three files and one install:
   "type": "module",
   "scripts": { "build": "vttforge build", "dev": "vttforge dev", "audit": "vttforge audit" },
   "dependencies": { "@vttforge/core": "^0.15.0" },
-  "devDependencies": { "@vttforge/cli": "^0.14.0", "@vttforge/vite-plugin": "^0.5.0", "vite": "^8.0.0" }
+  "devDependencies": { "@vttforge/cli": "^0.15.0", "@vttforge/vite-plugin": "^0.5.0", "vite": "^8.0.0" }
 }
 ```
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -575,6 +575,11 @@
     color: var(--vttf-text-muted);
     font-size: 14px;
   }
+  /* Lets the block shrink inside a grid item; the scroll then happens inside it. */
+  .vttf-codeblock {
+    min-width: 0;
+    max-width: 100%;
+  }
   .try-card .vttf-codeblock {
     margin-top: auto;
   }
@@ -770,11 +775,6 @@
   .feat-grid > *,
   .hero-meta > * {
     min-width: 0;
-  }
-
-  .vttf-codeblock {
-    min-width: 0;
-    max-width: 100%;
   }
 
   /* The packages table has more columns than a phone has room for. */

--- a/biome.json
+++ b/biome.json
@@ -61,6 +61,20 @@
   },
   "overrides": [
     {
+      "includes": ["**/__tests__/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noTemplateCurlyInString": "off"
+          },
+          "complexity": {
+            "noStaticOnlyClass": "off",
+            "noThisInStatic": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["scripts/**", "apps/*/scripts/**"],
       "linter": {
         "rules": {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   commands:
     biome:
       glob: '*.{js,jsx,ts,tsx,mjs,cjs,json,jsonc,css,md,yml,yaml}'
-      run: biome check --staged --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      run: pnpm exec biome check --staged --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
 
 pre-push:
   commands:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ vttforge dev   [--foundry-data <path>] [--port <n>]
 vttforge build
 vttforge lint  [dir] [--fix] [--no-audit] [--strict]
 vttforge audit [dir] [--json] [--strict]
-vttforge migrate [dir] [--write] [--json] [--data-models] [--sheets]
+vttforge migrate [dir] [--write] [--strict] [--json] [--data-models] [--sheets]
 ```
 
 **`init`** writes a runnable system or module into `<name>/` from one of four templates (`system-ts`, `system-js`, `module-ts`, `module-js`). It asks for what you did not pass, or takes defaults with `--yes`, so it works in CI. It detects the package manager that invoked it (`pnpm`, `npm`, `bun`, `yarn`), installs, and runs `git init`.
@@ -28,7 +28,7 @@ vttforge migrate [dir] [--write] [--json] [--data-models] [--sheets]
 
 **`audit`** checks the manifest, the source and the templates against the v14 breakages that fail quietly: the `flags.hotReload` shape, the removed grid fields, the v12 `styles` shape, `HTMLField`/`FilePathField` paths missing from `documentTypes`, `TypeDataModel` without `prepareBaseData`, a bad `_addDataFieldMigrations` override, token attributes that do not point at a `{ value, max }` field, a sheet template that opens a `<form>` the sheet already is, a declared subtype with no name in any language file, a `template.json` that erases the metadata `system.json` declares for the same type, and the v13 code v14 broke or deprecated: bare `mergeObject`-style globals, `-=` update keys, `rollMode`, whole-array `CONFIG.statusEffects` assignment, `legacyTransferral`, numeric Active Effect modes, a release workflow that zips the checkout of a project that builds to `dist/`, and a template that still calls `{{#select}}` or `{{colorPicker}}`. `--json` prints the findings as JSON, and `--strict` exits non-zero on any finding rather than only on HIGH.
 
-**`migrate`** rewrites a v13 project for v14: the removed globals, `-=` keys, `rollMode`, context-menu keys, numeric effect modes, whole-array `CONFIG.statusEffects`, `legacyTransferral`, the core-sheet unregister lines, and the manifest's `type` and `compatibility`. It reports by default, writes with `--write`, and lists the changes it will not decide for you. `--data-models` writes a data model per `template.json` type; `--sheets` writes a V2 sheet file on the SDK bases next to each Application v1 sheet class, with the `data-action` attributes its templates need.
+**`migrate`** rewrites a v13 project for v14: the removed globals, `-=` keys, `rollMode`, context-menu keys, numeric effect modes, whole-array `CONFIG.statusEffects`, `legacyTransferral`, the core-sheet unregister lines, and the manifest's `type` and `compatibility`. It reports by default, writes with `--write` (every file computed before the first write), lists the changes it will not decide for you, and with `--strict` exits 1 while any is left. `--data-models` writes a data model per `template.json` type; `--sheets` writes a V2 sheet file on the SDK bases next to each Application v1 sheet class, with the `data-action` attributes its templates need.
 
 ## As a library
 

--- a/packages/cli/src/__tests__/migrate/migrate-command.test.ts
+++ b/packages/cli/src/__tests__/migrate/migrate-command.test.ts
@@ -192,13 +192,13 @@ describe('vttforge migrate --sheets', () => {
     const { report } = await runMigrateCommand({ cwd, sheets: true, out: () => {} });
     expect(report.sheets?.files.map((f) => f.to)).toEqual(['module/actor-sheet.v2.mjs']);
     expect(
-      report.sheets?.notes.some((n) => /module\/broken\.mjs.*could not be parsed/.test(n)),
+      report.sheets?.decisions.some((n) => /module\/broken\.mjs.*could not be parsed/.test(n)),
     ).toBe(true);
   });
 
   it('says so when there is no v1 sheet', async () => {
     const { report } = await runMigrateCommand({ cwd, sheets: true, out: () => {} });
-    expect(report.sheets).toEqual({ files: [], templates: [], notes: [] });
+    expect(report.sheets).toEqual({ files: [], templates: [], notes: [], decisions: [] });
   });
 });
 
@@ -250,6 +250,55 @@ describe('--strict', () => {
     expect(out).toContain('--strict: 1 decision(s) left');
     await rm(join(cwd, 'chat.mjs'));
     const clean = await runMigrateCommand({ cwd, strict: true, out: () => undefined });
+    expect(clean.exitCode).toBe(0);
+  });
+
+  it('does not fail on the notes that only say what to do next', async () => {
+    // A sheet with nothing the codemod could not decide, and no template.json.
+    await mkdir(join(cwd, 'templates'), { recursive: true });
+    await writeFile(
+      join(cwd, 'templates', 'hero.html'),
+      '<form><a class="roll">r</a></form>\n',
+      'utf8',
+    );
+    await writeFile(
+      join(cwd, 'sheet.mjs'),
+      `export class HeroSheet extends ActorSheet {
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, { template: 'systems/s/templates/hero.html' });
+  }
+  activateListeners(html) { super.activateListeners(html); html.find('.roll').click(() => this._onRoll()); }
+  _onRoll() { return 1; }
+}
+`,
+      'utf8',
+    );
+    const r = await runMigrateCommand({
+      cwd,
+      strict: true,
+      sheets: true,
+      dataModels: true,
+      out: () => undefined,
+    });
+    expect(r.report.sheets?.files).toHaveLength(1);
+    expect(r.report.sheets?.notes.length).toBeGreaterThan(0);
+    expect(r.report.dataModels?.notes).toEqual(['No template.json here; nothing to generate.']);
+    // The root <form> is the one real decision left; drop it and the run is clean.
+    expect(r.report.sheets?.decisions).toHaveLength(1);
+    expect(r.exitCode).toBe(1);
+    await writeFile(
+      join(cwd, 'templates', 'hero.html'),
+      '<div><a class="roll">r</a></div>\n',
+      'utf8',
+    );
+    const clean = await runMigrateCommand({
+      cwd,
+      strict: true,
+      sheets: true,
+      dataModels: true,
+      out: () => undefined,
+    });
+    expect(clean.report.sheets?.decisions).toEqual([]);
     expect(clean.exitCode).toBe(0);
   });
 });

--- a/packages/cli/src/__tests__/migrate/migrate-command.test.ts
+++ b/packages/cli/src/__tests__/migrate/migrate-command.test.ts
@@ -230,3 +230,26 @@ describe('vttforge migrate and the release workflow', () => {
     );
   });
 });
+
+describe('--strict', () => {
+  it('exits 1 when a decision is left, 0 when none is', async () => {
+    await writeFile(
+      join(cwd, 'chat.mjs'),
+      'Hooks.on("renderChatMessage", (m, html) => html.find(".x"));\n',
+      'utf8',
+    );
+    let out = '';
+    const left = await runMigrateCommand({
+      cwd,
+      strict: true,
+      out: (c) => {
+        out += c;
+      },
+    });
+    expect(left.exitCode).toBe(1);
+    expect(out).toContain('--strict: 1 decision(s) left');
+    await rm(join(cwd, 'chat.mjs'));
+    const clean = await runMigrateCommand({ cwd, strict: true, out: () => undefined });
+    expect(clean.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/src/__tests__/migrate/migrate-write-order.test.ts
+++ b/packages/cli/src/__tests__/migrate/migrate-write-order.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `--write` computes every rewrite before the first write, so a run that
+ * throws on one file leaves the tree as it was.
+ */
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const calls: string[] = [];
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    readFile: (async (...args: Parameters<typeof actual.readFile>) => {
+      calls.push('read');
+      return actual.readFile(...args);
+    }) as typeof actual.readFile,
+    writeFile: (async (...args: Parameters<typeof actual.writeFile>) => {
+      calls.push('write');
+      return actual.writeFile(...args);
+    }) as typeof actual.writeFile,
+  };
+});
+
+const { runMigrate } = await import('../../migrate/index.js');
+
+let cwd: string;
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'vttf-migrate-order-'));
+  await writeFile(
+    join(cwd, 'system.json'),
+    '{ "id": "s", "compatibility": { "minimum": "13" } }\n',
+    'utf8',
+  );
+  await writeFile(join(cwd, 'a.mjs'), 'mergeObject(a, b);\n', 'utf8');
+  await writeFile(join(cwd, 'b.mjs'), 'Math.clamped(x, 0, 1);\n', 'utf8');
+  await writeFile(
+    join(cwd, 'sheet.mjs'),
+    'export class S extends ActorSheet { activateListeners(html) { html.find(".a").click(() => 1); } }\n',
+    'utf8',
+  );
+  calls.length = 0;
+});
+afterEach(async () => {
+  await rm(cwd, { recursive: true, force: true });
+});
+
+describe('migrate --write', () => {
+  it('reads and rewrites every file before it writes the first one', async () => {
+    const report = await runMigrate({ cwd, write: true, sheets: true });
+    expect(report.counts.changes).toBeGreaterThan(0);
+    expect(report.sheets?.files).toHaveLength(1);
+    const firstWrite = calls.indexOf('write');
+    const lastRead = calls.lastIndexOf('read');
+    expect(firstWrite).toBeGreaterThan(-1);
+    expect(lastRead).toBeLessThan(firstWrite);
+  });
+});

--- a/packages/cli/src/__tests__/migrate/transforms.test.ts
+++ b/packages/cli/src/__tests__/migrate/transforms.test.ts
@@ -357,3 +357,12 @@ describe('namespaced globals', () => {
     expect(namespacedGlobals(src).output).toBe(src);
   });
 });
+
+describe('a one-line manifest', () => {
+  it('gets "type" inline after "id" and still parses', () => {
+    const r = transformManifest('{ "id": "s", "compatibility": { "minimum": "13" } }\n', 'system');
+    expect(r?.output).toBe(
+      '{ "id": "s", "type": "system", "compatibility": { "minimum": "14" } }\n',
+    );
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -268,6 +268,11 @@ export const migrate = defineCommand({
       default: false,
       description: 'Emit the report as JSON',
     },
+    strict: {
+      type: 'boolean',
+      default: false,
+      description: 'Exit 1 when anything is left that needs a decision, for CI',
+    },
     'data-models': {
       type: 'boolean',
       default: false,
@@ -297,6 +302,7 @@ export const migrate = defineCommand({
         cwd: args.path ? String(args.path) : undefined,
         write: Boolean(args.write),
         json: Boolean(args.json),
+        strict: Boolean(args.strict),
         dataModels: Boolean(args['data-models']),
         style: String(args.style) === 'sdk' ? 'sdk' : 'plain',
         lang: String(args.lang) === 'ts' ? 'ts' : 'js',

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -3,16 +3,23 @@
  *
  * Exit codes:
  *   0: ran, whether or not anything changed
- *   1: the target is not a directory
+ *   1: the target is not a directory, or --strict and a decision was left
  */
 
 import { resolve } from 'node:path';
-import { formatMigrateReport, type MigrateReport, runMigrate } from '../migrate/index.js';
+import {
+  countDecisions,
+  formatMigrateReport,
+  type MigrateReport,
+  runMigrate,
+} from '../migrate/index.js';
 
 export interface MigrateCommandOptions {
   cwd?: string;
   write?: boolean;
   json?: boolean;
+  /** Exit 1 when the report leaves anything that needs a decision. */
+  strict?: boolean;
   /** Also generate a data model per template.json type. */
   dataModels?: boolean;
   style?: 'plain' | 'sdk';
@@ -41,5 +48,10 @@ export async function runMigrateCommand(
     sheets: options.sheets === true,
   });
   out(options.json ? `${JSON.stringify(report, null, 2)}\n` : formatMigrateReport(report));
+  const decisions = countDecisions(report);
+  if (options.strict === true && decisions > 0) {
+    if (!options.json) out(`--strict: ${decisions} decision(s) left; exiting 1.\n`);
+    return { report, exitCode: 1 };
+  }
   return { report, exitCode: 0 };
 }

--- a/packages/cli/src/migrate/index.ts
+++ b/packages/cli/src/migrate/index.ts
@@ -36,13 +36,19 @@ export interface MigrateReport {
     files: string[];
     documentTypes: Record<string, Record<string, Record<string, unknown>>>;
     registration: string;
+    /** What happened, for the reader: a file left alone, nothing to generate. */
     notes: string[];
+    /** What the generator could not decide: a guessed field, a template.json to delete. */
+    decisions: string[];
   };
   /** Present when V2 sheet files were generated from Application v1 classes. */
   sheets?: {
     files: Array<Omit<SheetPlanFile, 'source'>>;
     templates: Array<{ file: string; edits: TemplateEdit[]; formRoot: boolean }>;
+    /** What to do next: point registerSheet at the file, run the audit again. */
     notes: string[];
+    /** What the codemod could not decide: a class it skipped, a root form to replace. */
+    decisions: string[];
   };
 }
 
@@ -54,15 +60,16 @@ interface PendingWrite {
 
 /**
  * The lines the report prints as "needs a decision": the rewrites the run did
- * not make, the TODO lines in generated files, and the notes on the generated
- * sets. `--strict` fails the run when any is left.
+ * not make, the TODO lines in generated files, and what the generators could
+ * not decide. `--strict` fails the run when any is left. A note that only says
+ * what happened (a file left alone, where to point registerSheet) is not one.
  */
 export function countDecisions(report: MigrateReport): number {
   return (
     report.counts.notes +
-    (report.dataModels?.notes.length ?? 0) +
+    (report.dataModels?.decisions.length ?? 0) +
     (report.sheets?.files.reduce((n, f) => n + f.todos.length, 0) ?? 0) +
-    (report.sheets?.notes.length ?? 0)
+    (report.sheets?.decisions.length ?? 0)
   );
 }
 
@@ -161,6 +168,7 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
         documentTypes: {},
         registration: '',
         notes: ['No template.json here; nothing to generate.'],
+        decisions: [],
       };
     } else {
       const template = JSON.parse(await readFile(templatePath, 'utf8')) as Record<string, unknown>;
@@ -169,10 +177,11 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
         lang: options.lang ?? 'js',
       });
       const written: string[] = [];
+      const info: string[] = [];
       for (const file of plan.files) {
         const target = join(cwd, file.path);
         if (existsSync(target)) {
-          plan.notes.unshift(`${file.path} exists and was left alone.`);
+          info.push(`${file.path} exists and was left alone.`);
           continue;
         }
         if (write) pending.push({ path: target, content: file.source });
@@ -182,7 +191,8 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
         files: written,
         documentTypes: plan.documentTypes,
         registration: plan.registration,
-        notes: plan.notes,
+        notes: info,
+        decisions: plan.notes,
       };
     }
   }
@@ -219,6 +229,7 @@ async function planSheets(
   const files: Array<Omit<SheetPlanFile, 'source'>> = [];
   const templates: Array<{ file: string; edits: TemplateEdit[]; formRoot: boolean }> = [];
   const notes: string[] = [];
+  const decisions: string[] = [];
   const generated = new Map<string, string>();
 
   for await (const path of _internal.walkSourceFiles(cwd)) {
@@ -246,10 +257,10 @@ async function planSheets(
       probe = planSheetFile(rel, source, { lang, tabIds: {} });
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
-      notes.push(`${rel} could not be parsed and was skipped: ${reason}`);
+      decisions.push(`${rel} could not be parsed and was skipped: ${reason}`);
       continue;
     }
-    notes.push(...probe.notes);
+    decisions.push(...probe.notes);
     if (probe.files.length === 0) continue;
     let templatePaths = [...new Set(probe.files.flatMap((f) => f.templates))]
       .map((t) => localTemplate(cwd, t))
@@ -309,7 +320,7 @@ async function planSheets(
       if (r.edits.length === 0) continue;
       templates.push({ file: t, edits: r.edits, formRoot: r.formRoot });
       if (r.formRoot) {
-        notes.push(
+        decisions.push(
           `${t} opens with <form>; the SDK sheet already is one. Make it a <div> once the old class is gone: a part needs one root element (audit rule 008).`,
         );
       }
@@ -325,7 +336,7 @@ async function planSheets(
     }
     if (write) pending.push({ path: target, content: out });
   }
-  return { files, templates, notes: [...new Set(notes)] };
+  return { files, templates, notes: [...new Set(notes)], decisions: [...new Set(decisions)] };
 }
 
 /** The report as text: one block per file, edits then notes. */
@@ -383,7 +394,8 @@ export function formatMigrateReport(report: MigrateReport): string {
         'Register the models at init:',
         ...dm.registration.split('\n').map((l) => `  ${l}`),
       );
-    for (const n of dm.notes) lines.push(`  needs a decision: ${n}`);
+    for (const n of dm.notes) lines.push(`  ${n}`);
+    for (const n of dm.decisions) lines.push(`  needs a decision: ${n}`);
   }
   if (report.sheets) {
     const s = report.sheets;
@@ -413,7 +425,8 @@ export function formatMigrateReport(report: MigrateReport): string {
         }
       }
     }
-    for (const n of s.notes) lines.push(`  needs a decision: ${n}`);
+    for (const n of s.notes) lines.push(`  ${n}`);
+    for (const n of s.decisions) lines.push(`  needs a decision: ${n}`);
   }
   return `${lines.join('\n')}\n`;
 }

--- a/packages/cli/src/migrate/index.ts
+++ b/packages/cli/src/migrate/index.ts
@@ -46,6 +46,26 @@ export interface MigrateReport {
   };
 }
 
+/** A file the run will write once every rewrite has been computed. */
+interface PendingWrite {
+  path: string;
+  content: string;
+}
+
+/**
+ * The lines the report prints as "needs a decision": the rewrites the run did
+ * not make, the TODO lines in generated files, and the notes on the generated
+ * sets. `--strict` fails the run when any is left.
+ */
+export function countDecisions(report: MigrateReport): number {
+  return (
+    report.counts.notes +
+    (report.dataModels?.notes.length ?? 0) +
+    (report.sheets?.files.reduce((n, f) => n + f.todos.length, 0) ?? 0) +
+    (report.sheets?.notes.length ?? 0)
+  );
+}
+
 export interface MigrateOptions {
   cwd: string;
   /** Write the edits. Default false: report only. */
@@ -68,6 +88,9 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
   }
 
   const files: FileResult[] = [];
+  // Every rewrite is computed before the first write, so a run that stops
+  // halfway (a parser that throws on one file) leaves the tree as it was.
+  const pending: PendingWrite[] = [];
 
   for (const [name, kind] of [
     ['system.json', 'system'],
@@ -85,7 +108,7 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
     const result = transformManifest(raw, kind);
     if (result === null) continue;
     files.push({ file: name, changes: result.changes, notes: result.notes });
-    if (write && result.changes.length > 0) await writeFile(path, result.output, 'utf8');
+    if (write && result.changes.length > 0) pending.push({ path, content: result.output });
   }
 
   for await (const path of _internal.walkSourceFiles(cwd)) {
@@ -98,7 +121,7 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
     const result = transformSource(source);
     if (result.changes.length === 0 && result.notes.length === 0) continue;
     files.push({ file: relative(cwd, path), changes: result.changes, notes: result.notes });
-    if (write && result.output !== source) await writeFile(path, result.output, 'utf8');
+    if (write && result.output !== source) pending.push({ path, content: result.output });
   }
 
   // A project that builds to dist/ with a release workflow written for the old
@@ -152,10 +175,7 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
           plan.notes.unshift(`${file.path} exists and was left alone.`);
           continue;
         }
-        if (write) {
-          await mkdir(dirname(target), { recursive: true });
-          await writeFile(target, file.source, 'utf8');
-        }
+        if (write) pending.push({ path: target, content: file.source });
         written.push(file.path);
       }
       report.dataModels = {
@@ -167,8 +187,12 @@ export async function runMigrate(options: MigrateOptions): Promise<MigrateReport
     }
   }
 
-  if (options.sheets) report.sheets = await planSheets(cwd, write, options.lang ?? 'js');
+  if (options.sheets) report.sheets = await planSheets(cwd, write, options.lang ?? 'js', pending);
 
+  for (const { path, content } of pending) {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, content, 'utf8');
+  }
   return report;
 }
 
@@ -190,6 +214,7 @@ async function planSheets(
   cwd: string,
   write: boolean,
   lang: 'js' | 'ts',
+  pending: PendingWrite[],
 ): Promise<NonNullable<MigrateReport['sheets']>> {
   const files: Array<Omit<SheetPlanFile, 'source'>> = [];
   const templates: Array<{ file: string; edits: TemplateEdit[]; formRoot: boolean }> = [];
@@ -288,7 +313,7 @@ async function planSheets(
           `${t} opens with <form>; the SDK sheet already is one. Make it a <div> once the old class is gone: a part needs one root element (audit rule 008).`,
         );
       }
-      if (write && r.edits.length > 0) await writeFile(join(cwd, t), r.output, 'utf8');
+      if (write && r.edits.length > 0) pending.push({ path: join(cwd, t), content: r.output });
     }
   }
 
@@ -298,10 +323,7 @@ async function planSheets(
       notes.unshift(`${to} exists and was left alone.`);
       continue;
     }
-    if (write) {
-      await mkdir(dirname(target), { recursive: true });
-      await writeFile(target, out, 'utf8');
-    }
+    if (write) pending.push({ path: target, content: out });
   }
   return { files, templates, notes: [...new Set(notes)] };
 }

--- a/packages/cli/src/migrate/transforms.ts
+++ b/packages/cli/src/migrate/transforms.ts
@@ -694,11 +694,18 @@ export function transformManifest(
         const indent = output.slice(lineStart, idKey.keyStart);
         const after = output.indexOf('\n', idKey.valueEnd);
         const insertAt = after === -1 ? output.length : after;
-        const needsComma = !/,\s*$/.test(output.slice(idKey.valueEnd, insertAt));
-        const head = needsComma
-          ? `${output.slice(0, idKey.valueEnd)},${output.slice(idKey.valueEnd, insertAt)}`
-          : output.slice(0, insertAt);
-        output = `${head}\n${indent}"type": "${kind}",${output.slice(insertAt)}`;
+        const rest = output.slice(idKey.valueEnd, insertAt);
+        if (/^\s*,?\s*$/.test(rest)) {
+          // "id" ends its line: the new key gets the next line, same indent.
+          const needsComma = !/,\s*$/.test(rest);
+          const head = needsComma
+            ? `${output.slice(0, idKey.valueEnd)},${rest}`
+            : output.slice(0, insertAt);
+          output = `${head}\n${indent}"type": "${kind}",${output.slice(insertAt)}`;
+        } else {
+          // More keys follow on the same line (a one-line manifest): stay inline.
+          output = `${output.slice(0, idKey.valueEnd)}, "type": "${kind}"${output.slice(idKey.valueEnd)}`;
+        }
         changes.push({
           line: lineAt(raw, idKey.keyStart) + 1,
           before: '(no "type")',

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -16,7 +16,7 @@
     "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.14.0",
+    "@vttforge/cli": "^0.15.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -17,7 +17,7 @@
     "@vttforge/core": "^0.15.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.14.0",
+    "@vttforge/cli": "^0.15.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -17,7 +17,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.14.0",
+    "@vttforge/cli": "^0.15.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -18,7 +18,7 @@
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.14.0",
+    "@vttforge/cli": "^0.15.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/core/src/__tests__/decorators.test.ts
+++ b/packages/core/src/__tests__/decorators.test.ts
@@ -124,7 +124,7 @@ describe('@OnHook', () => {
     mock = withMockFoundry();
     const seen: unknown[] = [];
 
-    // biome-ignore lint/complexity/noStaticOnlyClass: @OnHook only accepts static methods, and that is what this case exercises
+    // @OnHook only accepts static methods, and that is what this case exercises.
     class MyModule {
       @OnHook('renderChatMessageHTML')
       static onRender(message: unknown) {


### PR DESCRIPTION
A reader asked what `migrate --write` leaves behind when one file hits a rewrite it cannot make. The answer today: such a rewrite is never attempted (it becomes a "needs a decision" line and the run goes on, exit 0), but writes were file by file, so a crash mid-run could leave a partial tree, and CI had no way to fail on leftover decisions.

- `--write` now computes every rewrite (manifest, sources, data models, sheets, templates) before the first file is written. A run that throws on one file leaves the tree as it was. A test asserts every read happens before the first write.
- `--strict` exits 1 when the report leaves anything that needs a decision: a source or manifest note, a `TODO(migrate)` in a generated file, or a note on a generated set.
- The ordering test found that a one-line manifest broke when `"type"` was inserted after `"id"` (a doubled comma and the key past the closing brace). The key now goes inline on that line.

Docs and README updated.