### PR TITLE
fix(cli): audit 004 reads the rich fields a template.json declares at the document level

### DIFF
--- a/.changeset/cli-audit-004-template-json.md
+++ b/.changeset/cli-audit-004-template-json.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/cli": patch
+---
+
+Audit rule 004 accepts an `HTMLField` or `FilePathField` that `template.json` declares at the document level for a type it lists: while the file exists the server copies that block onto every listed type, so the path is declared. A system generated with a `template.json` no longer gets one finding per rich field.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -86,7 +86,7 @@ deprecation warning that turns into a removal two versions from now.
 | `VTTF-AUDIT-001` | HIGH | `flags.hotReload` in the wrong shape, so hot reload is silently off |
 | `VTTF-AUDIT-002` | HIGH | Top-level `gridDistance` / `gridUnits`; v14 dropped the shim, so the system falls back to the default grid with no warning |
 | `VTTF-AUDIT-003` | LOW | `styles` as an array of strings, the v12 shape |
-| `VTTF-AUDIT-004` | MEDIUM | An `HTMLField` or `FilePathField` not listed in `documentTypes`; the server only sanitises declared paths |
+| `VTTF-AUDIT-004` | MEDIUM | An `HTMLField` or `FilePathField` not listed in `documentTypes`, nor at the document level of a `template.json` that still lists the type; the server only sanitises declared paths |
 | `VTTF-AUDIT-005` | MEDIUM | A `TypeDataModel` without `prepareBaseData`; Active Effects apply between it and `prepareDerivedData` |
 | `VTTF-AUDIT-006` | LOW | An `_addDataFieldMigrations` override; the signature is not what it looks like |
 | `VTTF-AUDIT-007` | MEDIUM | `primaryTokenAttribute` / `secondaryTokenAttribute` not pointing at a `{ value, max }` field, in a data model or in `template.json`; the token bar degrades with no error |

--- a/packages/cli/src/__tests__/audit/source-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/source-rules.test.ts
@@ -170,6 +170,42 @@ registerSystem({ id: 'my-system', actorDataModels: { character: PersonData, npc:
       expect(four[0]?.message).toContain('Actor.npc');
     });
 
+    it('accepts a path that template.json declares at the document level', async () => {
+      // While template.json exists the server copies its document-level
+      // htmlFields onto every type it lists, so the field is declared.
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0' }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'template.json'),
+        JSON.stringify({
+          Actor: { types: ['hero', 'npc'], htmlFields: ['description'], hero: {}, npc: {} },
+          Item: { types: ['gear'], htmlFields: ['notes'], gear: {} },
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `class HeroData extends TypeDataModel {
+  static defineSchema() {
+    return { description: new fields.HTMLField(), bio: new fields.HTMLField() };
+  }
+}
+class GearData extends TypeDataModel {
+  static defineSchema() {
+    return { notes: new fields.HTMLField() };
+  }
+}
+CONFIG.Actor.dataModels.hero = HeroData;
+CONFIG.Item.dataModels.gear = GearData;`,
+        'utf8',
+      );
+      const four = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-004');
+      expect(four.map((f) => f.message)).toEqual([expect.stringContaining('`bio`')]);
+    });
+
     it('flags HTMLField that is missing from manifest documentTypes', async () => {
       await writeFile(
         join(cwd, 'system.json'),

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -950,6 +950,51 @@ async function collectDeclaredRichFields(cwd: string): Promise<{
       }
     }
   }
+  // A system that still ships template.json declares its rich fields there,
+  // at the document level. While the file exists the server resets each
+  // listed type's documentTypes entry and copies that document-level block
+  // back, so those paths are declared for every type the file lists.
+  const templatePath = join(cwd, 'template.json');
+  if (existsSync(templatePath)) {
+    let template: unknown;
+    try {
+      template = JSON.parse(await readFile(templatePath, 'utf8'));
+    } catch {
+      template = null;
+    }
+    if (template && typeof template === 'object' && !Array.isArray(template)) {
+      for (const [docName, doc] of Object.entries(template as Record<string, unknown>)) {
+        if (!doc || typeof doc !== 'object' || Array.isArray(doc)) continue;
+        const { types, htmlFields, filePathFields } = doc as {
+          types?: unknown;
+          htmlFields?: unknown;
+          filePathFields?: unknown;
+        };
+        if (!Array.isArray(types)) continue;
+        const html = Array.isArray(htmlFields)
+          ? htmlFields.filter((e): e is string => typeof e === 'string').map(normalizeDeclaredPath)
+          : [];
+        const filePath = declaredFilePathKeys(filePathFields).map(normalizeDeclaredPath);
+        for (const type of types) {
+          if (typeof type !== 'string') continue;
+          const key = `${docName}.${type}`;
+          const entry = perSubtype.get(key) ?? {
+            html: new Set<string>(),
+            filePath: new Set<string>(),
+          };
+          for (const path of html) {
+            entry.html.add(path);
+            globalHtml.add(path);
+          }
+          for (const path of filePath) {
+            entry.filePath.add(path);
+            globalFilePath.add(path);
+          }
+          perSubtype.set(key, entry);
+        }
+      }
+    }
+  }
   return {
     declared: { perSubtype, packageId, globalHtml, globalFilePath },
     manifestPath,


### PR DESCRIPTION
While `template.json` exists, the server resets each listed type's `documentTypes` entry and copies the document-level `htmlFields`, `filePathFields` and `gmOnlyFields` back onto it. A path declared there is declared for every type the file lists. Rule 004 only read the manifest, so a system that still ships a `template.json` got one finding per rich field even though the server sanitises them. Rule 007 already read the file; 004 now folds its document-level block into each listed type's declared set.

Found by running `vttforge audit` on a system generated by a third-party tool: 11 of the 13 findings left after `migrate --write` were this. Test added; docs row updated.