### PR TITLE
fix(core): the keywords journal rewrites only its own page, and postRoll keeps the caller's vttforge flags

### DIFF
--- a/.changeset/core-review-followups.md
+++ b/.changeset/core-review-followups.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/core": patch
+---
+
+The keywords journal finds its page by flag and rewrites only that page, so pages the GM adds to the journal survive a sync, and a deleted page comes back without touching the others. `postRoll` merges `vttforge.roll` into the scope's existing `vttforge` flags instead of replacing them.

--- a/packages/core/src/__tests__/chat.test.ts
+++ b/packages/core/src/__tests__/chat.test.ts
@@ -102,7 +102,7 @@ describe('postRoll', () => {
       labels: { crit: 'X.Crit' },
       messageMode: 'gm',
       scope: 'my-module',
-      flags: { 'my-module': { a: 1 }, other: { b: 2 } },
+      flags: { 'my-module': { a: 1, vttforge: { keep: true } }, other: { b: 2 } },
     });
     expect(roll.evaluate).not.toHaveBeenCalled();
     expect(getSpeaker).not.toHaveBeenCalled();
@@ -114,7 +114,10 @@ describe('postRoll', () => {
     expect(data.content).toContain('class="vttf-roll vttf-roll--crit" data-vttforge-roll="crit"');
     expect(data.content).toContain('<span class="vttf-roll__tag">Natural twenty</span>');
     expect(data.flags).toEqual({
-      'my-module': { a: 1, vttforge: { roll: { natural: 20, crit: true, fumble: false } } },
+      'my-module': {
+        a: 1,
+        vttforge: { keep: true, roll: { natural: 20, crit: true, fumble: false } },
+      },
       other: { b: 2 },
     });
     expect(options).toEqual({ messageMode: 'gm' });

--- a/packages/core/src/__tests__/keywords.test.ts
+++ b/packages/core/src/__tests__/keywords.test.ts
@@ -135,6 +135,7 @@ describe('syncKeywordJournal', () => {
         name: 'My System keywords',
         type: 'text',
         text: { content: keywordJournalContent(KEYWORDS), format: 1 },
+        flags: { 'my-system': { vttforge: { keywords: true } } },
       },
     ]);
   });
@@ -146,34 +147,69 @@ describe('syncKeywordJournal', () => {
     expect((create.mock.calls[1] as [{ name: string }])[0].name).toBe('Glossary');
   });
 
-  it('finds its journal by flag and rewrites the page only when the content changed', async () => {
-    const update = vi.fn(async () => undefined);
+  it('finds its journal and page by flag, rewrites only that page, and only when the content changed', async () => {
+    const flags = { 'my-system': { vttforge: { keywords: true } } };
+    const updateEmbeddedDocuments = vi.fn(async () => undefined);
+    const createEmbeddedDocuments = vi.fn(async () => undefined);
     const journal = {
       id: 'j1',
       name: 'Renamed by the GM',
-      flags: { 'my-system': { vttforge: { keywords: true } } },
-      pages: [{ id: 'p1', text: { content: keywordJournalContent(KEYWORDS) } }],
-      update,
+      flags,
+      pages: [
+        { id: 'gm', flags: {}, text: { content: '<p>House rules</p>' } },
+        { id: 'p1', flags, text: { content: keywordJournalContent(KEYWORDS) } },
+      ],
+      updateEmbeddedDocuments,
+      createEmbeddedDocuments,
     };
-    const other = { id: 'j0', name: 'Other', flags: {}, pages: [], update: vi.fn() };
+    const other = {
+      id: 'j0',
+      name: 'Other',
+      flags: {},
+      pages: [],
+      updateEmbeddedDocuments: vi.fn(),
+      createEmbeddedDocuments: vi.fn(),
+    };
     (globalThis as { game: { journal: unknown[] } }).game.journal = [other, journal];
 
     expect(await syncKeywordJournal('my-system', KEYWORDS)).toBe('unchanged');
-    expect(update).not.toHaveBeenCalled();
+    expect(updateEmbeddedDocuments).not.toHaveBeenCalled();
 
     const more = [...KEYWORDS, { id: 'heavy', label: 'Heavy', description: 'Two hands.' }];
     expect(await syncKeywordJournal('my-system', more)).toBe('updated');
-    expect(update).toHaveBeenCalledWith({
-      pages: [
-        {
-          _id: 'p1',
-          name: 'My System keywords',
-          type: 'text',
-          text: { content: keywordJournalContent(more), format: 1 },
-        },
-      ],
-    });
-    expect(other.update).not.toHaveBeenCalled();
+    expect(updateEmbeddedDocuments).toHaveBeenCalledWith('JournalEntryPage', [
+      {
+        _id: 'p1',
+        name: 'My System keywords',
+        text: { content: keywordJournalContent(more), format: 1 },
+      },
+    ]);
+    expect(createEmbeddedDocuments).not.toHaveBeenCalled();
+    expect(other.updateEmbeddedDocuments).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
+  });
+
+  it('adds its page back when the GM deleted it, leaving the other pages alone', async () => {
+    const flags = { 'my-system': { vttforge: { keywords: true } } };
+    const createEmbeddedDocuments = vi.fn(async () => undefined);
+    const journal = {
+      id: 'j1',
+      flags,
+      pages: [{ id: 'gm', flags: {}, text: { content: '<p>House rules</p>' } }],
+      updateEmbeddedDocuments: vi.fn(),
+      createEmbeddedDocuments,
+    };
+    (globalThis as { game: { journal: unknown[] } }).game.journal = [journal];
+
+    expect(await syncKeywordJournal('my-system', KEYWORDS)).toBe('updated');
+    expect(createEmbeddedDocuments).toHaveBeenCalledWith('JournalEntryPage', [
+      {
+        name: 'My System keywords',
+        type: 'text',
+        text: { content: keywordJournalContent(KEYWORDS), format: 1 },
+        flags,
+      },
+    ]);
+    expect(journal.updateEmbeddedDocuments).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/chat.ts
+++ b/packages/core/src/chat.ts
@@ -23,6 +23,8 @@
  * a package id, which is why the outcome is not filed under `vttforge`.
  */
 
+import { escapeHtml, localize } from './text.js';
+
 /** How to decide a critical or a fumble. */
 export type RollThreshold = boolean | number | ((roll: PostableRoll) => boolean);
 
@@ -119,30 +121,6 @@ function systemId(): string | undefined {
   return game?.system?.id;
 }
 
-function localize(text: string): string {
-  const game = (globalThis as Record<string, unknown>).game as
-    | { i18n?: { localize?: (key: string) => string } }
-    | undefined;
-  return game?.i18n?.localize?.(text) ?? text;
-}
-
-function escapeHtml(text: string): string {
-  return text.replace(/[&<>"']/g, (char) => {
-    switch (char) {
-      case '&':
-        return '&amp;';
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-      case '"':
-        return '&quot;';
-      default:
-        return '&#39;';
-    }
-  });
-}
-
 /** The first active result of the first die term. */
 export function naturalResult(roll: PostableRoll): number | undefined {
   const die = roll.dice?.[0];
@@ -216,12 +194,18 @@ export async function postRoll(
       'postRoll() needs a flag scope: pass `scope` (your system or module id) when game.system is not available',
     );
   }
+  // Merge into whatever the caller already put under the scope, including
+  // its own `vttforge` keys; only `vttforge.roll` is ours.
   const scoped = (options.flags?.[scope] ?? {}) as Record<string, unknown>;
+  const ours = (scoped.vttforge ?? {}) as Record<string, unknown>;
   const data: Record<string, unknown> = {
     content,
     rolls: [roll],
     speaker: options.speaker ?? ChatMessage.getSpeaker({ actor: options.actor }),
-    flags: { ...options.flags, [scope]: { ...scoped, vttforge: { roll: outcome } } },
+    flags: {
+      ...options.flags,
+      [scope]: { ...scoped, vttforge: { ...ours, roll: outcome } },
+    },
   };
   if (options.flavor !== undefined) data.flavor = options.flavor;
   const sound = diceSound();

--- a/packages/core/src/keywords.ts
+++ b/packages/core/src/keywords.ts
@@ -22,6 +22,7 @@
 
 import { VttfError } from './errors/registry.js';
 import type { EnricherRegistration } from './register-enrichers.js';
+import { escapeHtml, localize } from './text.js';
 
 export interface Keyword {
   /** One segment of letters, digits and hyphens: what goes in `@Keyword[id]`. */
@@ -53,15 +54,19 @@ interface Game {
   journal?: Iterable<JournalLike>;
 }
 
+interface PageLike {
+  readonly id?: string;
+  readonly flags?: Record<string, unknown>;
+  readonly text?: { readonly content?: string };
+}
+
 interface JournalLike {
   readonly id?: string;
   readonly name?: string;
   readonly flags?: Record<string, unknown>;
-  readonly pages?: Iterable<{
-    readonly id?: string;
-    readonly text?: { readonly content?: string };
-  }>;
-  update(data: Record<string, unknown>): Promise<unknown>;
+  readonly pages?: Iterable<PageLike>;
+  updateEmbeddedDocuments(name: string, updates: Record<string, unknown>[]): Promise<unknown>;
+  createEmbeddedDocuments(name: string, data: Record<string, unknown>[]): Promise<unknown>;
 }
 
 interface JournalClass {
@@ -70,27 +75,6 @@ interface JournalClass {
 
 function game(): Game | undefined {
   return (globalThis as Record<string, unknown>).game as Game | undefined;
-}
-
-function localize(text: string): string {
-  return game()?.i18n?.localize?.(text) ?? text;
-}
-
-function escapeHtml(text: string): string {
-  return text.replace(/[&<>"']/g, (char) => {
-    switch (char) {
-      case '&':
-        return '&amp;';
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-      case '"':
-        return '&quot;';
-      default:
-        return '&#39;';
-    }
-  });
 }
 
 /** Refuse ids that cannot appear in `@Keyword[id]` or repeat within the package. */
@@ -170,8 +154,16 @@ function packageTitle(packageId: string): string {
   return current?.modules?.get?.(packageId)?.title ?? packageId;
 }
 
-function isOurJournal(journal: JournalLike, packageId: string): boolean {
-  const scoped = journal.flags?.[packageId] as { vttforge?: { keywords?: unknown } } | undefined;
+/** The journal and its page both carry this; the rest of the journal is the GM's. */
+function ourFlags(packageId: string): Record<string, unknown> {
+  return { [packageId]: { vttforge: { keywords: true } } };
+}
+
+function isOurs(
+  document: { readonly flags?: Record<string, unknown> },
+  packageId: string,
+): boolean {
+  const scoped = document.flags?.[packageId] as { vttforge?: { keywords?: unknown } } | undefined;
   return scoped?.vttforge?.keywords === true;
 }
 
@@ -179,8 +171,9 @@ function isOurJournal(journal: JournalLike, packageId: string): boolean {
  * Create the keywords journal, or rewrite its page when the content changed.
  * Runs on the GM's client only; other clients return at once.
  *
- * The journal is found by a flag under the package's scope, not by name, so
- * renaming it in the world is safe.
+ * The journal and its page are found by a flag under the package's scope, not
+ * by name or position, so the GM can rename the journal and add pages of
+ * their own; only the flagged page is ever rewritten.
  */
 export async function syncKeywordJournal(
   packageId: string,
@@ -194,25 +187,24 @@ export async function syncKeywordJournal(
 
   let existing: JournalLike | undefined;
   for (const journal of current.journal ?? []) {
-    if (isOurJournal(journal, packageId)) {
+    if (isOurs(journal, packageId)) {
       existing = journal;
       break;
     }
   }
 
   if (existing) {
-    const page = [...(existing.pages ?? [])][0];
+    const page = [...(existing.pages ?? [])].find((candidate) => isOurs(candidate, packageId));
     if (page?.text?.content === content) return 'unchanged';
-    await existing.update({
-      pages: [
-        {
-          ...(page?.id ? { _id: page.id } : {}),
-          name: pageName,
-          type: 'text',
-          text: { content, format: 1 },
-        },
-      ],
-    });
+    if (page?.id) {
+      await existing.updateEmbeddedDocuments('JournalEntryPage', [
+        { _id: page.id, name: pageName, text: { content, format: 1 } },
+      ]);
+    } else {
+      await existing.createEmbeddedDocuments('JournalEntryPage', [
+        { name: pageName, type: 'text', text: { content, format: 1 }, flags: ourFlags(packageId) },
+      ]);
+    }
     return 'updated';
   }
 
@@ -228,8 +220,10 @@ export async function syncKeywordJournal(
   }
   await JournalEntry.create({
     name: pageName,
-    pages: [{ name: pageName, type: 'text', text: { content, format: 1 } }],
-    flags: { [packageId]: { vttforge: { keywords: true } } },
+    pages: [
+      { name: pageName, type: 'text', text: { content, format: 1 }, flags: ourFlags(packageId) },
+    ],
+    flags: ourFlags(packageId),
   });
   return 'created';
 }

--- a/packages/core/src/text.ts
+++ b/packages/core/src/text.ts
@@ -1,0 +1,27 @@
+/** Small text helpers shared by the runtime modules. Internal. */
+
+/** Translate through `game.i18n` when it is there; the text itself otherwise. */
+export function localize(text: string): string {
+  const game = (globalThis as Record<string, unknown>).game as
+    | { i18n?: { localize?: (key: string) => string } }
+    | undefined;
+  return game?.i18n?.localize?.(text) ?? text;
+}
+
+/** Escape the five characters that matter inside HTML text and attributes. */
+export function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      default:
+        return '&#39;';
+    }
+  });
+}


### PR DESCRIPTION
The three follow-ups from the review of #213 and #214.

- The keywords journal page now carries the same flag as the journal, and the sync finds it by that flag. Only that page is rewritten, through \`updateEmbeddedDocuments\`; pages the GM adds survive, and a page the GM deleted is created again next to theirs.
- \`postRoll\` merges \`roll\` into the scope's existing \`vttforge\` flags instead of replacing the whole key.
- \`localize\` and \`escapeHtml\` live once, in an internal module both files import.

Verified with unit tests and in a real Foundry v14: after adding a GM page to the journal, a changed list rewrote the flagged page only, deleting the flagged page brought it back beside the GM's, and the journal count stayed at one. The end-to-end suite passes.