### PR TITLE
ci: publish when the Version PR lands on main

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -8,7 +8,7 @@ Add one with:
 pnpm changeset
 ```
 
-The walkthrough asks which packages changed and at what semver level (patch / minor / major). Changesets are consumed by the release workflow (`.github/workflows/changesets.yml`) which opens a Version PR that bumps versions and updates each package's `CHANGELOG.md`.
+The walkthrough asks which packages changed and at what semver level (patch / minor / major). Changesets are consumed by the release workflow (`.github/workflows/changesets.yml`) which opens a Version PR that bumps versions and updates each package's `CHANGELOG.md`. Merging that PR runs `publish.yml`, which publishes the new versions to npm and tags them.
 
 Only published packages get a changeset. A changeset that names a private
 package (`apps/*`, `examples/*`) is skipped by `changeset version` and

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --force
 
-      - name: Create Version PR (publishing happens in publish.yml under OIDC)
+      - name: Create Version PR (merging it runs publish.yml under OIDC)
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2
         with:
           version-script: pnpm changeset:version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,17 @@
 name: Publish to npm
 
-# Tagged release (v*) triggers publish under npm Trusted Publishing (OIDC).
-# No NPM_TOKEN, no --provenance flag — both handled server-side under OIDC.
-# Per-package npmjs.com Trusted Publisher config must point at this repo +
-# this workflow filename.
+# Runs when the Version PR from changesets lands on main (its squash commit
+# keeps the PR title), on a manual dispatch, or on a v* tag. Publishing uses
+# npm Trusted Publishing (OIDC): no NPM_TOKEN, no --provenance flag, both
+# handled server-side. Per-package npmjs.com Trusted Publisher config must
+# point at this repo + this workflow filename.
+#
+# The tags this workflow pushes are `<package>@<version>`, created after the
+# publish, so a tag can never be what starts a release; the merge is.
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch: {}
@@ -25,6 +31,12 @@ concurrency:
 jobs:
   publish:
     name: Verify + publish (OIDC)
+    # On a push to main, only the merged Version PR publishes. `pnpm publish -r`
+    # skips versions already on the registry, so a re-run is harmless.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref_type == 'tag' ||
+      startsWith(github.event.head_commit.message, 'chore(release): version packages')
     # GitHub-hosted on purpose, unlike CI. npm attaches sigstore provenance to
     # public packages and refuses it from a self-hosted runner — only
     # github-hosted ones are accepted. This surfaced the moment the repository


### PR DESCRIPTION
`publish.yml` only ran on a `v*` tag or by hand, and the tags it pushes are `<package>@<version>`, created after the publish, so merging the Version PR never released anything; every release so far was a manual dispatch.

It now also runs on a push to `main` whose head commit is the merged Version PR (the squash commit keeps the PR title `chore(release): version packages`). `pnpm publish -r` skips versions already on the registry, so a re-run is harmless. Manual dispatch and the tag trigger stay.