### PR TITLE
feat(core): resourceField, and registerSystem checks the manifest's token bars against the data models

### DIFF
--- a/.changeset/cli-audit-resource-field.md
+++ b/.changeset/cli-audit-resource-field.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/cli": patch
+---
+
+Audit rule 007 reads `resourceField()` from `@vttforge/core` as a `{ value, max }` field, at the top level or nested in a SchemaField, so a system using it is not flagged. The scaffold templates pin `@vttforge/core` at the version this release publishes.

--- a/.changeset/core-resource-field.md
+++ b/.changeset/core-resource-field.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/core": minor
+---
+
+`resourceField(options)` builds the `{ value, max }` SchemaField a token bar reads, with both children required, non-nullable numbers, typed as `{ value: number; max: number }`. `registerSystem` now checks the manifest's `primaryTokenAttribute` and `secondaryTokenAttribute` against the Actor data models it registers and throws VTTF-0010 at `init` when no model declares a resource at that path; Foundry would draw no bar and say nothing. `schemaHasResource(schema, path)` is the check on its own.

--- a/apps/docs/errors/VTTF-0010.md
+++ b/apps/docs/errors/VTTF-0010.md
@@ -1,0 +1,21 @@
+# VTTF-0010: InvalidResource
+
+> [!NOTE]
+> resourceField() was given a min above its initial or max, or the manifest names a primaryTokenAttribute or secondaryTokenAttribute that no registered Actor data model declares as a { value, max } field. Foundry draws no bar for such a path and says nothing.
+
+| Field | Value |
+|---|---|
+| Code | `VTTF-0010` |
+| Name | `InvalidResource` |
+| Package | `@vttforge/core` |
+| Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
+
+---
+
+This page comes from the registry entry. We are still writing the root
+causes, common triggers and code samples for each code; the message above
+is what the runtime throws.
+
+`packages/core/scripts/codegen-errors.mjs` builds this file from the
+registry at [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts). Do not edit by hand;
+re-run `pnpm --filter @vttforge/core build` after editing the registry.

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -89,7 +89,7 @@ deprecation warning that turns into a removal two versions from now.
 | `VTTF-AUDIT-004` | MEDIUM | An `HTMLField` or `FilePathField` not listed in `documentTypes`, nor at the document level of a `template.json` that still lists the type; the server only sanitises declared paths |
 | `VTTF-AUDIT-005` | MEDIUM | A `TypeDataModel` without `prepareBaseData`; Active Effects apply between it and `prepareDerivedData` |
 | `VTTF-AUDIT-006` | LOW | An `_addDataFieldMigrations` override; the signature is not what it looks like |
-| `VTTF-AUDIT-007` | MEDIUM | `primaryTokenAttribute` / `secondaryTokenAttribute` not pointing at a `{ value, max }` field, in a data model or in `template.json`; the token bar degrades with no error |
+| `VTTF-AUDIT-007` | MEDIUM | `primaryTokenAttribute` / `secondaryTokenAttribute` not pointing at a `{ value, max }` field, in a data model (a `SchemaField` with both keys, or `resourceField()`) or in `template.json`; the token bar degrades with no error |
 | `VTTF-AUDIT-008` | HIGH | A sheet template that opens its own `<form>` when the sheet base already is one; the fields belong to the inner form, so closing the sheet drops every edit |
 | `VTTF-AUDIT-009` | MEDIUM | A subtype declared in `documentTypes` with no `TYPES` label; Foundry prints the raw key as the type's name |
 | `VTTF-AUDIT-010` | HIGH | A `template.json` listing a type whose `documentTypes` entry declares `htmlFields`, `filePathFields` or `gmOnlyFields`; Foundry replaces the entry and drops them |

--- a/apps/docs/guide/data-models.md
+++ b/apps/docs/guide/data-models.md
@@ -44,6 +44,43 @@ values in the schema instead, as a `NumberField` with `initial: 0`, and
 assign them in `prepareDerivedData`. The scaffold's JavaScript template does
 this for the ability modifiers.
 
+## Resources and token bars
+
+A resource is `{ value, max }`: hit points, power, ammunition, the shape a
+token bar reads. `resourceField()` builds that `SchemaField` with both
+children required, non-nullable numbers, so `system.health.value` is a
+`number` everywhere:
+
+```ts
+import { fields, resourceField } from '@vttforge/core';
+
+const defineCharacterSchema = () => {
+  const f = fields();
+  return {
+    health: resourceField({ initial: 10 }),
+    power: resourceField({ initial: 5, max: 5, label: 'MY_SYSTEM.Power' }),
+    level: new f.NumberField({ required: true, nullable: false, initial: 1 }),
+  };
+};
+```
+
+| Option | Default | What it sets |
+| --- | --- | --- |
+| `initial` | `0` | starting `value` |
+| `max` | `initial` | starting `max` |
+| `min` | `0` | lowest allowed for both |
+| `integer` | `true` | whole numbers only |
+| `label`, `hint` | none | the SchemaField's own |
+
+Point `primaryTokenAttribute` and `secondaryTokenAttribute` in the manifest at
+the field key, `health` and `power` here, or a dotted path such as
+`attributes.hp`. Foundry draws no bar for a path without both keys and says
+nothing about it, so `registerSystem` checks the two manifest paths against
+the Actor data models it registers and throws
+[VTTF-0010](../errors/VTTF-0010) at `init` when no model has a resource
+there. `vttforge audit` runs the same check on the source (rule 007) and reads
+`resourceField()` as a resource.
+
 ## Nullability defaults
 
 Every field class picks its own defaults, and they disagree.

--- a/apps/e2e/tests/system.spec.mjs
+++ b/apps/e2e/tests/system.spec.mjs
@@ -110,6 +110,11 @@ test('a character sheet renders its parts and its derived data', async ({ page }
         healthMax: actor.system.health.max,
         strMod: actor.system.abilities.str.mod,
       },
+      // The manifest's token bars, read the way a token reads them.
+      bars: {
+        bar1: actor.prototypeToken.getBarAttribute('bar1'),
+        bar2: actor.prototypeToken.getBarAttribute('bar2'),
+      },
     };
   });
 
@@ -124,6 +129,9 @@ test('a character sheet renders its parts and its derived data', async ({ page }
   // 10 + level 1 + the con modifier.
   expect(sheet.derived.healthMax).toBe(11);
   expect(sheet.derived.strMod).toBe(0);
+  // `resourceField()` gave both bars the { value, max } pair they read.
+  expect(sheet.bars.bar1).toMatchObject({ type: 'bar', attribute: 'health', value: 10, max: 11 });
+  expect(sheet.bars.bar2).toMatchObject({ type: 'bar', attribute: 'power', value: 5, max: 5 });
 });
 
 test('a sheet with MODES opens in play, locks its fields, and edit opens them again', async ({

--- a/docs/errors/VTTF-0010.md
+++ b/docs/errors/VTTF-0010.md
@@ -1,0 +1,21 @@
+# VTTF-0010: InvalidResource
+
+> [!NOTE]
+> resourceField() was given a min above its initial or max, or the manifest names a primaryTokenAttribute or secondaryTokenAttribute that no registered Actor data model declares as a { value, max } field. Foundry draws no bar for such a path and says nothing.
+
+| Field | Value |
+|---|---|
+| Code | `VTTF-0010` |
+| Name | `InvalidResource` |
+| Package | `@vttforge/core` |
+| Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
+
+---
+
+This page comes from the registry entry. We are still writing the root
+causes, common triggers and code samples for each code; the message above
+is what the runtime throws.
+
+`packages/core/scripts/codegen-errors.mjs` builds this file from the
+registry at [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts). Do not edit by hand;
+re-run `pnpm --filter @vttforge/core build` after editing the registry.

--- a/examples/simple-system/scripts/data/character-data.mjs
+++ b/examples/simple-system/scripts/data/character-data.mjs
@@ -8,7 +8,7 @@
  * Never write to the database in prepareDerivedData — only assign onto `this`.
  */
 
-import { BaseTypeDataModel, fields } from '@vttforge/core';
+import { BaseTypeDataModel, fields, resourceField } from '@vttforge/core';
 
 /**
  * The schema, as a function passed to the factory rather than a `static
@@ -76,38 +76,10 @@ const defineCharacterSchema = () => {
       wis: score(),
       cha: score(),
     }),
-    health: new f.SchemaField({
-      value: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 10,
-      }),
-      max: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 10,
-      }),
-    }),
-    power: new f.SchemaField({
-      value: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 5,
-      }),
-      max: new f.NumberField({
-        required: true,
-        nullable: false,
-        integer: true,
-        min: 0,
-        initial: 5,
-      }),
-    }),
+    // The token bars in system.json point at these two: a resource is the
+    // `{ value, max }` pair a bar reads.
+    health: resourceField({ initial: 10 }),
+    power: resourceField({ initial: 5 }),
     biography: new f.HTMLField(),
   };
 };

--- a/packages/cli/src/__tests__/audit/source-rules.test.ts
+++ b/packages/cli/src/__tests__/audit/source-rules.test.ts
@@ -467,6 +467,53 @@ registerSystem({ id: 'my-system', actorDataModels: { character: CharacterData } 
       expect(await runSourceRules(cwd)).toEqual([]);
     });
 
+    it('accepts resourceField() from @vttforge/core at the manifest path, nested or not', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({
+          id: 'my-system',
+          version: '1.0.0',
+          primaryTokenAttribute: 'health',
+          secondaryTokenAttribute: 'attributes.power',
+        }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `import { resourceField } from '@vttforge/core';
+const defineCharacterSchema = () => {
+  const f = fields();
+  return {
+    health: resourceField({ initial: 10 }),
+    attributes: new f.SchemaField({
+      power: resourceField({ initial: 5 }),
+    }),
+  };
+};
+export class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
+registerSystem({ id: 'my-system', actorDataModels: { character: CharacterData } });`,
+        'utf8',
+      );
+      expect(await runSourceRules(cwd)).toEqual([]);
+    });
+
+    it('still flags a manifest path that resourceField() does not sit at', async () => {
+      await writeFile(
+        join(cwd, 'system.json'),
+        JSON.stringify({ id: 'my-system', version: '1.0.0', primaryTokenAttribute: 'hp' }),
+        'utf8',
+      );
+      await writeFile(
+        join(cwd, 'data.ts'),
+        `const defineCharacterSchema = () => ({ health: resourceField({ initial: 10 }) });
+export class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {}
+registerSystem({ id: 'my-system', actorDataModels: { character: CharacterData } });`,
+        'utf8',
+      );
+      const seven = (await runSourceRules(cwd)).filter((r) => r.ruleId === 'VTTF-AUDIT-007');
+      expect(seven).toHaveLength(1);
+    });
+
     it('reads a factory with a return type and a brace inside a string', async () => {
       await writeFile(
         join(cwd, 'system.json'),

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -753,6 +753,7 @@ async function sourceHasValueMaxSchemaAtPath(
         const owner = classes.find((c) => decl.index > c.openIdx && decl.index < c.endIdx);
         if (owner && !actorClasses.has(owner.className)) continue;
       }
+      if (decl.resource) return true;
       const topKeys = extractTopLevelKeys(decl.body);
       if (topKeys.has('value') && topKeys.has('max')) return true;
     }
@@ -771,10 +772,24 @@ interface SchemaFieldDecl {
   body: string;
   /** Offset of the declaration, used to find its enclosing class. */
   index: number;
+  /** A `resourceField()` call: a SchemaField with `value` and `max` by construction. */
+  resource?: boolean;
 }
 
 function findAllSchemaFields(content: string): SchemaFieldDecl[] {
   const out: SchemaFieldDecl[] = [];
+  // `health: resourceField({ initial: 10 })` from @vttforge/core is a
+  // `{ value, max }` SchemaField; there is no literal body to read keys from.
+  const resourceRe = /(\w+)\s*:\s*(?:[\w.]+\.)?resourceField\s*\(/g;
+  for (const m of content.matchAll(resourceRe)) {
+    if (m.index === undefined) continue;
+    out.push({
+      path: buildSchemaPath(content, m.index, m[1] ?? ''),
+      body: '',
+      index: m.index,
+      resource: true,
+    });
+  }
   const startRe = /(\w+)\s*:\s*new\s+(?:[\w.]+\.)?SchemaField\s*\(\s*\{/g;
   for (const m of content.matchAll(startRe)) {
     if (m.index === undefined) continue;

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.16.0"
+    "@vttforge/core": "^0.17.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.15.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.16.0"
+    "@vttforge/core": "^0.17.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.15.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.16.0",
+    "@vttforge/core": "^0.17.0",
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.16.0",
+    "@vttforge/core": "^0.17.0",
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,6 +15,7 @@ pnpm add @vttforge/core
 | `fields()` | `foundry.data.fields`, typed, read lazily so the module imports in Node |
 | `InferSchema<T>` / `Model['$inferData']` | The hand-written interface that drifts from the schema |
 | `BaseActorSheet()` / `BaseItemSheet()` | `static TABS`, `static DRAG_DROP`, `static MODES` (play and edit, with the fields locked in play), typed `onDropItem` and friends on `ActorSheetV2` / `ItemSheetV2` with Handlebars |
+| `resourceField()` | The `{ value, max }` field a token bar reads, typed as two numbers; `registerSystem` checks the manifest's bars against it |
 | `postRoll()` | Posts a roll as a chat card, tagged as a critical or a fumble by the thresholds you give |
 | `keywords` on either registration | Rules terms as `@Keyword[id]` with a tooltip, and a journal entry the GM's client creates and keeps current |
 | `BaseDocumentSheet('Actor' \| 'Item')` / `BaseApplication()` | The same plumbing without Handlebars, for a sheet that builds its own element |

--- a/packages/core/src/__tests__/register-system.test.ts
+++ b/packages/core/src/__tests__/register-system.test.ts
@@ -270,6 +270,33 @@ describe('registerSystem', () => {
     ).toThrow(/VTTF-0009/);
   });
 
+  it("checks the manifest's token attributes against the Actor data models on init", () => {
+    const { hooks } = setupFoundryGlobals();
+    const resource = { fields: { value: {}, max: {} } };
+    const HeroData = class {
+      static schema = { fields: { health: resource, level: {} } };
+    };
+    const VehicleData = class {
+      static schema = { fields: { hull: resource } };
+    };
+    (globalThis as Record<string, unknown>).game = {
+      system: { primaryTokenAttribute: 'health', secondaryTokenAttribute: 'hull' },
+    };
+    registerSystem({ id: 'my-system', actorDataModels: { hero: HeroData, vehicle: VehicleData } });
+    const initCallback = hooks.once.mock.calls[0]?.[1] as () => void;
+    // Each bar lands on some Actor model: hero has health, vehicle has hull.
+    expect(() => initCallback()).not.toThrow();
+
+    (globalThis as Record<string, unknown>).game = {
+      system: { primaryTokenAttribute: 'level', secondaryTokenAttribute: null },
+    };
+    registerSystem({ id: 'other-system', actorDataModels: { hero: HeroData } });
+    const otherInit = hooks.once.mock.calls[1]?.[1] as () => void;
+    expect(() => otherInit()).toThrow(/VTTF-0010/);
+    expect(() => otherInit()).toThrow(/primaryTokenAttribute to "level"/);
+    (globalThis as Record<string, unknown>).game = undefined;
+  });
+
   it('does not register i18nInit or setup hooks when their callbacks are omitted', () => {
     const { hooks } = setupFoundryGlobals();
     registerSystem({ id: 'my-system' });

--- a/packages/core/src/__tests__/resource-field.test.ts
+++ b/packages/core/src/__tests__/resource-field.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { InferSchema } from '../data/infer-schema.js';
+import { resourceField, schemaHasResource } from '../data/resource-field.js';
+import { VttfError } from '../errors/registry.js';
+
+class FakeNumberField {
+  constructor(readonly options: Record<string, unknown>) {}
+}
+
+class FakeSchemaField {
+  constructor(
+    readonly fields: Record<string, unknown>,
+    readonly options: Record<string, unknown> = {},
+  ) {}
+}
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).foundry = {
+    data: { fields: { NumberField: FakeNumberField, SchemaField: FakeSchemaField } },
+  };
+});
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).foundry = undefined;
+});
+
+describe('resourceField', () => {
+  it('builds a SchemaField with required, non-nullable integer value and max', () => {
+    const field = resourceField({ initial: 10 }) as unknown as FakeSchemaField;
+    expect(field).toBeInstanceOf(FakeSchemaField);
+    const value = field.fields.value as FakeNumberField;
+    const max = field.fields.max as FakeNumberField;
+    expect(value.options).toEqual({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 0,
+      initial: 10,
+    });
+    expect(max.options).toEqual({
+      required: true,
+      nullable: false,
+      integer: true,
+      min: 0,
+      initial: 10,
+    });
+    expect(field.options).toEqual({});
+  });
+
+  it('takes a separate max, a min, decimals, a label and a hint', () => {
+    const field = resourceField({
+      initial: 3,
+      max: 8,
+      min: 1,
+      integer: false,
+      label: 'X.Power',
+      hint: 'X.PowerHint',
+    }) as unknown as FakeSchemaField;
+    expect((field.fields.value as FakeNumberField).options).toMatchObject({
+      initial: 3,
+      min: 1,
+      integer: false,
+    });
+    expect((field.fields.max as FakeNumberField).options).toMatchObject({
+      initial: 8,
+      min: 1,
+      integer: false,
+    });
+    expect(field.options).toEqual({ label: 'X.Power', hint: 'X.PowerHint' });
+  });
+
+  it('defaults everything to zero', () => {
+    const field = resourceField() as unknown as FakeSchemaField;
+    expect((field.fields.value as FakeNumberField).options).toMatchObject({ initial: 0, min: 0 });
+    expect((field.fields.max as FakeNumberField).options).toMatchObject({ initial: 0, min: 0 });
+  });
+
+  it('refuses a min above the initial or the max', () => {
+    expect(() => resourceField({ initial: 2, min: 5 })).toThrow(VttfError);
+    expect(() => resourceField({ initial: 9, max: 2, min: 5 })).toThrow(/VTTF-0010/);
+  });
+
+  it('types as { value: number; max: number }', () => {
+    const schema = { health: resourceField({ initial: 10 }) };
+    type System = InferSchema<typeof schema>;
+    const system: System = { health: { value: 4, max: 10 } };
+    // @ts-expect-error value is a number, never null
+    const wrong: System = { health: { value: null, max: 10 } };
+    expect(system.health.value + wrong.health.max).toBe(14);
+  });
+});
+
+describe('schemaHasResource', () => {
+  const schema = {
+    fields: {
+      health: { fields: { value: {}, max: {} } },
+      attributes: { fields: { hp: { fields: { value: {}, max: {} } }, level: {} } },
+      name: {},
+    },
+  };
+
+  it('resolves top-level and dotted paths to a value/max field', () => {
+    expect(schemaHasResource(schema, 'health')).toBe(true);
+    expect(schemaHasResource(schema, 'attributes.hp')).toBe(true);
+  });
+
+  it('rejects a missing path, a leaf, and a schema without both keys', () => {
+    expect(schemaHasResource(schema, 'power')).toBe(false);
+    expect(schemaHasResource(schema, 'name')).toBe(false);
+    expect(schemaHasResource(schema, 'attributes.level')).toBe(false);
+    expect(schemaHasResource(schema, 'attributes')).toBe(false);
+    expect(schemaHasResource(undefined, 'health')).toBe(false);
+  });
+});

--- a/packages/core/src/data/resource-field.ts
+++ b/packages/core/src/data/resource-field.ts
@@ -1,0 +1,103 @@
+/**
+ * A resource: `{ value, max }`, the shape a token bar reads.
+ *
+ * Hit points, power, stress, ammunition: every system writes this
+ * `SchemaField` several times, and every time the two children must be
+ * required, non-nullable numbers or the token bar degrades to a number with
+ * no bar. `resourceField()` is that once, typed so `system.health.value` is a
+ * `number` in `prepareDerivedData` and on the sheet.
+ */
+
+import { VttfError } from '../errors/registry.js';
+import type { SchemaFieldOptions } from './field-options.js';
+import { fields, type NumberFieldInstance, type SchemaFieldInstance } from './fields.js';
+
+export interface ResourceFieldOptions {
+  /** Starting `value`. Default `0`. */
+  readonly initial?: number;
+  /** Starting `max`. Default: the same as `initial`. */
+  readonly max?: number;
+  /** Lowest allowed for both. Default `0`. */
+  readonly min?: number;
+  /** Whole numbers only. Default `true`. */
+  readonly integer?: boolean;
+  /** Label for the field, as a localization key or text. */
+  readonly label?: string;
+  /** Hint for the field, as a localization key or text. */
+  readonly hint?: string;
+}
+
+/** What the children are, as `InferSchema` reads them: a `number` each. */
+export type ResourceChildField = NumberFieldInstance<{
+  readonly required: true;
+  readonly nullable: false;
+  readonly integer: boolean;
+  readonly min: number;
+  readonly initial: number;
+}>;
+
+export type ResourceFieldInstance = SchemaFieldInstance<
+  { value: ResourceChildField; max: ResourceChildField },
+  SchemaFieldOptions
+>;
+
+/**
+ * A `SchemaField` with `value` and `max`, both required, non-nullable
+ * numbers.
+ *
+ * ```ts
+ * const f = fields();
+ * return {
+ *   health: resourceField({ initial: 10 }),
+ *   power: resourceField({ initial: 5, max: 5, label: 'MY_SYSTEM.Power' }),
+ * };
+ * ```
+ *
+ * Point the manifest's `primaryTokenAttribute` at the key, `health` here,
+ * and the token bar has what it needs.
+ */
+export function resourceField(options: ResourceFieldOptions = {}): ResourceFieldInstance {
+  const initial = options.initial ?? 0;
+  const max = options.max ?? initial;
+  const min = options.min ?? 0;
+  const integer = options.integer ?? true;
+  if (min > initial || min > max) {
+    throw new VttfError(
+      'VTTF-0010',
+      `resourceField(): min (${min}) is above initial (${initial}) or max (${max}).`,
+    );
+  }
+  const f = fields();
+  const child = (start: number): ResourceChildField =>
+    new f.NumberField({
+      required: true,
+      nullable: false,
+      integer,
+      min,
+      initial: start,
+    }) as ResourceChildField;
+  const schemaOptions: { label?: string; hint?: string } = {};
+  if (options.label !== undefined) schemaOptions.label = options.label;
+  if (options.hint !== undefined) schemaOptions.hint = options.hint;
+  return new f.SchemaField(
+    { value: child(initial), max: child(max) },
+    schemaOptions,
+  ) as ResourceFieldInstance;
+}
+
+/**
+ * Whether a schema declares a resource at `path`: a `SchemaField` whose
+ * `fields` hold both `value` and `max`. Reads Foundry's own field objects,
+ * so it works on any schema, not only one built with `resourceField()`.
+ */
+export function schemaHasResource(schema: unknown, path: string): boolean {
+  let node: unknown = schema;
+  for (const segment of path.split('.')) {
+    const fieldsOf = (node as { fields?: Record<string, unknown> } | undefined)?.fields;
+    if (!fieldsOf || typeof fieldsOf !== 'object') return false;
+    node = fieldsOf[segment];
+    if (node === undefined) return false;
+  }
+  const leaf = (node as { fields?: Record<string, unknown> } | undefined)?.fields;
+  return Boolean(leaf && typeof leaf === 'object' && 'value' in leaf && 'max' in leaf);
+}

--- a/packages/core/src/errors/registry.ts
+++ b/packages/core/src/errors/registry.ts
@@ -76,6 +76,12 @@ const REGISTRY: Readonly<Record<VttfErrorCode, VttfErrorEntry>> = Object.freeze(
     summary:
       'A keyword reached registerSystem() or registerModule() with an id that cannot go inside @Keyword[...] (letters, digits and hyphens only), with an id another keyword of the same package already uses, or without a string label and description.',
   }),
+  'VTTF-0010': Object.freeze({
+    code: 'VTTF-0010',
+    name: 'InvalidResource',
+    summary:
+      'resourceField() was given a min above its initial or max, or the manifest names a primaryTokenAttribute or secondaryTokenAttribute that no registered Actor data model declares as a { value, max } field. Foundry draws no bar for such a path and says nothing.',
+  }),
 });
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,13 @@ export {
 } from './data/fields.js';
 export type { InferField, InferSchema, Prettify } from './data/infer-schema.js';
 export {
+  type ResourceChildField,
+  type ResourceFieldInstance,
+  type ResourceFieldOptions,
+  resourceField,
+  schemaHasResource,
+} from './data/resource-field.js';
+export {
   ActorDataModel,
   DocumentSheet,
   type DocumentSheetOptions,

--- a/packages/core/src/register-system.ts
+++ b/packages/core/src/register-system.ts
@@ -18,6 +18,7 @@
  * themselves.
  */
 
+import { schemaHasResource } from './data/resource-field.js';
 import { VttfError, type VttfErrorCode } from './errors/registry.js';
 import type {
   CombatConfig,
@@ -227,6 +228,7 @@ function applyInit(config: SystemRegistration): void {
 
   if (config.actorDataModels !== undefined) {
     Object.assign(CONFIG.Actor.dataModels, config.actorDataModels);
+    assertTokenAttributes(config.id, config.actorDataModels);
   }
   if (config.itemDataModels !== undefined) {
     Object.assign(CONFIG.Item.dataModels, config.itemDataModels);
@@ -258,4 +260,41 @@ function applyInit(config: SystemRegistration): void {
   }
 
   config.onAfterInit?.();
+}
+
+interface SystemPackage {
+  readonly primaryTokenAttribute?: string | null;
+  readonly secondaryTokenAttribute?: string | null;
+}
+
+/**
+ * The manifest's token bars must land on a `{ value, max }` field of some
+ * Actor data model, or Foundry draws no bar and says nothing. Checked here,
+ * once, where both sides are known: the manifest through `game.system`, the
+ * schemas through the classes just registered.
+ */
+function assertTokenAttributes(
+  systemId: string,
+  dataModels: Readonly<Record<string, unknown>>,
+): void {
+  const game = (globalThis as Record<string, unknown>).game as
+    | { system?: SystemPackage }
+    | undefined;
+  const system = game?.system;
+  if (!system) return;
+  const models = Object.values(dataModels);
+  if (models.length === 0) return;
+  for (const key of ['primaryTokenAttribute', 'secondaryTokenAttribute'] as const) {
+    const path = system[key];
+    if (typeof path !== 'string' || path.length === 0) continue;
+    const found = models.some((model) =>
+      schemaHasResource((model as { schema?: unknown }).schema, path),
+    );
+    if (!found) {
+      throw vttfError(
+        'VTTF-0010',
+        `"${systemId}" sets ${key} to "${path}", but no Actor data model declares a { value, max } field at that path. Use resourceField() there, or point the manifest at a field that has value and max.`,
+      );
+    }
+  }
 }


### PR DESCRIPTION
\`resourceField(options)\` in \`@vttforge/core\`: the \`{ value, max }\` SchemaField a token bar reads, both children required, non-nullable numbers, typed as \`{ value: number; max: number }\`. Options: \`initial\`, \`max\`, \`min\`, \`integer\`, \`label\`, \`hint\`.

\`registerSystem\` now checks the manifest's \`primaryTokenAttribute\` and \`secondaryTokenAttribute\` (read from \`game.system\`) against the Actor data models it registers, and throws \`VTTF-0010\` at \`init\` when no model declares a resource at that path. Foundry draws no bar for such a path and says nothing. \`schemaHasResource(schema, path)\` is the check on its own, and it reads Foundry's field objects, so a hand-written SchemaField with both keys passes too.

Audit rule 007 reads \`resourceField()\` as a resource, top-level or nested in a SchemaField, so a system using it is not flagged.

Also: the example system's \`health\` and \`power\` use it, a section in the data models guide, README row, changesets (core minor, cli patch, template pins to \`^0.17.0\`).

Verified: unit tests for the field, the schema check, the init check and the audit rule; and the end-to-end run on a real Foundry v14, which now reads both prototype token bars through \`getBarAttribute\` and gets \`{ type: 'bar', value, max }\` for each.