### PR TITLE
fix(core): sheet bases await the parent render before binding drag-drop, and use DragDrop.implementation

### DIFF
--- a/.changeset/core-render-dragdrop.md
+++ b/.changeset/core-render-dragdrop.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/core": patch
+---
+
+`BaseActorSheet` and `BaseItemSheet` now declare `_onRender` as `async` and await the parent's render before binding the `DRAG_DROP` entries; a subclass that overrides it should `await super._onRender(context, options)`. The instances come from `foundry.applications.ux.DragDrop.implementation` when the runtime provides it. The JSDoc examples pass `{ inplace: false }` to `mergeObject`, which the parent's static options need.

--- a/packages/core/src/__tests__/base-actor-sheet.test.ts
+++ b/packages/core/src/__tests__/base-actor-sheet.test.ts
@@ -217,15 +217,15 @@ describe('BaseActorSheet — default `tab` action', () => {
 });
 
 describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
-  it('does nothing when DRAG_DROP is empty', () => {
+  it('does nothing when DRAG_DROP is empty', async () => {
     const Sub = BaseActorSheet();
     const instance = new Sub();
     stub(instance, { element: document.createElement('div') });
-    instance._onRender({}, {});
+    await instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(0);
   });
 
-  it('binds one DragDrop per static DRAG_DROP entry with default permissions and callbacks', () => {
+  it('binds one DragDrop per static DRAG_DROP entry with default permissions and callbacks', async () => {
     const Base = BaseActorSheet();
     class Sheet extends Base {
       static override DRAG_DROP: ReadonlyArray<DragDropConfig> = [
@@ -236,7 +236,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     const instance = new Sheet();
     const element = document.createElement('div');
     stub(instance, { element: element, isEditable: true });
-    instance._onRender({}, {});
+    await instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(2);
     const first = dragDropBinds[0];
     if (!first) throw new Error('expected dragDropBinds[0] after length assertion');
@@ -250,7 +250,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     expect(typeof callbacks.drop).toBe('function');
   });
 
-  it('honours user-supplied permissions and callbacks (user wins over defaults)', () => {
+  it('honours user-supplied permissions and callbacks (user wins over defaults)', async () => {
     const Base = BaseActorSheet();
     const customDrag = vi.fn();
     class Sheet extends Base {
@@ -264,7 +264,7 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     }
     const instance = new Sheet();
     stub(instance, { element: document.createElement('div'), isEditable: true });
-    instance._onRender({}, {});
+    await instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(1);
     const entry = dragDropBinds[0];
     if (!entry) throw new Error('expected dragDropBinds[0] after length assertion');
@@ -275,14 +275,14 @@ describe('BaseActorSheet — DRAG_DROP wiring in _onRender', () => {
     expect(callbacks.dragstart).toBe(customDrag);
   });
 
-  it('isEditable false locks dragstart and drop', () => {
+  it('isEditable false locks dragstart and drop', async () => {
     const Base = BaseActorSheet();
     class Sheet extends Base {
       static override DRAG_DROP: ReadonlyArray<DragDropConfig> = [{ dragSelector: '.item' }];
     }
     const instance = new Sheet();
     stub(instance, { element: document.createElement('div'), isEditable: false });
-    instance._onRender({}, {});
+    await instance._onRender({}, {});
     const lockedEntry = dragDropBinds[0];
     if (!lockedEntry) throw new Error('expected dragDropBinds[0]');
     const perms = lockedEntry.config.permissions as {

--- a/packages/core/src/__tests__/base-item-sheet.test.ts
+++ b/packages/core/src/__tests__/base-item-sheet.test.ts
@@ -127,14 +127,14 @@ describe('BaseItemSheet', () => {
     ).toBeTypeOf('function');
   });
 
-  it('binds DragDrop entries declared via static DRAG_DROP', () => {
+  it('binds DragDrop entries declared via static DRAG_DROP', async () => {
     const Base = BaseItemSheet();
     class Sheet extends Base {
       static override DRAG_DROP = [{ dragSelector: '.item' }];
     }
     const instance = new Sheet();
     stub(instance, { element: document.createElement('div'), isEditable: true });
-    instance._onRender({}, {});
+    await instance._onRender({}, {});
     expect(dragDropBinds).toHaveLength(1);
     const entry = dragDropBinds[0];
     if (!entry) throw new Error('expected dragDropBinds[0] after length assertion');

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -84,7 +84,7 @@ export interface SheetBaseMembers {
   /** Fills in `context.tabs` for every group in `static TABS`. */
   _prepareContext(options: unknown): Promise<Record<string, unknown>>;
   /** Binds the `static DRAG_DROP` entries. */
-  _onRender(context: unknown, options: unknown): void;
+  _onRender(context: unknown, options: unknown): Promise<void>;
   _onDragStart(event: DragEvent): void;
 
   /**
@@ -160,7 +160,12 @@ function resolveBases(): { Base: AnyConstructor; mixin: (b: AnyConstructor) => A
 
 function resolveDragDrop(): DragDropCtor | undefined {
   const foundry = (globalThis as Record<string, unknown>).foundry as FoundryGlobal | undefined;
-  const ctor = foundry?.applications?.ux?.DragDrop;
+  // `implementation` is the class a system or module may have swapped in
+  // through CONFIG.ux; the bare class is the fallback for a runtime without it.
+  const dragDrop = foundry?.applications?.ux?.DragDrop as
+    | (DragDropCtor & { implementation?: DragDropCtor })
+    | undefined;
+  const ctor = dragDrop?.implementation ?? dragDrop;
   return typeof ctor === 'function' ? ctor : undefined;
 }
 
@@ -193,6 +198,7 @@ export const VTTFORGE_SHEET_CLASS = 'vttforge';
  *   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
  *     super.DEFAULT_OPTIONS,
  *     { classes: ['my-system'], position: { width: 720 } },
+ *     { inplace: false }, // never edit the parent's static options in place
  *   );
  *   static PARTS = { ... };
  *   static TABS = {
@@ -309,12 +315,16 @@ export function BaseActorSheet(): SheetBaseCtor {
      * `_onDragStart` / `_onDrop`. Subclasses extending `_onRender` MUST call
      * `super._onRender(context, options)` to keep DragDrop wired.
      */
-    _onRender(context: unknown, options: unknown): void {
+    async _onRender(context: unknown, options: unknown): Promise<void> {
+      // ApplicationV2 renders asynchronously; the parent's work has to finish
+      // before the DragDrop instances bind to the element it produced.
       const superRender = (
-        Mixed.prototype as { _onRender?: (context: unknown, options: unknown) => void }
+        Mixed.prototype as {
+          _onRender?: (context: unknown, options: unknown) => void | Promise<void>;
+        }
       )._onRender;
       if (typeof superRender === 'function') {
-        superRender.call(this, context, options);
+        await superRender.call(this, context, options);
       }
       const configs = (this.constructor as { DRAG_DROP?: ReadonlyArray<DragDropConfig> }).DRAG_DROP;
       if (!configs?.length) return;

--- a/packages/core/src/base-item-sheet.ts
+++ b/packages/core/src/base-item-sheet.ts
@@ -66,7 +66,12 @@ function resolveBases(): { Base: AnyConstructor; mixin: (b: AnyConstructor) => A
 
 function resolveDragDrop(): DragDropCtor | undefined {
   const foundry = (globalThis as Record<string, unknown>).foundry as FoundryGlobal | undefined;
-  const ctor = foundry?.applications?.ux?.DragDrop;
+  // `implementation` is the class a system or module may have swapped in
+  // through CONFIG.ux; the bare class is the fallback for a runtime without it.
+  const dragDrop = foundry?.applications?.ux?.DragDrop as
+    | (DragDropCtor & { implementation?: DragDropCtor })
+    | undefined;
+  const ctor = dragDrop?.implementation ?? dragDrop;
   return typeof ctor === 'function' ? ctor : undefined;
 }
 
@@ -79,6 +84,7 @@ function resolveDragDrop(): DragDropCtor | undefined {
  *   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
  *     super.DEFAULT_OPTIONS,
  *     { classes: ['my-system'], position: { width: 540 } },
+ *     { inplace: false }, // never edit the parent's static options in place
  *   );
  *   static PARTS = { ... };
  *   static TABS = {
@@ -164,12 +170,16 @@ export function BaseItemSheet(): SheetBaseCtor {
       }
     }
 
-    _onRender(context: unknown, options: unknown): void {
+    async _onRender(context: unknown, options: unknown): Promise<void> {
+      // ApplicationV2 renders asynchronously; the parent's work has to finish
+      // before the DragDrop instances bind to the element it produced.
       const superRender = (
-        Mixed.prototype as { _onRender?: (context: unknown, options: unknown) => void }
+        Mixed.prototype as {
+          _onRender?: (context: unknown, options: unknown) => void | Promise<void>;
+        }
       )._onRender;
       if (typeof superRender === 'function') {
-        superRender.call(this, context, options);
+        await superRender.call(this, context, options);
       }
       const configs = (this.constructor as { DRAG_DROP?: ReadonlyArray<DragDropConfig> }).DRAG_DROP;
       if (!configs?.length) return;


### PR DESCRIPTION
Three follow-ups from the review of the sheet codemod, all in `@vttforge/core`:

- `_onRender` on `BaseActorSheet` and `BaseItemSheet` is `async` and awaits the mixin's own `_onRender` before binding the `DRAG_DROP` entries, so they bind to the element the parent finished producing. A subclass that overrides it should `await super._onRender(context, options)`; the codemod already writes that.
- `resolveDragDrop` prefers `foundry.applications.ux.DragDrop.implementation`, the class a package may have swapped in, with the bare class as the fallback.
- The JSDoc examples pass `{ inplace: false }` to `mergeObject`. Without it the parent's static `DEFAULT_OPTIONS` are edited in place. The templates and the example already did this.

Tests updated to await the render; 209 pass.