### PR TITLE
docs: say the project is not related to The Forge hosting service

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,4 +209,4 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Disclaimer
 
-VTTForge is an independent, community-developed project. It is not affiliated with, endorsed by, or sponsored by Foundry Gaming LLC. "Foundry Virtual Tabletop", "Foundry VTT", and "FVTT" are trademarks of Foundry Gaming LLC.
+VTTForge is an independent, community-developed project. It is not affiliated with, endorsed by, or sponsored by Foundry Gaming LLC. "Foundry Virtual Tabletop", "Foundry VTT", and "FVTT" are trademarks of Foundry Gaming LLC. It is also not related to The Forge, the Foundry hosting service; the name is a coincidence.

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -159,7 +159,7 @@ export default defineConfig({
 
     footer: {
       message: 'MIT licensed.',
-      copyright: 'Not affiliated with Foundry Gaming LLC.',
+      copyright: 'Not affiliated with Foundry Gaming LLC or with The Forge hosting service.',
     },
   },
 });

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -445,7 +445,7 @@
             <svg width="20" height="20" aria-hidden="true"><use href="#vttf-mark" /></svg>
             <span><span class="v">VTT</span>Forge</span>
           </span>
-          <span>Independent · Not affiliated with Foundry Gaming LLC · MIT &copy; 2026 Fabricio Cavalcante de Souza</span>
+          <span>Independent · Not affiliated with Foundry Gaming LLC or with The Forge hosting service · MIT &copy; 2026 Fabricio Cavalcante de Souza</span>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
A reader pointed out that people will read VTTForge as The Forge, the Foundry hosting service. The README disclaimer, the site footer and the docs footer now say there is no relation.