### PR TITLE
feat(core): play and edit modes for the sheet bases

### DIFF
--- a/.changeset/cli-pins-sheet-modes.md
+++ b/.changeset/cli-pins-sheet-modes.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/cli": patch
+---
+
+The scaffold templates pin `@vttforge/core` at the version this release publishes.

--- a/.changeset/core-sheet-modes.md
+++ b/.changeset/core-sheet-modes.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/core": minor
+---
+
+Play and edit modes for the sheet bases. Opt in with `static MODES = { initial: 'play' }` on a `BaseActorSheet()` or `BaseItemSheet()`: a header control switches between the two, `sheet.mode`, `sheet.toggleMode()` and `context.mode` report it, the sheet element carries `vttforge-mode-play` or `vttforge-mode-edit`, and in play every form field in the window content is disabled except those inside an element with `data-vttforge-edit-in-play`. A sheet without `MODES` behaves as before.

--- a/apps/docs/guide/sheets.md
+++ b/apps/docs/guide/sheets.md
@@ -122,6 +122,40 @@ If you are registering a sheet for an actor, it must extend `ActorSheetV2`, and
 `BaseActorSheet()` does. A plain `ApplicationV2` leaves `actor.sheet` as `null`
 and reports nothing anywhere.
 
+## Play and edit modes
+
+A sheet in play is read: the numbers, the buttons that roll, the tabs. A
+sheet in edit is written. Opt in on any sheet built on `BaseActorSheet()`,
+`BaseItemSheet()` or `BaseDocumentSheet()`:
+
+```ts
+class CharacterSheet extends BaseActorSheet() {
+  static MODES = {
+    initial: 'play',
+    labels: { play: 'MY_SYSTEM.Mode.play', edit: 'MY_SYSTEM.Mode.edit' },
+  };
+}
+```
+
+What that gives, and nothing of it happens without the opt-in:
+
+- A header control that reads "Edit mode" in play and "Play mode" in edit,
+  shown to users who can edit the document. Its action is `vttforgeToggleMode`.
+- `sheet.mode`, `sheet.isEditMode`, `sheet.isPlayMode` and
+  `sheet.toggleMode(mode?)`, which re-renders.
+- `context.mode`, `context.isEditMode` and `context.isPlayMode` for the
+  templates.
+- The class `vttforge-mode-play` or `vttforge-mode-edit` on the sheet element
+  after every render, for the CSS.
+- In play, every form field inside the window content is `disabled`: inputs,
+  selects, textareas and Foundry's own elements such as `<prose-mirror>`. A
+  `<button>` is an action, not a field, so rolls keep working. A field that
+  must stay open in play, hit points say, sits inside an element with
+  `data-vttforge-edit-in-play`.
+
+The mode lives on the sheet instance. It resets when the window is closed
+and opened again, and it is never written to a setting.
+
 ## Registering a sheet
 
 Register through `registerSystem` or `registerModule`, and give each sheet an

--- a/apps/e2e/tests/system.spec.mjs
+++ b/apps/e2e/tests/system.spec.mjs
@@ -122,6 +122,59 @@ test('a character sheet renders its parts and its derived data', async ({ page }
   expect(sheet.derived.strMod).toBe(0);
 });
 
+test('a sheet with MODES opens in play, locks its fields, and edit opens them again', async ({
+  page,
+}) => {
+  await joinWorld(page);
+
+  const result = await page.evaluate(async () => {
+    const actor = await Actor.create({ name: 'End-to-end Mode Hero', type: 'character' });
+    await actor.sheet.render(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const sheet = actor.sheet;
+    const read = () => {
+      const element = sheet.element;
+      const content = element.querySelector('.window-content');
+      return {
+        mode: sheet.mode,
+        classes: [...element.classList].filter((c) => c.startsWith('vttforge-mode-')),
+        nameDisabled: content.querySelector('input[name="name"]').disabled,
+        hpDisabled: content.querySelector('input[name="system.health.value"]').disabled,
+        rollDisabled: content.querySelector('[data-action="rollAbility"]').disabled,
+      };
+    };
+    const play = read();
+    const control = sheet._getHeaderControls().find((c) => c.action === 'vttforgeToggleMode');
+    const controlInPlay = { label: control.label, visible: control.visible.call(sheet) };
+    await sheet.toggleMode();
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const edit = read();
+    const controlInEdit = sheet
+      ._getHeaderControls()
+      .find((c) => c.action === 'vttforgeToggleMode').label;
+    // The header control is what the user clicks; drive it through the action.
+    await sheet.element.querySelector('[data-action="vttforgeToggleMode"]')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    return { play, controlInPlay, edit, controlInEdit, afterClick: read().mode };
+  });
+
+  expect(result.play.mode).toBe('play');
+  expect(result.play.classes).toEqual(['vttforge-mode-play']);
+  expect(result.play.nameDisabled).toBe(true);
+  // Hit points sit inside a data-vttforge-edit-in-play wrapper.
+  expect(result.play.hpDisabled).toBe(false);
+  expect(result.play.rollDisabled).toBe(false);
+  expect(result.controlInPlay).toEqual({
+    label: 'VTTFORGE_EXAMPLE.Sheet.Mode.edit',
+    visible: true,
+  });
+
+  expect(result.edit.mode).toBe('edit');
+  expect(result.edit.classes).toEqual(['vttforge-mode-edit']);
+  expect(result.edit.nameDisabled).toBe(false);
+  expect(result.controlInEdit).toBe('VTTFORGE_EXAMPLE.Sheet.Mode.play');
+});
+
 test("the sheet styles compose with the system's own CSS, and yield to modules", async ({
   page,
 }) => {

--- a/examples/simple-system/lang/en.json
+++ b/examples/simple-system/lang/en.json
@@ -1,13 +1,13 @@
 {
   "VTTFORGE_EXAMPLE.System.title": "VTTForge Example System",
   "VTTFORGE_EXAMPLE.System.description": "Smoke-test system that exercises @vttforge/core end-to-end.",
-
   "TYPES.Actor.character": "Character",
   "TYPES.Item.gear": "Gear",
-
   "VTTFORGE_EXAMPLE.Sheet.Character.title": "Character",
   "VTTFORGE_EXAMPLE.Sheet.Gear.title": "Gear",
   "VTTFORGE_EXAMPLE.Sheet.NamePlaceholder": "Name…",
+  "VTTFORGE_EXAMPLE.Sheet.Mode.play": "Play mode",
+  "VTTFORGE_EXAMPLE.Sheet.Mode.edit": "Edit mode",
   "VTTFORGE_EXAMPLE.Sheet.Level": "LV",
   "VTTFORGE_EXAMPLE.Sheet.AbilityScores": "Ability scores",
   "VTTFORGE_EXAMPLE.Sheet.Inventory": "Inventory",
@@ -18,37 +18,31 @@
   "VTTFORGE_EXAMPLE.Sheet.NewGearName": "New Gear",
   "VTTFORGE_EXAMPLE.Sheet.NoGear": "No gear yet — drag items here or click 'New gear'.",
   "VTTFORGE_EXAMPLE.Sheet.Delete": "Delete",
-
   "VTTFORGE_EXAMPLE.Sheet.Quick.HP": "HP",
   "VTTFORGE_EXAMPLE.Sheet.Quick.AC": "AC",
   "VTTFORGE_EXAMPLE.Sheet.Quick.SPD": "SPD",
   "VTTFORGE_EXAMPLE.Sheet.Quick.INIT": "INIT",
-
   "VTTFORGE_EXAMPLE.Sheet.Tabs.abilities": "Abilities",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.inventory": "Inventory",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.spells": "Spells",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.biography": "Biography",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.details": "Details",
   "VTTFORGE_EXAMPLE.Sheet.Tabs.description": "Description",
-
   "VTTFORGE_EXAMPLE.Sheet.Roll.label": "Roll",
   "VTTFORGE_EXAMPLE.Sheet.Roll.flavor": "{ability} check",
   "VTTFORGE_EXAMPLE.Sheet.Drop.label": "Drop item to add",
   "VTTFORGE_EXAMPLE.Sheet.Drop.rejected": "Cannot drop {type} items on a character — only gear is accepted.",
-
   "VTTFORGE_EXAMPLE.Ability.str": "Strength",
   "VTTFORGE_EXAMPLE.Ability.dex": "Dexterity",
   "VTTFORGE_EXAMPLE.Ability.con": "Constitution",
   "VTTFORGE_EXAMPLE.Ability.int": "Intelligence",
   "VTTFORGE_EXAMPLE.Ability.wis": "Wisdom",
   "VTTFORGE_EXAMPLE.Ability.cha": "Charisma",
-
   "VTTFORGE_EXAMPLE.Gear.Quantity": "Quantity",
   "VTTFORGE_EXAMPLE.Gear.Weight": "Weight (lb)",
   "VTTFORGE_EXAMPLE.Gear.Kind.equipped": "equipped",
   "VTTFORGE_EXAMPLE.Gear.Kind.valued": "valued",
   "VTTFORGE_EXAMPLE.Gear.Kind.stowed": "stowed",
-
   "VTTFORGE_EXAMPLE.Settings.showTutorial.name": "Show tutorial",
   "VTTFORGE_EXAMPLE.Settings.showTutorial.hint": "Display the example-system tutorial banner on world load."
 }

--- a/examples/simple-system/scripts/sheets/character-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/character-sheet.mjs
@@ -84,6 +84,7 @@ export class CharacterSheet extends BaseActorSheet() {
    * roll buttons live. The header control switches to edit. Hit points stay
    * open in play through `data-vttforge-edit-in-play` on their wrapper.
    * @override
+   * @type {import('@vttforge/core').SheetModesConfig}
    */
   static MODES = {
     initial: 'play',

--- a/examples/simple-system/scripts/sheets/character-sheet.mjs
+++ b/examples/simple-system/scripts/sheets/character-sheet.mjs
@@ -79,6 +79,20 @@ export class CharacterSheet extends BaseActorSheet() {
     },
   };
 
+  /**
+   * Play and edit modes. The sheet opens in play: every field locked, the
+   * roll buttons live. The header control switches to edit. Hit points stay
+   * open in play through `data-vttforge-edit-in-play` on their wrapper.
+   * @override
+   */
+  static MODES = {
+    initial: 'play',
+    labels: {
+      play: 'VTTFORGE_EXAMPLE.Sheet.Mode.play',
+      edit: 'VTTFORGE_EXAMPLE.Sheet.Mode.edit',
+    },
+  };
+
   /** @override */
   static DRAG_DROP = [
     {

--- a/examples/simple-system/templates/actor/character-sheet.hbs
+++ b/examples/simple-system/templates/actor/character-sheet.hbs
@@ -30,7 +30,7 @@
         </div>
       </div>
       <div class="sh-quick">
-        <div class="q">
+        <div class="q" data-vttforge-edit-in-play>
           <div class="qv">
             <input type="number" name="system.health.value" value="{{system.health.value}}" min="0" />
             <span class="qv-sep">/</span>

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.15.0"
+    "@vttforge/core": "^0.16.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.15.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.15.0"
+    "@vttforge/core": "^0.16.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.15.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.15.0",
+    "@vttforge/core": "^0.16.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.15.0",
+    "@vttforge/core": "^0.16.0",
     "@vttforge/styles": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,7 +14,7 @@ pnpm add @vttforge/core
 | `BaseTypeDataModel(defineSchema)` | A `TypeDataModel` whose fields are typed from the schema, so `this.level` is a `number` inside `prepareDerivedData` |
 | `fields()` | `foundry.data.fields`, typed, read lazily so the module imports in Node |
 | `InferSchema<T>` / `Model['$inferData']` | The hand-written interface that drifts from the schema |
-| `BaseActorSheet()` / `BaseItemSheet()` | `static TABS`, `static DRAG_DROP`, typed `onDropItem` and friends on `ActorSheetV2` / `ItemSheetV2` with Handlebars |
+| `BaseActorSheet()` / `BaseItemSheet()` | `static TABS`, `static DRAG_DROP`, `static MODES` (play and edit, with the fields locked in play), typed `onDropItem` and friends on `ActorSheetV2` / `ItemSheetV2` with Handlebars |
 | `BaseDocumentSheet('Actor' \| 'Item')` / `BaseApplication()` | The same plumbing without Handlebars, for a sheet that builds its own element |
 | `SystemConfig` | `game.settings.register/get/set` with the package id filled in and unregistered reads caught |
 | `createMigrationRunner` | The `schemaVersion` setting, the `isNewerVersion` compare and the sequential `await` every system grows |

--- a/packages/core/src/__tests__/sheet-modes.test.ts
+++ b/packages/core/src/__tests__/sheet-modes.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseActorSheet } from '../base-actor-sheet.js';
+import { BaseItemSheet } from '../base-item-sheet.js';
+import { EDIT_IN_PLAY_ATTRIBUTE, MODE_CLASS, TOGGLE_MODE_ACTION } from '../sheet-modes.js';
+
+function stub<T extends object>(instance: T, values: Record<string, unknown>): void {
+  Object.assign(instance as Record<string, unknown>, values);
+}
+
+class FakeSheetV2 {
+  async _prepareContext(_options: unknown): Promise<Record<string, unknown>> {
+    return { fromSuper: true };
+  }
+  async _onRender(_context: unknown, _options: unknown): Promise<void> {
+    /* foundry super */
+  }
+  _getHeaderControls(): Array<{ action?: string; label?: string; icon?: string }> {
+    const controls = (
+      this.constructor as unknown as { DEFAULT_OPTIONS: { window: { controls: unknown[] } } }
+    ).DEFAULT_OPTIONS.window.controls;
+    return [...(controls as Array<{ action?: string; label?: string; icon?: string }>)];
+  }
+}
+
+const HandlebarsApplicationMixin = (base: typeof FakeSheetV2) => class extends base {};
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).foundry = {
+    applications: {
+      api: { HandlebarsApplicationMixin },
+      sheets: { ActorSheetV2: FakeSheetV2, ItemSheetV2: FakeSheetV2 },
+      ux: {},
+    },
+  };
+});
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).foundry = undefined;
+});
+
+function sheetElement(): HTMLElement {
+  const root = document.createElement('form');
+  root.innerHTML = `
+    <header class="window-header"><input name="ignored-in-header" /></header>
+    <div class="window-content">
+      <input name="system.hp" />
+      <select name="system.kind"><option>a</option></select>
+      <prose-mirror name="system.notes"></prose-mirror>
+      <button type="button" data-action="rollAbility">Roll</button>
+      <div ${EDIT_IN_PLAY_ATTRIBUTE}><input name="system.hp.value" /></div>
+    </div>`;
+  return root;
+}
+
+describe('a sheet without static MODES', () => {
+  it('is always in edit, adds no class and touches no field', async () => {
+    class Plain extends BaseActorSheet() {}
+    const sheet = new Plain();
+    const element = sheetElement();
+    stub(sheet, { element, isEditable: true });
+    expect(sheet.mode).toBe('edit');
+    expect(sheet.isEditMode).toBe(true);
+    await sheet._onRender({}, {});
+    expect(element.classList.contains(MODE_CLASS.edit)).toBe(false);
+    expect(element.querySelector<HTMLInputElement>('input[name="system.hp"]')?.disabled).toBe(
+      false,
+    );
+    const context = await sheet._prepareContext({});
+    expect(context).toMatchObject({ mode: 'edit', isEditMode: true, isPlayMode: false });
+  });
+
+  it('keeps the header control hidden and toggleMode a no-op', async () => {
+    class Plain extends BaseItemSheet() {}
+    const sheet = new Plain();
+    const render = vi.fn();
+    stub(sheet, { isEditable: true, render });
+    const control = sheet
+      ._getHeaderControls()
+      .find((c) => (c as { action?: string }).action === TOGGLE_MODE_ACTION) as
+      | { visible: (this: unknown) => boolean }
+      | undefined;
+    expect(control?.visible.call(sheet)).toBe(false);
+    await sheet.toggleMode();
+    expect(sheet.mode).toBe('edit');
+    expect(render).not.toHaveBeenCalled();
+  });
+});
+
+describe('a sheet with static MODES', () => {
+  // Built inside each test: the globals only exist once beforeEach has run.
+  const hero = () =>
+    class Hero extends BaseActorSheet() {
+      static override readonly MODES = { initial: 'play' as const, labels: { edit: 'X.Edit' } };
+    };
+
+  it('opens in the initial mode, exposes it on the context, and disables the fields in play', async () => {
+    const Hero = hero();
+    const sheet = new Hero();
+    const element = sheetElement();
+    stub(sheet, { element, isEditable: true });
+    expect(sheet.mode).toBe('play');
+    expect(sheet.isPlayMode).toBe(true);
+    expect(await sheet._prepareContext({})).toMatchObject({ mode: 'play', isPlayMode: true });
+
+    await sheet._onRender({}, {});
+    expect(element.classList.contains(MODE_CLASS.play)).toBe(true);
+    expect(element.classList.contains(MODE_CLASS.edit)).toBe(false);
+    const content = element.querySelector('.window-content') as HTMLElement;
+    expect(content.querySelector<HTMLInputElement>('input[name="system.hp"]')?.disabled).toBe(true);
+    expect(content.querySelector<HTMLSelectElement>('select')?.disabled).toBe(true);
+    expect(content.querySelector('prose-mirror')?.hasAttribute('disabled')).toBe(true);
+    // A button is an action, not a field.
+    expect(content.querySelector<HTMLButtonElement>('button')?.disabled).toBe(false);
+    // The opt-out keeps its field open, and the header is never touched.
+    expect(content.querySelector<HTMLInputElement>('input[name="system.hp.value"]')?.disabled).toBe(
+      false,
+    );
+    expect(
+      element.querySelector<HTMLInputElement>('input[name="ignored-in-header"]')?.disabled,
+    ).toBe(false);
+  });
+
+  it('toggles, re-renders, and swaps the control label for where it leads', async () => {
+    const Hero = hero();
+    const sheet = new Hero();
+    const render = vi.fn();
+    stub(sheet, { element: sheetElement(), isEditable: true, render });
+    const control = () =>
+      sheet
+        ._getHeaderControls()
+        .find((c) => (c as { action?: string }).action === TOGGLE_MODE_ACTION) as {
+        label: string;
+        icon: string;
+        visible: (this: unknown) => boolean;
+      };
+    expect(control().visible.call(sheet)).toBe(true);
+    expect(control().label).toBe('X.Edit');
+
+    await sheet.toggleMode();
+    expect(sheet.mode).toBe('edit');
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(control().label).toBe('Play mode');
+    expect(control().icon).toBe('fa-solid fa-dice-d20');
+
+    await sheet._onRender({}, {});
+    const element = (sheet as unknown as { element: HTMLElement }).element;
+    expect(element.classList.contains(MODE_CLASS.edit)).toBe(true);
+    expect(element.querySelector<HTMLInputElement>('input[name="system.hp"]')?.disabled).toBe(
+      false,
+    );
+
+    await sheet.toggleMode('play');
+    expect(sheet.mode).toBe('play');
+    stub(sheet, { isEditable: false });
+    expect(control().visible.call(sheet)).toBe(false);
+  });
+
+  it('dispatches the header control through the action handler', async () => {
+    const Hero = hero();
+    const sheet = new Hero();
+    const render = vi.fn();
+    stub(sheet, { element: sheetElement(), isEditable: true, render });
+    const handler = (
+      Hero.DEFAULT_OPTIONS.actions as unknown as Record<
+        string,
+        (this: unknown, e: Event, t: HTMLElement) => void
+      >
+    )[TOGGLE_MODE_ACTION];
+    handler?.call(sheet, new Event('click'), document.createElement('button'));
+    await Promise.resolve();
+    expect(sheet.mode).toBe('edit');
+    expect(render).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -31,6 +31,16 @@
 
 import { VttfError } from './errors/registry.js';
 import type { DocumentSheetV2Members } from './foundry-base.js';
+import {
+  applyMode,
+  currentMode,
+  decorateHeaderControls,
+  modeContext,
+  type SheetMode,
+  type SheetModesConfig,
+  toggleMode,
+  toggleModeControl,
+} from './sheet-modes.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: Foundry's ActorSheetV2 shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
@@ -67,6 +77,11 @@ export interface SheetBaseStatics {
   // biome-ignore lint/suspicious/noExplicitAny: a subclass merges arbitrary ApplicationV2 options in; a narrower type would reject the merge
   readonly DEFAULT_OPTIONS: Record<string, any>;
   readonly DRAG_DROP: ReadonlyArray<DragDropConfig>;
+  /**
+   * Opt into play and edit modes. Absent, the sheet is always in edit and
+   * shows no toggle. See `sheet-modes.ts` for what the opt-in gives.
+   */
+  readonly MODES?: SheetModesConfig;
 }
 
 /**
@@ -86,6 +101,14 @@ export interface SheetBaseMembers {
   /** Binds the `static DRAG_DROP` entries. */
   _onRender(context: unknown, options: unknown): void;
   _onDragStart(event: DragEvent): void;
+  /** `'play'` or `'edit'`; always `'edit'` on a sheet without `static MODES`. */
+  readonly mode: SheetMode;
+  readonly isEditMode: boolean;
+  readonly isPlayMode: boolean;
+  /** Flip the mode, or set the one given, and re-render. */
+  toggleMode(mode?: SheetMode): Promise<void>;
+  /** The header controls, with the mode toggle labelled for where it leads. */
+  _getHeaderControls(): unknown[];
 
   /**
    * The typed drop hooks. Override the one you want; returning `undefined`
@@ -219,11 +242,14 @@ export function BaseActorSheet(): SheetBaseCtor {
   class VttforgeBaseActorSheet extends Mixed {
     static readonly DEFAULT_OPTIONS = {
       classes: [VTTFORGE_SHEET_CLASS],
-      window: { resizable: true },
+      window: { resizable: true, controls: [toggleModeControl()] },
       position: { width: 600, height: 700 },
       tag: 'form',
       form: { submitOnChange: true, closeOnSubmit: false },
-      actions: { vttforgeTab: VttforgeBaseActorSheet._onTab },
+      actions: {
+        vttforgeTab: VttforgeBaseActorSheet._onTab,
+        vttforgeToggleMode: VttforgeBaseActorSheet._onToggleMode,
+      },
     } as const;
 
     /**
@@ -264,7 +290,38 @@ export function BaseActorSheet(): SheetBaseCtor {
           context.tabs = tabs;
         }
       }
+      Object.assign(context, modeContext(this));
       return context;
+    }
+
+    get mode(): SheetMode {
+      return currentMode(this);
+    }
+
+    get isEditMode(): boolean {
+      return currentMode(this) === 'edit';
+    }
+
+    get isPlayMode(): boolean {
+      return currentMode(this) === 'play';
+    }
+
+    async toggleMode(mode?: SheetMode): Promise<void> {
+      await toggleMode(this, mode);
+    }
+
+    /** The toggle control reads "Play mode" in edit and "Edit mode" in play. */
+    _getHeaderControls(): unknown[] {
+      const superControls = (Mixed.prototype as { _getHeaderControls?: () => unknown[] })
+        ._getHeaderControls;
+      const controls =
+        typeof superControls === 'function' ? (superControls.call(this) as unknown[]) : [];
+      return decorateHeaderControls(this, controls as Array<{ action?: string }>);
+    }
+
+    static _onToggleMode(_event: Event, _target: HTMLElement): void {
+      // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
+      void toggleMode(this as unknown as object);
     }
 
     /**
@@ -317,11 +374,12 @@ export function BaseActorSheet(): SheetBaseCtor {
         superRender.call(this, context, options);
       }
       const configs = (this.constructor as { DRAG_DROP?: ReadonlyArray<DragDropConfig> }).DRAG_DROP;
-      if (!configs?.length) return;
       const DragDrop = resolveDragDrop();
-      if (!DragDrop) return;
       const element = (this as { element?: HTMLElement }).element;
-      if (!element) return;
+      if (!configs?.length || !DragDrop || !element) {
+        applyMode(this);
+        return;
+      }
       const onDragStart = (this as { _onDragStart?: (event: DragEvent) => void })._onDragStart;
       const onDrop = (this as { _onDrop?: (event: DragEvent) => void })._onDrop;
       for (const cfg of configs) {
@@ -339,6 +397,7 @@ export function BaseActorSheet(): SheetBaseCtor {
           },
         }).bind(element);
       }
+      applyMode(this);
     }
 
     /**

--- a/packages/core/src/base-item-sheet.ts
+++ b/packages/core/src/base-item-sheet.ts
@@ -17,6 +17,15 @@
 import type { DragDropConfig, SheetBaseCtor } from './base-actor-sheet.js';
 import { VTTFORGE_SHEET_CLASS } from './base-actor-sheet.js';
 import { VttfError } from './errors/registry.js';
+import {
+  applyMode,
+  currentMode,
+  decorateHeaderControls,
+  modeContext,
+  type SheetMode,
+  toggleMode,
+  toggleModeControl,
+} from './sheet-modes.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: Foundry's ItemSheetV2 class is resolved at runtime; the members the SDK stands on are in @vttforge/types
 type AnyConstructor = new (...args: any[]) => any;
@@ -100,11 +109,14 @@ export function BaseItemSheet(): SheetBaseCtor {
   class VttforgeBaseItemSheet extends Mixed {
     static readonly DEFAULT_OPTIONS = {
       classes: [VTTFORGE_SHEET_CLASS],
-      window: { resizable: true },
+      window: { resizable: true, controls: [toggleModeControl()] },
       position: { width: 520, height: 480 },
       tag: 'form',
       form: { submitOnChange: true, closeOnSubmit: false },
-      actions: { vttforgeTab: VttforgeBaseItemSheet._onTab },
+      actions: {
+        vttforgeTab: VttforgeBaseItemSheet._onTab,
+        vttforgeToggleMode: VttforgeBaseItemSheet._onToggleMode,
+      },
     } as const;
 
     static readonly DRAG_DROP: ReadonlyArray<DragDropConfig> = [];
@@ -137,7 +149,37 @@ export function BaseItemSheet(): SheetBaseCtor {
           context.tabs = tabs;
         }
       }
+      Object.assign(context, modeContext(this));
       return context;
+    }
+
+    get mode(): SheetMode {
+      return currentMode(this);
+    }
+
+    get isEditMode(): boolean {
+      return currentMode(this) === 'edit';
+    }
+
+    get isPlayMode(): boolean {
+      return currentMode(this) === 'play';
+    }
+
+    async toggleMode(mode?: SheetMode): Promise<void> {
+      await toggleMode(this, mode);
+    }
+
+    _getHeaderControls(): unknown[] {
+      const superControls = (Mixed.prototype as { _getHeaderControls?: () => unknown[] })
+        ._getHeaderControls;
+      const controls =
+        typeof superControls === 'function' ? (superControls.call(this) as unknown[]) : [];
+      return decorateHeaderControls(this, controls as Array<{ action?: string }>);
+    }
+
+    static _onToggleMode(_event: Event, _target: HTMLElement): void {
+      // biome-ignore lint/complexity/noThisInStatic: ApplicationV2 binds `this` to the sheet instance at call time
+      void toggleMode(this as unknown as object);
     }
 
     static _onTab(_event: Event, target: HTMLElement): void {
@@ -172,11 +214,12 @@ export function BaseItemSheet(): SheetBaseCtor {
         superRender.call(this, context, options);
       }
       const configs = (this.constructor as { DRAG_DROP?: ReadonlyArray<DragDropConfig> }).DRAG_DROP;
-      if (!configs?.length) return;
       const DragDrop = resolveDragDrop();
-      if (!DragDrop) return;
       const element = (this as { element?: HTMLElement }).element;
-      if (!element) return;
+      if (!configs?.length || !DragDrop || !element) {
+        applyMode(this);
+        return;
+      }
       const onDragStart = (this as { _onDragStart?: (event: DragEvent) => void })._onDragStart;
       const onDrop = (this as { _onDrop?: (event: DragEvent) => void })._onDrop;
       for (const cfg of configs) {
@@ -194,6 +237,7 @@ export function BaseItemSheet(): SheetBaseCtor {
           },
         }).bind(element);
       }
+      applyMode(this);
     }
 
     #isEditable(): boolean {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,4 +160,11 @@ export {
   type SheetRegistration,
 } from './register-sheets.js';
 export { registerSystem, type SystemRegistration } from './register-system.js';
+export {
+  EDIT_IN_PLAY_ATTRIBUTE,
+  MODE_CLASS,
+  type SheetMode,
+  type SheetModesConfig,
+  TOGGLE_MODE_ACTION,
+} from './sheet-modes.js';
 export { SystemConfig } from './system-config.js';

--- a/packages/core/src/sheet-modes.ts
+++ b/packages/core/src/sheet-modes.ts
@@ -1,0 +1,163 @@
+/**
+ * Play and edit modes for a sheet.
+ *
+ * A sheet in play is read: the numbers, the buttons that roll, the tabs. A
+ * sheet in edit is written: every field open. Most systems end up with the
+ * two, and each writes the same toggle, the same class on the root, the same
+ * `disabled` on every input. This is that once.
+ *
+ * Opt in with `static MODES = { initial: 'play' }` on a sheet built on one of
+ * the bases. Without it a sheet behaves as before: always in edit, no header
+ * control, no field touched.
+ *
+ * What the opt-in gives:
+ *
+ * - A header control, "Edit mode" in play and "Play mode" in edit, shown to
+ *   users who can edit the document. Its action is `vttforgeToggleMode`.
+ * - `sheet.mode`, `sheet.isEditMode`, `sheet.isPlayMode`, and
+ *   `sheet.toggleMode(mode?)`, which re-renders.
+ * - `context.mode`, `context.isEditMode` and `context.isPlayMode` for the
+ *   templates.
+ * - The class `vttforge-mode-play` or `vttforge-mode-edit` on the sheet
+ *   element after every render.
+ * - In play, every form field inside the window content is `disabled`, except
+ *   those inside an element that carries `data-vttforge-edit-in-play`. A roll
+ *   button is not a form field; it keeps working.
+ *
+ * The mode lives on the sheet instance, so it resets when the window is
+ * closed and opened again. That is what a player expects from a toggle, and
+ * it keeps the sheet out of the settings.
+ */
+
+export type SheetMode = 'play' | 'edit';
+
+/** The opt-in. `static MODES = {}` is enough; both fields have defaults. */
+export interface SheetModesConfig {
+  /** The mode a fresh sheet opens in. Default `'play'`. */
+  readonly initial?: SheetMode;
+  /**
+   * Labels for the header control, as localization keys or plain text. The
+   * `play` label is shown while in edit (it leads to play), and the reverse.
+   * Defaults: `'Play mode'` and `'Edit mode'`.
+   */
+  readonly labels?: { readonly play?: string; readonly edit?: string };
+}
+
+/** The action name the header control dispatches. */
+export const TOGGLE_MODE_ACTION = 'vttforgeToggleMode';
+
+/** Class put on the sheet element for the current mode. */
+export const MODE_CLASS: Readonly<Record<SheetMode, string>> = {
+  play: 'vttforge-mode-play',
+  edit: 'vttforge-mode-edit',
+};
+
+/**
+ * Form fields disabled in play. Foundry's own elements are included; a
+ * `<button>` is not, so actions keep working.
+ */
+const FIELD_SELECTOR =
+  'input, select, textarea, prose-mirror, file-picker, color-picker, range-picker, string-tags, multi-select, multi-checkbox, formula-input';
+
+/** Fields inside an element with this attribute stay editable in play. */
+export const EDIT_IN_PLAY_ATTRIBUTE = 'data-vttforge-edit-in-play';
+
+const current = new WeakMap<object, SheetMode>();
+
+interface SheetLike {
+  readonly constructor: { readonly MODES?: SheetModesConfig };
+  readonly isEditable?: boolean;
+  readonly element?: HTMLElement;
+  render?: (options?: unknown) => unknown;
+}
+
+function modesConfig(sheet: object): SheetModesConfig | undefined {
+  const config = (sheet as SheetLike).constructor.MODES;
+  return config && typeof config === 'object' ? config : undefined;
+}
+
+/** The sheet's mode. A sheet without `MODES` is always in edit. */
+export function currentMode(sheet: object): SheetMode {
+  const config = modesConfig(sheet);
+  if (!config) return 'edit';
+  return current.get(sheet) ?? config.initial ?? 'play';
+}
+
+function setMode(sheet: object, mode: SheetMode): void {
+  current.set(sheet, mode);
+}
+
+/** The context keys templates read. */
+export function modeContext(sheet: object): {
+  mode: SheetMode;
+  isEditMode: boolean;
+  isPlayMode: boolean;
+} {
+  const mode = currentMode(sheet);
+  return { mode, isEditMode: mode === 'edit', isPlayMode: mode === 'play' };
+}
+
+/**
+ * The header control entry for `DEFAULT_OPTIONS.window.controls`. Its label
+ * is fixed here; `decorateHeaderControls` swaps it for the current mode.
+ */
+export function toggleModeControl(): {
+  icon: string;
+  label: string;
+  action: string;
+  visible: (this: unknown) => boolean;
+} {
+  return {
+    icon: 'fa-solid fa-pen-to-square',
+    label: 'Edit mode',
+    action: TOGGLE_MODE_ACTION,
+    visible(this: unknown) {
+      const sheet = this as SheetLike;
+      return modesConfig(sheet) !== undefined && Boolean(sheet.isEditable);
+    },
+  };
+}
+
+/** Give the toggle control the label and icon for where it leads. */
+export function decorateHeaderControls<T extends { action?: string }>(
+  sheet: object,
+  controls: readonly T[],
+): T[] {
+  const config = modesConfig(sheet);
+  return controls.map((control) => {
+    if (control.action !== TOGGLE_MODE_ACTION || !config) return control;
+    const toPlay = currentMode(sheet) === 'edit';
+    return {
+      ...control,
+      icon: toPlay ? 'fa-solid fa-dice-d20' : 'fa-solid fa-pen-to-square',
+      label: toPlay ? (config.labels?.play ?? 'Play mode') : (config.labels?.edit ?? 'Edit mode'),
+    };
+  });
+}
+
+/** Class on the root, fields disabled in play. Called after every render. */
+export function applyMode(sheet: object): void {
+  const element = (sheet as SheetLike).element;
+  if (!element || !modesConfig(sheet)) return;
+  const mode = currentMode(sheet);
+  element.classList.toggle(MODE_CLASS.play, mode === 'play');
+  element.classList.toggle(MODE_CLASS.edit, mode === 'edit');
+  if (mode !== 'play') return;
+  const content = element.querySelector<HTMLElement>('.window-content') ?? element;
+  for (const field of content.querySelectorAll<HTMLElement & { disabled?: boolean }>(
+    FIELD_SELECTOR,
+  )) {
+    if (field.closest(`[${EDIT_IN_PLAY_ATTRIBUTE}]`)) continue;
+    field.disabled = true;
+    field.setAttribute('disabled', '');
+  }
+}
+
+/** Flip the mode (or set the one given) and re-render. */
+export async function toggleMode(sheet: object, mode?: SheetMode): Promise<void> {
+  if (!modesConfig(sheet)) return;
+  const next = mode ?? (currentMode(sheet) === 'play' ? 'edit' : 'play');
+  setMode(sheet, next);
+  const render = (sheet as SheetLike).render;
+  if (typeof render === 'function') await render.call(sheet);
+}


### PR DESCRIPTION
Opt in with `static MODES = { initial: 'play', labels: { play, edit } }` on a `BaseActorSheet()` or `BaseItemSheet()`. What it gives, and none of it happens without the opt-in:

- A header control that reads "Edit mode" in play and "Play mode" in edit, shown to users who can edit the document (action `vttforgeToggleMode`).
- `sheet.mode`, `sheet.isEditMode`, `sheet.isPlayMode`, `sheet.toggleMode(mode?)` (re-renders), and `context.mode` / `isEditMode` / `isPlayMode` for templates.
- `vttforge-mode-play` or `vttforge-mode-edit` on the sheet element after every render.
- In play, every form field in the window content is disabled, including Foundry's own elements (`prose-mirror`, `file-picker`, ...), except inside an element with `data-vttforge-edit-in-play`. A `<button>` is an action, not a field.

The mode lives on the instance and resets when the window closes; nothing is written to a setting.

Verified: unit tests against a stubbed runtime (214), and the end-to-end suite on a real Foundry v14, where the example character sheet opens in play with the name locked, hit points open, the roll button live, and the header control flips it to edit. Docs: new section in the sheets guide, README row, changeset (minor).