### PR TITLE
feat(core): registerSocket, for talking to the other clients

### DIFF
--- a/.changeset/cli-pins-sockets.md
+++ b/.changeset/cli-pins-sockets.md
@@ -1,0 +1,7 @@
+---
+'@vttforge/cli': patch
+---
+
+Point the project templates at the `@vttforge/core` minor that carries
+`registerSocket()`. On a 0.x line a caret pins the minor, so the old pin would
+have scaffolded a project that cannot see the new API.

--- a/.changeset/core-sockets.md
+++ b/.changeset/core-sockets.md
@@ -1,0 +1,19 @@
+---
+'@vttforge/core': minor
+---
+
+`registerSocket()`: the two ways a package talks to the other clients.
+
+`emit` sends a one-way message. `askGm` asks the Gamemaster's client to do
+something a player has no permission to do, and waits for the answer.
+
+It covers the four things that are silent when you get them wrong. The
+channel is `module.<id>` or `system.<id>`, not the package id. `"socket": true`
+is a manifest field, and without it Foundry accepts the emit and delivers
+nothing. The sender id comes from the server, not the payload, so a permission
+check that reads the payload is not a check. And Foundry never delivers a
+message back to whoever sent it, so `emit` runs the handler locally too and
+drops the sender's own id from `recipients`.
+
+Handlers fail closed: `from` defaults to `'gm'`, and a message from anyone else
+is dropped. New error codes VTTF-0012 and VTTF-0013.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The whole guide is at **[vttforge.dev/docs](https://vttforge.dev/docs/)**.
 - [Rolls](https://vttforge.dev/docs/guide/rolls). `postRoll`, and how a card gets tagged as a critical or a fumble.
 - [Dialogs](https://vttforge.dev/docs/guide/dialogs). `promptFields`: a dialog from a list of fields, typed answers back.
 - [Modules](https://vttforge.dev/docs/guide/modules). Namespaced sub-types, enrichers, and what a module may not touch.
+- [Sockets](https://vttforge.dev/docs/guide/sockets). `registerSocket`: one-way messages, and questions only the Gamemaster's client can answer.
 - [Settings and migrations](https://vttforge.dev/docs/guide/settings-and-migrations). `SystemConfig` and the migration runner.
 - [Keywords](https://vttforge.dev/docs/guide/keywords). Rules terms defined once: `@Keyword[id]` in any text, and a journal the GM's client keeps current.
 - [The dev loop](https://vttforge.dev/docs/guide/dev-loop). What reloads in place and what does not.

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -166,6 +166,7 @@ export default defineVersionedConfig({
             { text: 'Rolls', link: '/guide/rolls' },
             { text: 'Dialogs', link: '/guide/dialogs' },
             { text: 'Modules', link: '/guide/modules' },
+            { text: 'Sockets', link: '/guide/sockets' },
             { text: 'Settings and migrations', link: '/guide/settings-and-migrations' },
             { text: 'Keywords', link: '/guide/keywords' },
             { text: 'Decorators', link: '/guide/decorators' },

--- a/apps/docs/src/errors/VTTF-0012.md
+++ b/apps/docs/src/errors/VTTF-0012.md
@@ -1,0 +1,21 @@
+# VTTF-0012: InvalidSocket
+
+> [!NOTE]
+> registerSocket() was called without a package id or kind, with no messages and no requests, with a name that cannot be used, twice for the same channel, or for a package whose manifest does not set "socket": true. Foundry accepts an emit on an undeclared channel and delivers it to nobody.
+
+| Field | Value |
+|---|---|
+| Code | `VTTF-0012` |
+| Name | `InvalidSocket` |
+| Package | `@vttforge/core` |
+| Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
+
+---
+
+This page comes from the registry entry. We are still writing the root
+causes, common triggers and code samples for each code; the message above
+is what the runtime throws.
+
+`packages/core/scripts/codegen-errors.mjs` builds this file from the
+registry at [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts). Do not edit by hand;
+re-run `pnpm --filter @vttforge/core build` after editing the registry.

--- a/apps/docs/src/errors/VTTF-0013.md
+++ b/apps/docs/src/errors/VTTF-0013.md
@@ -1,0 +1,21 @@
+# VTTF-0013: NoGamemaster
+
+> [!NOTE]
+> askGm() was called for a request that was never registered, or while no Gamemaster was connected. A player cannot write to world documents, so the work has nowhere to run.
+
+| Field | Value |
+|---|---|
+| Code | `VTTF-0013` |
+| Name | `NoGamemaster` |
+| Package | `@vttforge/core` |
+| Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
+
+---
+
+This page comes from the registry entry. We are still writing the root
+causes, common triggers and code samples for each code; the message above
+is what the runtime throws.
+
+`packages/core/scripts/codegen-errors.mjs` builds this file from the
+registry at [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts). Do not edit by hand;
+re-run `pnpm --filter @vttforge/core build` after editing the registry.

--- a/apps/docs/src/guide/modules.md
+++ b/apps/docs/src/guide/modules.md
@@ -114,3 +114,10 @@ which rejects a non-global regex, and that throw is outside the handler Foundry
 wraps enrichers in. VTTForge checks the flag when you register.
 
 `registerSystem` takes the same option.
+
+## Talking to the other clients
+
+A module that shows the table something, or that lets a player change what
+only a Gamemaster may change, needs the socket. That is
+[its own page](./sockets), because the parts that go wrong there are not the
+parts the API docs describe.

--- a/apps/docs/src/guide/sockets.md
+++ b/apps/docs/src/guide/sockets.md
@@ -1,0 +1,129 @@
+# Sockets
+
+`registerSocket()` sets up the two ways a package talks to the other clients:
+one-way messages, and questions for the Gamemaster's client.
+
+```js
+import { registerSocket } from '@vttforge/core';
+
+const socket = registerSocket({
+  id: 'my-module',
+  kind: 'module',
+
+  messages: {
+    // Runs on every other client when a Gamemaster sends it.
+    turnToPage: ({ page }) => viewer.goToPage(page),
+  },
+
+  requests: {
+    // Runs on the Gamemaster's client, whoever asked.
+    grantItem: async ({ actorId, itemData }) => {
+      const actor = game.actors.get(actorId);
+      const [item] = await actor.createEmbeddedDocuments('Item', [itemData]);
+      return item.id;
+    },
+  },
+});
+
+await socket.emit('turnToPage', { page: 12 });
+const itemId = await socket.askGm('grantItem', { actorId, itemData });
+```
+
+Call it once, from `onSetup` or `onReady`. Registering twice means every
+message runs its handler twice, and Foundry will not warn you.
+
+Add `"socket": true` to the manifest. Without it Foundry accepts the emit and
+delivers nothing, silently. `registerSocket` reads the manifest and throws
+[VTTF-0012](../errors/VTTF-0012) instead.
+
+## The two directions
+
+`emit` is one-way. A Gamemaster turns everyone's page, a client is told to
+warm a cache. Nothing comes back, and nothing waits.
+
+`askGm` is a question with an answer. A player cannot write to a world
+document, so they ask the Gamemaster's client to do it and get the return
+value back. It rides on Foundry's queries rather than the socket, because a
+query returns a value and reports a failure. A Gamemaster calling `askGm`
+runs the handler directly, with no round trip, which is why it still works in
+a world where the Gamemaster is alone.
+
+## Who may send what
+
+A handler is a function, or an object when you need the `from` option:
+
+```js
+messages: {
+  turnToPage: ({ page }) => viewer.goToPage(page),
+  warmCache: { from: 'anyone', run: ({ url }) => cache(url) },
+}
+```
+
+`from` defaults to `'gm'`. A message from anyone else is dropped, with no
+notification: a player should learn nothing from a message that was not meant
+to reach them. Use `'anyone'` only for messages that touch the receiving
+client and nothing else, and treat the payload as something the sender chose.
+
+The check reads the sender id Foundry's server appends to every relayed
+message. That id comes from the authenticated session. A sender id written
+into the payload proves nothing, so it is never read.
+
+## Who receives it
+
+```js
+await socket.emit('turnToPage', { page: 12 });                  // everyone
+await socket.emit('turnToPage', { page: 12 }, { to: [userId] }); // those users
+await socket.emit('turnToPage', { page: 12 }, { self: false });  // not this client
+```
+
+The sender's handler runs too. Foundry never delivers a message back to
+whoever sent it, so without that a Gamemaster alone in a world sees nothing
+happen, and there is no way to tell that apart from a bug. `self: false` turns
+it off when the sender must not act on its own message.
+
+The sender's own id is dropped from `to` before sending, so naming yourself
+does not make the handler run twice.
+
+## What a handler is told
+
+The second argument carries the sender:
+
+| Field | What it is |
+| --- | --- |
+| `user` | The sending user, looked up from the id the server supplied |
+| `userId` | That id. Empty when this client sent the message itself |
+| `local` | `true` when this is the sender's own copy |
+
+## When no Gamemaster is connected
+
+`askGm` throws [VTTF-0013](../errors/VTTF-0013). There is nowhere for the work
+to run, and a player's write would be refused. Check first when you would
+rather say something than throw:
+
+```js
+if (!socket.isGmOnline()) {
+  ui.notifications.warn('A Gamemaster has to be online for this.');
+  return;
+}
+```
+
+## Systems
+
+The same call, with `kind: 'system'`. The only difference is the channel,
+`system.<id>` instead of `module.<id>`, and which manifest carries
+`"socket": true`.
+
+## Before you reach for this
+
+Many sockets exist only to avoid several writes in a row. `modifyBatch` sends
+them in one request, all applied or none, and needs no socket at all:
+
+```js
+await foundry.documents.modifyBatch([
+  { action: 'update', documentName: 'Actor', updates: [{ _id: actor.id, 'system.hp.value': 3 }] },
+  { action: 'create', documentName: 'Item', data: [{ name: 'Loot', type: 'loot' }], parent: actor },
+]);
+```
+
+The caller still needs permission for every operation, so a player-initiated
+write still goes through `askGm`.

--- a/apps/e2e/tests/sockets.spec.mjs
+++ b/apps/e2e/tests/sockets.spec.mjs
@@ -1,0 +1,180 @@
+/**
+ * The socket helper, with two people in the world.
+ *
+ * Every other test here drives one browser. A socket cannot be proved that
+ * way: the thing it does is carry a message from one client to another, and a
+ * single context can only watch itself. So this file opens two, a Gamemaster
+ * and a player, against the same running world.
+ *
+ * What one context could never show:
+ *
+ * - a message reaching the other client at all
+ * - the sender's own copy running as well, which is what stops a lone GM from
+ *   seeing nothing happen
+ * - a player's message being dropped, because the check reads the sender id
+ *   the server supplied rather than anything in the payload
+ * - a player getting a world document written, which they have no permission
+ *   to write themselves
+ */
+import { expect, test } from '@playwright/test';
+import { baseUrl } from '../scripts/foundry.mjs';
+
+const MODULE_ID = 'vttforge-example-module';
+const PLAYER_NAME = 'Tester';
+
+/** Foundry refuses to lay out below 1024x700 and says so in a banner. */
+const VIEWPORT = { width: 1600, height: 1000 };
+
+const consoleErrors = [];
+
+/** Open a browser of its own and join the running world as `name`. */
+async function join(browser, name) {
+  const context = await browser.newContext({ viewport: VIEWPORT });
+  const page = await context.newPage();
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(`${name}: ${message.text()}`);
+  });
+  page.on('pageerror', (error) => consoleErrors.push(`${name}: ${String(error)}`));
+  await page.goto(`${baseUrl()}/join`);
+  await page.waitForSelector('form[name=join] input[name=username]');
+  await page.fill('form[name=join] input[name=username]', name);
+  await page.click('form[name=join] button[name=join]');
+  await page.waitForURL('**/game');
+  await page.waitForFunction(() => globalThis.game?.ready === true, null, { timeout: 90_000 });
+  return page;
+}
+
+/**
+ * The two clients, opened once for the whole file.
+ *
+ * Foundry allows a user one session: logging in again as the Gamemaster boots
+ * the window that was already there. So the table is set up in `beforeAll`
+ * and every test shares it, rather than each test joining again.
+ */
+let gm;
+let player;
+
+test.beforeAll(async ({ browser }) => {
+  gm = await join(browser, 'Gamemaster');
+
+  // Enabling a module needs a world reload before Foundry loads its scripts.
+  const wasActive = await gm.evaluate(async (id) => {
+    const configuration = game.settings.get('core', 'moduleConfiguration');
+    if (configuration[id] === true) return true;
+    await game.settings.set('core', 'moduleConfiguration', { ...configuration, [id]: true });
+    return false;
+  }, MODULE_ID);
+  if (!wasActive) {
+    await gm.context().close();
+    gm = await join(browser, 'Gamemaster');
+  }
+
+  // The player has to exist before anyone can log in as them.
+  await gm.evaluate(async (name) => {
+    if (!game.users.find((user) => user.name === name)) {
+      await User.implementation.create({ name, role: 1 });
+    }
+  }, PLAYER_NAME);
+
+  player = await join(browser, PLAYER_NAME);
+});
+
+test.afterAll(async () => {
+  await player?.context().close();
+  await gm?.context().close();
+});
+
+/** Give the server a moment to relay, then read the marker the handler sets. */
+async function announced(page) {
+  await page.waitForTimeout(1500);
+  return page.evaluate(() => globalThis.vttforgeExampleAnnounced);
+}
+
+test('the manifest declares the channel, and both clients agree on it', async () => {
+  for (const page of [gm, player]) {
+    const seen = await page.evaluate(
+      (id) => ({
+        active: game.modules.get(id)?.active,
+        socket: game.modules.get(id)?.socket,
+        api: Object.keys(game.modules.get(id)?.api ?? {}).sort(),
+        query: typeof CONFIG.queries?.[`${id}.createNote`],
+      }),
+      MODULE_ID,
+    );
+    expect(seen.active).toBe(true);
+    // Without this field Foundry accepts the emit and delivers nothing.
+    expect(seen.socket).toBe(true);
+    expect(seen.api).toEqual(['announce', 'createNote', 'noteType', 'requestNote']);
+    // Requests live in one namespace shared by everything installed, so the
+    // name carries the module id.
+    expect(seen.query).toBe('function');
+  }
+});
+
+test('a message from the Gamemaster reaches the player and the Gamemaster', async () => {
+  await gm.evaluate((id) => game.modules.get(id).api.announce('rocks fall'), MODULE_ID);
+
+  expect(await announced(player)).toBe('rocks fall');
+  // The sender's own copy. Foundry does not deliver a message back to whoever
+  // sent it, so without this a Gamemaster alone in a world sees nothing.
+  expect(await announced(gm)).toBe('rocks fall');
+});
+
+test('the same message from a player is dropped, whatever the payload claims', async () => {
+  await gm.evaluate(() => {
+    globalThis.vttforgeExampleAnnounced = 'unchanged';
+  });
+  await player.evaluate((id) => game.modules.get(id).api.announce('players cannot'), MODULE_ID);
+  expect(await announced(gm)).toBe('unchanged');
+
+  // And by hand, straight down the channel, with a forged sender in the
+  // payload. The server appends the real one as the second argument, and that
+  // is the only one read.
+  await player.evaluate((id) => {
+    const gmUser = game.users.find((user) => user.isGM);
+    game.socket.emit(`module.${id}`, {
+      name: 'announce',
+      payload: { text: 'forged', userId: gmUser.id },
+    });
+  }, MODULE_ID);
+  expect(await announced(gm)).toBe('unchanged');
+});
+
+test('a player gets a world item written by asking the Gamemaster', async () => {
+  const before = await gm.evaluate(() => game.items.size);
+  const created = await player.evaluate(
+    (id) => game.modules.get(id).api.requestNote('From a player', 'body'),
+    MODULE_ID,
+  );
+
+  expect(created).toBeTruthy();
+  await gm.waitForTimeout(800);
+  expect(await gm.evaluate(() => game.items.size)).toBe(before + 1);
+
+  const item = await gm.evaluate((itemId) => {
+    const found = game.items.get(itemId);
+    return { type: found?.type, body: found?.system?.body };
+  }, created);
+  expect(item.type).toBe(`${MODULE_ID}.note`);
+  // The handler ran on the Gamemaster's client and was told who asked.
+  expect(item.body).toBe(`body (asked for by ${PLAYER_NAME})`);
+});
+
+test('a player cannot write that item themselves', async () => {
+  // The reason askGm exists. Foundry refuses the write, which is what a
+  // module would otherwise discover from a bug report.
+  const refused = await player.evaluate(async (id) => {
+    try {
+      await CONFIG.Item.documentClass.create({ name: 'Direct', type: `${id}.note` });
+      return 'created';
+    } catch (error) {
+      return String(error.message ?? error).slice(0, 120);
+    }
+  }, MODULE_ID);
+  expect(refused).not.toBe('created');
+});
+
+test.afterAll(() => {
+  const ours = consoleErrors.filter((line) => /vttforge|VTTF-\d{4}/i.test(line));
+  expect(ours, `console errors naming VTTForge:\n${ours.join('\n')}`).toEqual([]);
+});

--- a/docs/errors/VTTF-0012.md
+++ b/docs/errors/VTTF-0012.md
@@ -1,0 +1,21 @@
+# VTTF-0012: InvalidSocket
+
+> [!NOTE]
+> registerSocket() was called without a package id or kind, with no messages and no requests, with a name that cannot be used, twice for the same channel, or for a package whose manifest does not set "socket": true. Foundry accepts an emit on an undeclared channel and delivers it to nobody.
+
+| Field | Value |
+|---|---|
+| Code | `VTTF-0012` |
+| Name | `InvalidSocket` |
+| Package | `@vttforge/core` |
+| Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
+
+---
+
+This page comes from the registry entry. We are still writing the root
+causes, common triggers and code samples for each code; the message above
+is what the runtime throws.
+
+`packages/core/scripts/codegen-errors.mjs` builds this file from the
+registry at [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts). Do not edit by hand;
+re-run `pnpm --filter @vttforge/core build` after editing the registry.

--- a/docs/errors/VTTF-0013.md
+++ b/docs/errors/VTTF-0013.md
@@ -1,0 +1,21 @@
+# VTTF-0013: NoGamemaster
+
+> [!NOTE]
+> askGm() was called for a request that was never registered, or while no Gamemaster was connected. A player cannot write to world documents, so the work has nowhere to run.
+
+| Field | Value |
+|---|---|
+| Code | `VTTF-0013` |
+| Name | `NoGamemaster` |
+| Package | `@vttforge/core` |
+| Source | [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts) |
+
+---
+
+This page comes from the registry entry. We are still writing the root
+causes, common triggers and code samples for each code; the message above
+is what the runtime throws.
+
+`packages/core/scripts/codegen-errors.mjs` builds this file from the
+registry at [`packages/core/src/errors/registry.ts`](https://github.com/vttforge/vttforge/blob/main/packages/core/src/errors/registry.ts). Do not edit by hand;
+re-run `pnpm --filter @vttforge/core build` after editing the registry.

--- a/examples/simple-module/module.json
+++ b/examples/simple-module/module.json
@@ -8,13 +8,30 @@
     "minimum": "14",
     "verified": "14"
   },
-  "authors": [{ "name": "VTTForge Contributors" }],
+  "authors": [
+    {
+      "name": "VTTForge Contributors"
+    }
+  ],
   "esmodules": ["main.mjs"],
-  "styles": [{ "src": "styles/main.css" }],
-  "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
+  "styles": [
+    {
+      "src": "styles/main.css"
+    }
+  ],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json"
+    }
+  ],
+  "socket": true,
   "documentTypes": {
     "Item": {
-      "note": { "htmlFields": ["body"] }
+      "note": {
+        "htmlFields": ["body"]
+      }
     }
   },
   "flags": {

--- a/examples/simple-module/scripts/main.mjs
+++ b/examples/simple-module/scripts/main.mjs
@@ -5,13 +5,20 @@
  * modules copy from each other: the sub-type, its sheet, the enricher, the
  * settings, and the public API.
  */
-import { registerModule, SystemConfig, VttfError } from '@vttforge/core';
+import { registerModule, registerSocket, SystemConfig, VttfError } from '@vttforge/core';
 import { MODULE_ID, NOTE_TYPE } from './constants.mjs';
 import { NoteData } from './data/note-data.mjs';
 import { noteEnricher } from './enricher.mjs';
 import { NoteSheet } from './sheets/note-sheet.mjs';
 
 const settings = new SystemConfig(MODULE_ID);
+
+/**
+ * Set by `registerSocket` at `setup`, used by the API below.
+ *
+ * @type {import('@vttforge/core').PackageSocket}
+ */
+let socket;
 
 /** What `game.modules.get("vttforge-example-module").api` offers other modules and macros. */
 const api = {
@@ -26,6 +33,30 @@ const api = {
       { name, type: NOTE_TYPE, system: { body } },
       { renderSheet: true },
     );
+  },
+
+  /**
+   * Show a note to the table. One-way: nothing comes back.
+   *
+   * @param {string} text
+   * @param {string[]} [userIds] who sees it. Left out, everyone.
+   */
+  announce(text, userIds) {
+    return socket.emit('announce', { text }, userIds ? { to: userIds } : undefined);
+  },
+
+  /**
+   * Ask the Gamemaster's client to file a note in the world.
+   *
+   * A player cannot create a world Item, so this is the only way for one to
+   * end up with a note. The answer is the new item's id.
+   *
+   * @param {string} name
+   * @param {string} [body]
+   * @returns {Promise<string>}
+   */
+  requestNote(name, body = '') {
+    return socket.askGm('createNote', { name, body });
   },
 };
 
@@ -70,6 +101,40 @@ try {
         config: true,
         type: Boolean,
         default: true,
+      });
+    },
+
+    // `setup` rather than `init`: the handlers are registered once, and by
+    // then every package has finished its own `init`.
+    onSetup: () => {
+      socket = registerSocket({
+        id: MODULE_ID,
+        kind: 'module',
+
+        messages: {
+          // Default `from: 'gm'`. A player sending this is ignored, and the
+          // check reads the sender id the server supplied, not the payload.
+          announce: {
+            run: ({ text }, context) => {
+              ui.notifications?.info(`${context.user?.name ?? 'Someone'}: ${text}`);
+              // A marker the end-to-end run reads to prove the message
+              // arrived on this client.
+              Object.assign(globalThis, { vttforgeExampleAnnounced: text });
+            },
+          },
+        },
+
+        requests: {
+          // Runs on the Gamemaster's client, whoever asked.
+          createNote: async ({ name, body }, context) => {
+            const item = await CONFIG.Item.documentClass.create({
+              name,
+              type: NOTE_TYPE,
+              system: { body: `${body} (asked for by ${context.user?.name ?? 'nobody'})` },
+            });
+            return item.id;
+          },
+        },
       });
     },
 

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.17.0"
+    "@vttforge/core": "^0.18.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.15.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.17.0"
+    "@vttforge/core": "^0.18.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.15.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.17.0",
+    "@vttforge/core": "^0.18.0",
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.17.0",
+    "@vttforge/core": "^0.18.0",
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -50,6 +50,7 @@ Foundry keys a sheet by its class name and saves that key on every document. A b
 - [Data models](https://vttforge.dev/docs/guide/data-models)
 - [Sheets](https://vttforge.dev/docs/guide/sheets)
 - [Modules](https://vttforge.dev/docs/guide/modules)
+- [Sockets](https://vttforge.dev/docs/guide/sockets). `registerSocket`: one-way messages, and questions only the Gamemaster's client can answer.
 - [Error codes](https://vttforge.dev/docs/errors/)
 
 Foundry v14+ only. The package runs in the browser inside Foundry; it reads the Foundry globals lazily, so it also imports cleanly in Node for tests.

--- a/packages/core/src/__tests__/sockets.test.ts
+++ b/packages/core/src/__tests__/sockets.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetRegisteredSocketsForTests, registerSocket } from '../sockets.js';
+
+interface FakeUser {
+  id: string;
+  name: string;
+  isGM: boolean;
+  active: boolean;
+  query?: ReturnType<typeof vi.fn>;
+}
+
+const GM: FakeUser = { id: 'gm1', name: 'Gamemaster', isGM: true, active: true };
+const PLAYER: FakeUser = { id: 'p1', name: 'Player', isGM: false, active: true };
+const OTHER: FakeUser = { id: 'p2', name: 'Other', isGM: false, active: true };
+
+let listeners: Array<(message: unknown, senderId?: unknown) => void>;
+let emitted: Array<{ channel: string; message: unknown; options?: unknown }>;
+let users: FakeUser[];
+
+/** Build the globals a package sees, as the user given. */
+function world(
+  self: FakeUser,
+  { socket = true, kind = 'module' as 'module' | 'system' } = {},
+): void {
+  listeners = [];
+  emitted = [];
+  users = [GM, PLAYER, OTHER];
+  (globalThis as Record<string, unknown>).CONFIG = { queries: {} };
+  (globalThis as Record<string, unknown>).game = {
+    user: { isGM: self.isGM },
+    userId: self.id,
+    users: {
+      get: (id: string) => users.find((user) => user.id === id),
+      find: (fn: (user: FakeUser) => boolean) => users.find(fn),
+      filter: (fn: (user: FakeUser) => boolean) => users.filter(fn),
+    },
+    socket: {
+      emit: (channel: string, message: unknown, options?: unknown) => {
+        emitted.push({ channel, message, options });
+      },
+      on: (_channel: string, listener: (message: unknown, senderId?: unknown) => void) => {
+        listeners.push(listener);
+      },
+    },
+    system: { id: 'my-system', socket: kind === 'system' ? socket : false },
+    modules: { get: () => (kind === 'module' ? { socket } : undefined) },
+  };
+}
+
+/** Deliver a message the way Foundry does: payload first, server's sender id second. */
+async function relay(message: unknown, senderId: unknown): Promise<void> {
+  for (const listener of listeners) listener(message, senderId);
+  await Promise.resolve();
+}
+
+/** The `recipients` of the one message that was sent. */
+function recipients(): readonly string[] | undefined {
+  const options = emitted.at(0)?.options as { recipients?: readonly string[] } | undefined;
+  return options?.recipients;
+}
+
+function queries(): Record<string, (data: unknown, context: unknown) => unknown> {
+  return (globalThis as { CONFIG: { queries: Record<string, never> } }).CONFIG.queries;
+}
+
+beforeEach(() => {
+  _resetRegisteredSocketsForTests();
+  world(GM);
+});
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).game = undefined;
+  (globalThis as Record<string, unknown>).CONFIG = undefined;
+  delete GM.query;
+  delete PLAYER.query;
+});
+
+describe('registering', () => {
+  it('names the channel after the manifest the package is declared in', () => {
+    const module = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      messages: { ping: { run: () => {} } },
+    });
+    expect(module.channel).toBe('module.my-module');
+
+    _resetRegisteredSocketsForTests();
+    world(GM, { kind: 'system' });
+    const system = registerSocket({
+      id: 'my-system',
+      kind: 'system',
+      messages: { ping: { run: () => {} } },
+    });
+    expect(system.channel).toBe('system.my-system');
+  });
+
+  it('refuses a package whose manifest has no socket field', () => {
+    world(GM, { socket: false });
+    expect(() =>
+      registerSocket({ id: 'my-module', kind: 'module', messages: { ping: { run: () => {} } } }),
+    ).toThrow(/VTTF-0012[\s\S]*"socket": true/);
+  });
+
+  it('registers requests without needing the socket field, since a query is not the socket', () => {
+    world(GM, { socket: false });
+    expect(() =>
+      registerSocket({ id: 'my-module', kind: 'module', requests: { grant: { run: () => 1 } } }),
+    ).not.toThrow();
+    expect(Object.keys(queries())).toEqual(['my-module.grant']);
+  });
+
+  it('refuses a second registration for the same channel', () => {
+    const register = () =>
+      registerSocket({ id: 'my-module', kind: 'module', messages: { ping: { run: () => {} } } });
+    register();
+    expect(register).toThrow(/already registered/);
+  });
+
+  it('refuses an empty registration, a bad kind and an unusable name', () => {
+    expect(() => registerSocket({ id: 'my-module', kind: 'module' })).toThrow(
+      /no messages and no requests/,
+    );
+    expect(() =>
+      registerSocket({
+        id: 'my-module',
+        kind: 'plugin' as never,
+        messages: { ping: { run: () => {} } },
+      }),
+    ).toThrow(/"module" or "system"/);
+    expect(() =>
+      registerSocket({ id: 'my-module', kind: 'module', messages: { '2fast': { run: () => {} } } }),
+    ).toThrow(/not usable/);
+  });
+});
+
+describe('a bare function handler', () => {
+  it('is the same as { run }, and defaults to Gamemaster only', async () => {
+    const run = vi.fn();
+    world(PLAYER);
+    registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      messages: { turn: run },
+      requests: { grant: () => 'ok' },
+    });
+    await relay({ name: 'turn', payload: 1 }, GM.id);
+    expect(run).toHaveBeenCalledTimes(1);
+    await relay({ name: 'turn', payload: 2 }, OTHER.id);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(queries()['my-module.grant']?.(null, {})).toBe('ok');
+  });
+});
+
+describe('a message arriving from another client', () => {
+  it('runs for a Gamemaster and is dropped for a player', async () => {
+    const run = vi.fn();
+    world(PLAYER);
+    registerSocket({ id: 'my-module', kind: 'module', messages: { turn: { run } } });
+
+    await relay({ name: 'turn', payload: { page: 3 } }, GM.id);
+    expect(run).toHaveBeenCalledTimes(1);
+    const [payload, context] = run.mock.calls[0] as [
+      { page: number },
+      { userId: string; local: boolean },
+    ];
+    expect(payload).toEqual({ page: 3 });
+    expect(context.userId).toBe(GM.id);
+    expect(context.local).toBe(false);
+
+    await relay({ name: 'turn', payload: { page: 4 } }, OTHER.id);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs for anyone when the handler says so', async () => {
+    const run = vi.fn();
+    world(PLAYER);
+    registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      messages: { warm: { from: 'anyone', run } },
+    });
+    await relay({ name: 'warm', payload: null }, OTHER.id);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a message with no sender id, an unknown sender, or a sender in the payload', async () => {
+    const run = vi.fn();
+    world(PLAYER);
+    registerSocket({ id: 'my-module', kind: 'module', messages: { turn: { run } } });
+
+    await relay({ name: 'turn', payload: null }, undefined);
+    await relay({ name: 'turn', payload: null }, 'nobody');
+    // The one that matters: a payload claiming to come from the GM, relayed
+    // by a player. The server's id is what decides, so this is dropped.
+    await relay({ name: 'turn', payload: { userId: GM.id } }, PLAYER.id);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('ignores a message that is not ours and a name nobody registered', async () => {
+    const run = vi.fn();
+    registerSocket({ id: 'my-module', kind: 'module', messages: { turn: { run } } });
+    await relay('not an envelope', GM.id);
+    await relay({ name: 'unknown', payload: null }, GM.id);
+    expect(run).not.toHaveBeenCalled();
+  });
+});
+
+describe('emitting', () => {
+  it('broadcasts and runs on the sender, because Foundry does not deliver to the sender', async () => {
+    const run = vi.fn();
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      messages: { turn: { run } },
+    });
+    await socket.emit('turn', { page: 2 });
+
+    expect(emitted).toEqual([
+      {
+        channel: 'module.my-module',
+        message: { name: 'turn', payload: { page: 2 } },
+        options: undefined,
+      },
+    ]);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect((run.mock.calls[0] as [unknown, { local: boolean }])[1].local).toBe(true);
+  });
+
+  it('routes to named users and drops the sender from the list', async () => {
+    const run = vi.fn();
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      messages: { turn: { run } },
+    });
+    await socket.emit('turn', null, { to: [GM.id, PLAYER.id] });
+
+    // The sender is in `to`, so it acts locally and is not also sent to.
+    expect(recipients()).toEqual([PLAYER.id]);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run locally when the sender is not a recipient', async () => {
+    const run = vi.fn();
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      messages: { turn: { run } },
+    });
+    await socket.emit('turn', null, { to: [PLAYER.id] });
+    expect(recipients()).toEqual([PLAYER.id]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing when the only recipient is the sender, and still acts locally', async () => {
+    const run = vi.fn();
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      messages: { turn: { run } },
+    });
+    await socket.emit('turn', null, { to: [GM.id] });
+    expect(emitted).toEqual([]);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the local run when asked, and refuses an unregistered name', async () => {
+    const run = vi.fn();
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      messages: { turn: { run } },
+    });
+    await socket.emit('turn', null, { self: false });
+    expect(emitted).toHaveLength(1);
+    expect(run).not.toHaveBeenCalled();
+    await expect(socket.emit('nope')).rejects.toThrow(/not a message registered/);
+  });
+});
+
+describe('asking the Gamemaster', () => {
+  it('runs the handler directly when the asker is the Gamemaster', async () => {
+    const run = vi.fn(() => 'done');
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      requests: { grant: { run } },
+    });
+    await expect(socket.askGm('grant', { itemId: 'x' })).resolves.toBe('done');
+    expect(run).toHaveBeenCalledWith({ itemId: 'x' }, expect.objectContaining({ local: true }));
+  });
+
+  it('queries a connected Gamemaster when the asker is a player', async () => {
+    world(PLAYER);
+    GM.query = vi.fn(async () => 'granted');
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      requests: { grant: { run: () => 'never here' } },
+    });
+    await expect(socket.askGm('grant', { itemId: 'x' }, { timeout: 5000 })).resolves.toBe(
+      'granted',
+    );
+    expect(GM.query).toHaveBeenCalledWith('my-module.grant', { itemId: 'x' }, { timeout: 5000 });
+  });
+
+  it('says so when no Gamemaster is connected', async () => {
+    world(PLAYER);
+    users = [PLAYER, { ...GM, active: false }];
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      requests: { grant: { run: () => 1 } },
+    });
+    await expect(socket.askGm('grant')).rejects.toThrow(/VTTF-0013[\s\S]*No Gamemaster/);
+    expect(socket.isGmOnline()).toBe(false);
+  });
+
+  it('registers the handler under the package id, and names the asker', async () => {
+    registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      requests: { grant: { run: (_payload, context) => context.user?.name } },
+    });
+    const handler = queries()['my-module.grant'];
+    expect(handler).toBeTypeOf('function');
+    expect(handler?.(null, { user: PLAYER })).toBe('Player');
+  });
+
+  it('refuses a request nobody registered', async () => {
+    const socket = registerSocket({
+      id: 'my-module',
+      kind: 'module',
+      requests: { grant: { run: () => 1 } },
+    });
+    await expect(socket.askGm('nope')).rejects.toThrow(/not a request registered/);
+  });
+});

--- a/packages/core/src/errors/registry.ts
+++ b/packages/core/src/errors/registry.ts
@@ -88,6 +88,18 @@ const REGISTRY: Readonly<Record<VttfErrorCode, VttfErrorEntry>> = Object.freeze(
     summary:
       'stepDie() was given a die that is not on the ladder or a fractional number of steps, or dicePool() was given a count, faces, keep or drop that is not a whole number in range (keep and drop go up to the number of dice), or both keep and drop.',
   }),
+  'VTTF-0012': Object.freeze({
+    code: 'VTTF-0012',
+    name: 'InvalidSocket',
+    summary:
+      'registerSocket() was called without a package id or kind, with no messages and no requests, with a name that cannot be used, twice for the same channel, or for a package whose manifest does not set "socket": true. Foundry accepts an emit on an undeclared channel and delivers it to nobody.',
+  }),
+  'VTTF-0013': Object.freeze({
+    code: 'VTTF-0013',
+    name: 'NoGamemaster',
+    summary:
+      'askGm() was called for a request that was never registered, or while no Gamemaster was connected. A player cannot write to world documents, so the work has nowhere to run.',
+  }),
 });
 
 /**

--- a/packages/core/src/foundry-globals.ts
+++ b/packages/core/src/foundry-globals.ts
@@ -41,9 +41,34 @@ export interface GameSettingsApi {
   set<T>(namespace: string, key: string, value: T): Promise<T>;
 }
 
+/** One connected or known user, as far as the socket helpers care. */
+export interface UserLike {
+  readonly id?: string;
+  readonly name?: string;
+  readonly isGM?: boolean;
+  readonly active?: boolean;
+  query?: (name: string, data: unknown, options?: { timeout?: number }) => Promise<unknown>;
+}
+
+/** `game.socket`. The second argument of a listener is the server's own sender id. */
+export interface SocketApi {
+  emit(channel: string, message: unknown, options?: { recipients?: readonly string[] }): void;
+  on(channel: string, listener: (message: unknown, senderId?: unknown) => void): void;
+  off?(channel: string, listener: (message: unknown, senderId?: unknown) => void): void;
+}
+
 export interface GameApi {
   readonly settings: GameSettingsApi;
   readonly user?: { readonly isGM: boolean };
+  readonly userId?: string | null;
+  readonly users?: {
+    get(id: string): UserLike | undefined;
+    filter(fn: (user: UserLike) => boolean): UserLike[];
+    find(fn: (user: UserLike) => boolean): UserLike | undefined;
+  };
+  readonly socket?: SocketApi;
+  readonly system?: { readonly id: string; readonly socket?: boolean };
+  readonly modules?: { get(id: string): { socket?: boolean; api?: unknown } | undefined };
 }
 
 export type ConfigCollection<T = unknown> = Record<string, T>;
@@ -72,10 +97,20 @@ export interface StatusEffectConfig {
   readonly [key: string]: unknown;
 }
 
+/**
+ * `CONFIG.queries`. A handler registered here can be called on this client by
+ * another user through `User#query`, and its return value travels back.
+ */
+export type QueryHandlers = Record<
+  string,
+  (data: unknown, context: { timeout?: number; user?: UserLike }) => unknown
+>;
+
 export interface FoundryConfig {
   Actor: ActorConfig;
   Item: ItemConfig;
   Combat: CombatConfig;
   statusEffects?: Record<string, unknown>;
+  queries?: QueryHandlers;
   [key: string]: unknown;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -216,4 +216,16 @@ export {
   type SheetModesConfig,
   TOGGLE_MODE_ACTION,
 } from './sheet-modes.js';
+export {
+  type AskGmOptions,
+  type EmitOptions,
+  type PackageKind,
+  type PackageSocket,
+  registerSocket,
+  type SocketContext,
+  type SocketMessageHandler,
+  type SocketRegistration,
+  type SocketRequestHandler,
+  type SocketSender,
+} from './sockets.js';
 export { SystemConfig } from './system-config.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,9 +160,12 @@ export type {
   HookCallback,
   HooksApi,
   ItemConfig,
+  QueryHandlers,
   SettingConfig,
   SettingScope,
+  SocketApi,
   StatusEffectConfig,
+  UserLike,
 } from './foundry-globals.js';
 export {
   KEYWORD_ATTRIBUTE,
@@ -224,8 +227,10 @@ export {
   registerSocket,
   type SocketContext,
   type SocketMessageHandler,
+  type SocketMessageRun,
   type SocketRegistration,
   type SocketRequestHandler,
+  type SocketRequestRun,
   type SocketSender,
 } from './sockets.js';
 export { SystemConfig } from './system-config.js';

--- a/packages/core/src/sockets.ts
+++ b/packages/core/src/sockets.ts
@@ -1,0 +1,348 @@
+/**
+ * Talking to the other clients.
+ *
+ * Foundry gives a package one socket channel and one queries namespace, and
+ * both are raw. The four things that go wrong are not in the API docs, they
+ * are in every module that has shipped a socket:
+ *
+ * - **The channel name is not the package id.** It is `module.<id>` or
+ *   `system.<id>`. A channel without the prefix is accepted by `emit` and
+ *   delivered to nobody.
+ * - **`"socket": true` is a manifest field.** Leave it out and `emit` still
+ *   returns, the listener never fires, and nothing is logged.
+ * - **The sender id comes from the server, not the payload.** Foundry appends
+ *   the authenticated sender's id as the second argument of a listener. A
+ *   sender written into the payload proves nothing: whoever built the payload
+ *   chose it. Permission checks that read the payload are not checks.
+ * - **Foundry never delivers a message back to whoever sent it.** A GM alone
+ *   in a world sees nothing happen, with no error to tell that apart from a
+ *   bug. So `emit` here runs the handler locally too, and strips the sender's
+ *   own id from `recipients` so a routed send cannot arrive twice.
+ *
+ * Two directions, because packages need both:
+ *
+ * - `emit` is one-way. A GM turns everyone's page, a client is told to warm a
+ *   cache. Nothing comes back.
+ * - `askGm` is a question. A player cannot write to a world document, so they
+ *   ask the GM's client to do it and wait for the answer. This rides on
+ *   `CONFIG.queries` and `User#query` rather than the socket, because a query
+ *   returns a value and reports a failure. A GM calling it runs the handler
+ *   directly, with no round trip.
+ *
+ * Handlers fail closed. `from` defaults to `'gm'`, and a message from anyone
+ * else is dropped without a notification: a player should learn nothing from
+ * a message that was not meant to reach them.
+ */
+
+import { VttfError } from './errors/registry.js';
+import type { FoundryConfig, GameApi, SocketApi, UserLike } from './foundry-globals.js';
+
+/** Which manifest the package is declared in. Decides the channel prefix. */
+export type PackageKind = 'module' | 'system';
+
+/** Who a handler is willing to hear from. */
+export type SocketSender = 'gm' | 'anyone';
+
+/** What a handler is told about the message it is running for. */
+export interface SocketContext {
+  /** The sending user, looked up from the id the server supplied. */
+  readonly user: UserLike | undefined;
+  /** That id. Empty string when this client sent the message itself. */
+  readonly userId: string;
+  /** True when this is the sender's own copy rather than a relayed message. */
+  readonly local: boolean;
+}
+
+/** What runs when a message arrives. */
+export type SocketMessageRun = (payload: never, context: SocketContext) => void | Promise<void>;
+
+/**
+ * One thing a package can be told to do.
+ *
+ * A bare function is the same as `{ run }`, which is what most handlers are.
+ * Use the object form when the message may come from someone who is not a
+ * Gamemaster.
+ */
+export type SocketMessageHandler =
+  | SocketMessageRun
+  | {
+      /**
+       * Who may trigger it. Default `'gm'`. `'anyone'` is for messages that
+       * only touch the receiving client, and even then the handler is the
+       * last line: the sender chose the payload.
+       */
+      readonly from?: SocketSender;
+      readonly run: SocketMessageRun;
+    };
+
+/** What runs on the Gamemaster's client, and whose return value travels back. */
+export type SocketRequestRun = (payload: never, context: SocketContext) => unknown;
+
+/**
+ * One thing a client can ask the GM's client to do on its behalf. A bare
+ * function is the same as `{ run }`.
+ */
+export type SocketRequestHandler = SocketRequestRun | { readonly run: SocketRequestRun };
+
+export interface SocketRegistration {
+  /** Package id: the `id` in `module.json` or `system.json`. */
+  readonly id: string;
+  /** Which manifest that is. Decides `module.<id>` against `system.<id>`. */
+  readonly kind: PackageKind;
+  /** One-way messages, keyed by name. */
+  readonly messages?: Readonly<Record<string, SocketMessageHandler>>;
+  /** Questions for the GM's client, keyed by name. */
+  readonly requests?: Readonly<Record<string, SocketRequestHandler>>;
+}
+
+export interface EmitOptions {
+  /**
+   * User ids to send to. Left out, every other client receives it. The
+   * sender's own id is dropped from the list, because the local run below
+   * already covers this client.
+   */
+  readonly to?: readonly string[];
+  /**
+   * Run the handler on this client as well. Default `true`, which is what
+   * makes a lone GM see the same thing as a table full of players. `false`
+   * when the sender must not act on its own message.
+   */
+  readonly self?: boolean;
+}
+
+export interface AskGmOptions {
+  /** Milliseconds to wait for the GM's client. Foundry's default applies otherwise. */
+  readonly timeout?: number;
+}
+
+/** What `registerSocket` hands back. */
+export interface PackageSocket {
+  /** The channel Foundry routes on: `module.<id>` or `system.<id>`. */
+  readonly channel: string;
+  /** Send a one-way message. Runs the handler here too, unless told not to. */
+  emit(name: string, payload?: unknown, options?: EmitOptions): Promise<void>;
+  /** Ask the GM's client to run a request, and wait for its answer. */
+  askGm<T = unknown>(name: string, payload?: unknown, options?: AskGmOptions): Promise<T>;
+  /** Is a Gamemaster connected right now? */
+  isGmOnline(): boolean;
+}
+
+interface Envelope {
+  readonly name: string;
+  readonly payload: unknown;
+}
+
+function config(): FoundryConfig {
+  return (globalThis as { CONFIG?: FoundryConfig }).CONFIG as FoundryConfig;
+}
+
+function game(): GameApi | undefined {
+  return (globalThis as { game?: GameApi }).game;
+}
+
+function socketApi(): SocketApi | undefined {
+  return game()?.socket;
+}
+
+function fail(code: 'VTTF-0012' | 'VTTF-0013', message: string): never {
+  throw new VttfError(code, message);
+}
+
+/**
+ * Is the package allowed to use its channel?
+ *
+ * Read from the manifest Foundry already parsed. Checking here turns the
+ * silent version of this mistake into a message at registration, which is the
+ * only moment anybody is looking.
+ */
+function assertSocketEnabled(id: string, kind: PackageKind): void {
+  const g = game();
+  if (!g) return;
+  const declared =
+    kind === 'system' ? g.system?.socket === true : g.modules?.get(id)?.socket === true;
+  if (declared) return;
+  fail(
+    'VTTF-0012',
+    `${kind} "${id}" registered socket handlers, but its manifest does not set "socket": true. ` +
+      'Foundry accepts the emit and delivers nothing. Add the field to ' +
+      `${kind === 'system' ? 'system.json' : 'module.json'} and reload the world.`,
+  );
+}
+
+function assertNames(kind: string, names: readonly string[]): void {
+  for (const name of names) {
+    if (typeof name === 'string' && /^[A-Za-z][A-Za-z0-9_-]*$/.test(name)) continue;
+    fail(
+      'VTTF-0012',
+      `Socket ${kind} name ${JSON.stringify(name)} is not usable. ` +
+        'Names start with a letter and hold letters, digits, hyphens and underscores.',
+    );
+  }
+}
+
+/** Both handler shapes, read the same way. */
+function runOf(
+  handler: SocketMessageHandler | SocketRequestHandler,
+): (payload: unknown, context: SocketContext) => unknown {
+  const run = typeof handler === 'function' ? handler : handler.run;
+  return run as (payload: unknown, context: SocketContext) => unknown;
+}
+
+function senderOf(handler: SocketMessageHandler): SocketSender {
+  if (typeof handler === 'function') return 'gm';
+  return handler.from ?? 'gm';
+}
+
+function isEnvelope(message: unknown): message is Envelope {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    typeof (message as { name?: unknown }).name === 'string'
+  );
+}
+
+const registered = new Set<string>();
+
+/** For tests: clears the in-process "already registered" guard. */
+export function _resetRegisteredSocketsForTests(): void {
+  registered.clear();
+}
+
+/**
+ * Register a package's socket handlers and get the two send functions back.
+ *
+ * Call it once, from `onSetup` or `onReady`. Registering twice means every
+ * message runs its handler twice, which Foundry will not warn about.
+ */
+export function registerSocket(registration: SocketRegistration): PackageSocket {
+  const { id, kind } = registration;
+  if (typeof id !== 'string' || id === '') {
+    fail('VTTF-0012', 'registerSocket() needs the package id.');
+  }
+  if (kind !== 'module' && kind !== 'system') {
+    fail('VTTF-0012', `registerSocket() kind must be "module" or "system", got ${String(kind)}.`);
+  }
+
+  const messages = registration.messages ?? {};
+  const requests = registration.requests ?? {};
+  assertNames('message', Object.keys(messages));
+  assertNames('request', Object.keys(requests));
+  if (Object.keys(messages).length === 0 && Object.keys(requests).length === 0) {
+    fail('VTTF-0012', `registerSocket() for "${id}" was given no messages and no requests.`);
+  }
+
+  const channel = `${kind}.${id}`;
+  if (registered.has(channel)) {
+    fail(
+      'VTTF-0012',
+      `Socket handlers for "${channel}" are already registered. Call registerSocket() once.`,
+    );
+  }
+
+  if (Object.keys(messages).length > 0) assertSocketEnabled(id, kind);
+
+  /** The id the server gave us, or nothing. Never read from the payload. */
+  function contextFor(senderId: unknown, local: boolean): SocketContext | undefined {
+    if (local) {
+      const own = game()?.userId ?? '';
+      return { user: own ? game()?.users?.get(own) : undefined, userId: own, local: true };
+    }
+    if (typeof senderId !== 'string' || senderId === '') return undefined;
+    const user = game()?.users?.get(senderId);
+    if (!user) return undefined;
+    return { user, userId: senderId, local: false };
+  }
+
+  function allowed(handler: SocketMessageHandler, context: SocketContext): boolean {
+    if (senderOf(handler) === 'anyone') return true;
+    return context.user?.isGM === true;
+  }
+
+  async function run(name: string, payload: unknown, context: SocketContext): Promise<void> {
+    const handler = messages[name];
+    if (!handler || !allowed(handler, context)) return;
+    await runOf(handler)(payload, context);
+  }
+
+  socketApi()?.on(channel, (message, senderId) => {
+    if (!isEnvelope(message)) return;
+    const context = contextFor(senderId, false);
+    if (!context) return;
+    void run(message.name, message.payload, context);
+  });
+
+  // Requests live in `CONFIG.queries`, which is one flat namespace shared by
+  // everything installed, so every name carries the package id.
+  const queries = config()?.queries;
+  if (queries) {
+    for (const [name, handler] of Object.entries(requests)) {
+      const run = runOf(handler);
+      queries[`${id}.${name}`] = (data, { user }) => {
+        const context: SocketContext = { user, userId: user?.id ?? '', local: false };
+        return run(data, context);
+      };
+    }
+  }
+
+  registered.add(channel);
+
+  function isGmOnline(): boolean {
+    return Boolean(game()?.users?.find((user) => user.isGM === true && user.active === true));
+  }
+
+  return {
+    channel,
+
+    async emit(name, payload, options = {}) {
+      if (!messages[name]) {
+        fail('VTTF-0012', `"${name}" is not a message registered for "${channel}".`);
+      }
+      const envelope: Envelope = { name, payload };
+      const own = game()?.userId ?? '';
+      if (options.to === undefined) {
+        socketApi()?.emit(channel, envelope);
+      } else {
+        const others = options.to.filter((userId) => userId !== own);
+        if (others.length > 0) socketApi()?.emit(channel, envelope, { recipients: others });
+      }
+      if (options.self === false) return;
+      if (options.to !== undefined && !options.to.includes(own)) return;
+      const context = contextFor(undefined, true);
+      if (context) await run(name, payload, context);
+    },
+
+    async askGm<T>(name: string, payload?: unknown, options: AskGmOptions = {}): Promise<T> {
+      const handler = requests[name];
+      if (!handler) {
+        fail('VTTF-0013', `"${name}" is not a request registered for "${channel}".`);
+      }
+      const g = game();
+      // A GM asking the GM is just a call. No round trip, and it still works
+      // in a world where this GM is the only one connected.
+      if (g?.user?.isGM === true) {
+        const own = g.userId ?? '';
+        const context: SocketContext = {
+          user: own ? g.users?.get(own) : undefined,
+          userId: own,
+          local: true,
+        };
+        return (await runOf(handler)(payload, context)) as T;
+      }
+      const gm = g?.users?.find((user) => user.isGM === true && user.active === true);
+      if (!gm?.query) {
+        fail(
+          'VTTF-0013',
+          `No Gamemaster is connected, so "${name}" cannot run. ` +
+            'A player cannot write to world documents; a GM has to be online.',
+        );
+      }
+      return (await gm.query(
+        `${id}.${name}`,
+        payload,
+        options.timeout === undefined ? undefined : { timeout: options.timeout },
+      )) as T;
+    },
+
+    isGmOnline,
+  };
+}


### PR DESCRIPTION
A package gets one socket channel and one queries namespace from Foundry, and both are raw. Every module that ships a socket writes the same hundred lines around them, and the parts that go wrong are not the parts the API describes.

`registerSocket()` covers the two directions a package needs.

- `emit` sends a one-way message. A Gamemaster turns everyone's page, a client is told to warm a cache.
- `askGm` asks the Gamemaster's client to do something the caller has no permission to do, and waits for the answer. It rides on Foundry's queries rather than the socket, because a query returns a value and reports a failure. A Gamemaster calling it runs the handler directly, with no round trip.

## The four silent mistakes

- The channel is `module.<id>` or `system.<id>`, not the package id.
- `"socket": true` is a manifest field. Without it Foundry accepts the emit and delivers nothing. The manifest is read at registration, so this throws where somebody is looking.
- The sender id comes from the server, not the payload. A check that reads the payload is not a check, because whoever built the payload chose it.
- Foundry never delivers a message back to whoever sent it. `emit` runs the handler locally too, and drops the sender's own id from the recipients so a routed send cannot arrive twice.

Handlers fail closed. `from` defaults to `gm`, and a message from anyone else is dropped with no notification. A handler is a plain function, or an object when it needs `from`.

New error codes: VTTF-0012 and VTTF-0013.

## How it was checked

20 unit tests, and an end-to-end run that opens two browsers against one world, a Gamemaster and a player. A socket cannot be proved with one context: the thing it does is carry a message to another client, and a single context can only watch itself relay nothing.

The five new end-to-end tests show the message arriving on the other client, the sender's own copy running, a player's message being dropped even with a forged sender id in the payload, a player ending up with a world item through `askGm`, and that same player being refused when they write it directly.

Two things the run found that the unit tests could not. The handler shape needed to accept a plain function: the example module in this repo got `{ run }` wrong within minutes of the API existing. And Foundry allows one session per user, so the spec sets the table once in `beforeAll` rather than joining again per test, which also took the file from seven minutes to fifty seconds.

Full suite: 16 passed in 2.3 minutes. `pnpm lint`, `pnpm typecheck`, `pnpm test` and `pnpm build` all pass.