### PR TITLE
feat(cli): audit rule for socket use with no "socket" in the manifest

### DIFF
--- a/.changeset/cli-audit-socket-flag.md
+++ b/.changeset/cli-audit-socket-flag.md
@@ -1,0 +1,18 @@
+---
+'@vttforge/cli': minor
+---
+
+`vttforge audit` gains VTTF-AUDIT-022: source that talks on the package socket
+channel while the manifest has no `"socket": true`.
+
+Foundry opens the `module.<id>` / `system.<id>` channel only for a package that
+declares the flag. Without it `emit` returns without throwing, the message
+never leaves the client, and nothing is logged. The listener on the other
+machine is bound and correct and never fires, so the search goes to the
+handler, the payload and the user permissions, and the manifest is the last
+place anyone looks.
+
+The rule wants the package channel. Core events ride the same socket under
+their own names and need no flag, so `game.socket.on('userActivity', ...)` on
+its own is not a finding. A file that names `module.<id>` or `system.<id>`, or
+that calls `registerSocket`, is. Calls quoted in comments are skipped.

--- a/.changeset/cli-audit-socket-flag.md
+++ b/.changeset/cli-audit-socket-flag.md
@@ -16,3 +16,6 @@ The rule wants the package channel. Core events ride the same socket under
 their own names and need no flag, so `game.socket.on('userActivity', ...)` on
 its own is not a finding. A file that names `module.<id>` or `system.<id>`, or
 that calls `registerSocket`, is. Calls quoted in comments are skipped.
+
+The project templates pin `@vttforge/cli` by minor, so they move to the
+release that carries the rule.

--- a/apps/docs/src/guide/cli.md
+++ b/apps/docs/src/guide/cli.md
@@ -104,6 +104,12 @@ deprecation warning that turns into a removal two versions from now.
 | `VTTF-AUDIT-019` | MEDIUM | A bare v13 global alias (`renderTemplate`, `ActorSheet`, `Actors`, `TextEditor`, `ChatLog`, ...); it warns on v14 and throws on v15, and the namespaced path is the same object |
 | `VTTF-AUDIT-020` | HIGH | A release workflow that zips the checkout of a project that builds to `dist/`, or builds and then zips the source tree; the published package has no entry file and no world starts on it |
 | `VTTF-AUDIT-021` | HIGH | A template that calls <code v-pre>{{#select}}</code> or <code v-pre>{{colorPicker}}</code>; v14 removed both, so the template throws "Missing helper" and whatever renders it never opens |
+| `VTTF-AUDIT-022` | HIGH | Source that talks on the package socket channel while the manifest has no `"socket": true`; Foundry never opens the channel, the emit returns without an error, and no listener anywhere fires |
+
+Rule 022 wants the package channel, not the socket. Core events ride the same
+socket under their own names and work without the flag, so a bare
+`game.socket.on('userActivity', ...)` is not a finding. A file naming
+`module.<id>` or `system.<id>`, or calling `registerSocket`, is.
 
 Rule 020 only fires for a project on the vite plugin (or a `build` script that
 runs vite), and only for a workflow that publishes a zip or a manifest. Rules

--- a/packages/cli/src/__tests__/audit-socket-flag.test.ts
+++ b/packages/cli/src/__tests__/audit-socket-flag.test.ts
@@ -1,0 +1,95 @@
+/**
+ * VTTF-AUDIT-022: a package that talks over its own socket channel while the
+ * manifest never declares one. Foundry drops the emit and logs nothing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runSourceRules } from '../audit/source-rules.js';
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'vttf-socket-'));
+});
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+async function project(manifest: Record<string, unknown>, source: string): Promise<void> {
+  await writeFile(join(cwd, 'module.json'), JSON.stringify({ id: 'my-module', ...manifest }));
+  await mkdir(join(cwd, 'scripts'), { recursive: true });
+  await writeFile(join(cwd, 'scripts', 'main.mjs'), source);
+}
+
+async function findings(): Promise<ReturnType<typeof runSourceRules>> {
+  const all = await runSourceRules(cwd);
+  return all.filter((f) => f.ruleId === 'VTTF-AUDIT-022') as never;
+}
+
+describe('VTTF-AUDIT-022', () => {
+  it('flags a raw emit on the package channel', async () => {
+    await project(
+      {},
+      `const CHANNEL = 'module.my-module';
+game.socket.on(CHANNEL, (data) => console.log(data));
+game.socket.emit(CHANNEL, { hello: true });`,
+    );
+
+    const found = await findings();
+    expect(found).toHaveLength(1);
+    expect(found[0]?.severity).toBe('HIGH');
+    expect(found[0]?.message).toContain('"socket": true');
+    // The call without its open paren, and the manifest by name.
+    expect(found[0]?.message).toContain('`game.socket.on`');
+    expect(found[0]?.message).toContain('module.json');
+    expect(found[0]?.line).toBe(2);
+  });
+
+  it('flags registerSocket on its own, with no channel string in sight', async () => {
+    await project({}, `import { registerSocket } from '@vttforge/core';\nregisterSocket({});`);
+    expect(await findings()).toHaveLength(1);
+  });
+
+  it('says nothing once the manifest declares the socket', async () => {
+    await project(
+      { socket: true },
+      `game.socket.emit('module.my-module', { hello: true });\nregisterSocket({});`,
+    );
+    expect(await findings()).toEqual([]);
+  });
+
+  it('leaves a core socket event alone', async () => {
+    // Core events travel the same socket under their own names. They work
+    // without the manifest flag, and flagging them would train people to
+    // ignore the rule.
+    await project({}, `game.socket.on('userActivity', (id, activity) => track(id, activity));`);
+    expect(await findings()).toEqual([]);
+  });
+
+  it('leaves a call quoted in a comment alone', async () => {
+    await project(
+      {},
+      `/**
+ * How to use this module from a macro:
+ *   game.socket.emit('module.my-module', { hello: true });
+ */
+export function nothing() {}`,
+    );
+    expect(await findings()).toEqual([]);
+  });
+
+  it('reports once per file, not once per call', async () => {
+    await project(
+      {},
+      `const C = 'module.my-module';
+game.socket.emit(C, { a: 1 });
+game.socket.emit(C, { b: 2 });
+game.socket.emit(C, { c: 3 });`,
+    );
+    expect(await findings()).toHaveLength(1);
+  });
+});

--- a/packages/cli/src/audit/index.ts
+++ b/packages/cli/src/audit/index.ts
@@ -4,7 +4,7 @@
  *
  * Rule organisation:
  *   - manifest-rules.ts → VTTF-AUDIT-001, 002, 003 (manifest-only)
- *   - source-rules.ts   → VTTF-AUDIT-004, 005, 006, 007 (source walker
+ *   - source-rules.ts   → VTTF-AUDIT-004, 005, 006, 007, 022 (source walker
  *                         + cross-check with manifest where needed)
  *   - template-rules.ts → VTTF-AUDIT-008 (the Handlebars, cross-checked
  *                         against which base each sheet is built on)

--- a/packages/cli/src/audit/source-rules.ts
+++ b/packages/cli/src/audit/source-rules.ts
@@ -10,6 +10,8 @@
  *   VTTF-AUDIT-006 (LOW)   : `_addDataFieldMigrations` override (wrong signature)
  *   VTTF-AUDIT-007 (MEDIUM): manifest primary/secondaryTokenAttribute not matched
  *                             by a `value`/`max` SchemaField in source
+ *   VTTF-AUDIT-022 (HIGH)  : source talks over the socket, manifest does not
+ *                             declare `"socket": true`
  *
  * Regex-based on purpose: avoids pulling in a TypeScript AST dependency
  * for what amount to four pattern checks. The trade-off is occasional
@@ -19,8 +21,25 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
+import { maskComments } from './mask.js';
 import type { RuleResult } from './types.js';
+
+/**
+ * `registerSocket` binds `game.socket.on` on the package channel and emits on
+ * it, so it carries the manifest requirement on its own.
+ */
+const REGISTER_SOCKET = /\bregisterSocket\s*\(/;
+
+/** A raw `game.socket.emit(` or `game.socket.on(`. */
+const RAW_SOCKET_CALL = /\bgame\s*\.\s*socket\s*\.\s*(?:emit|on)\s*\(/;
+
+/**
+ * The package channel, in a string or a template literal. Core events travel
+ * the same socket under their own names, and those need no manifest flag, so
+ * a raw call only counts when the file also names a package channel.
+ */
+const PACKAGE_CHANNEL = /['"`](?:module|system)\.[^'"`\s]*/;
 
 /** Directories we never descend into; they are not user source. */
 const EXCLUDED_DIRS = new Set([
@@ -1063,6 +1082,55 @@ function lastSegment(path: string): string {
 }
 
 /** Entry point: gather everything once, then dispatch to the per-file rules. */
+/**
+ * VTTF-AUDIT-022 (HIGH): the source uses the package socket, the manifest
+ * does not declare it.
+ *
+ * Foundry only opens the `module.<id>` / `system.<id>` channel for a package
+ * whose manifest carries `"socket": true`. Without the flag, `emit` returns
+ * without throwing and the message never leaves the client. Nothing is
+ * logged. The listener on the other machine is bound and correct, and it
+ * never fires, so the search goes to the handler and the payload shape and
+ * the user permissions, and the manifest is the last place anyone looks.
+ */
+function rule022(
+  manifestPath: string | null,
+  manifestRaw: string | null,
+  manifestParsed: Record<string, unknown> | null,
+  contents: Map<string, string>,
+): RuleResult[] {
+  if (!manifestPath || !manifestRaw || !manifestParsed) return [];
+  if (manifestParsed.socket === true) return [];
+  const manifestName = basename(manifestPath);
+
+  const out: RuleResult[] = [];
+  for (const [file, content] of contents) {
+    // A call quoted in a JSDoc block is documentation, not a socket.
+    const code = maskComments(content);
+    const registered = REGISTER_SOCKET.exec(code);
+    // A raw call only counts when the file also names a package channel.
+    // Core events ride the same socket under their own names and need no
+    // manifest flag.
+    const raw = PACKAGE_CHANNEL.test(code) ? RAW_SOCKET_CALL.exec(code) : null;
+    const match = registered ?? raw;
+    if (match?.index === undefined) continue;
+    // `game . socket . emit (` as written, without the open paren.
+    const call = match[0].replace(/\s*\($/, '').replaceAll(/\s+/g, '');
+    out.push({
+      ruleId: 'VTTF-AUDIT-022',
+      title: 'Socket use with no "socket": true in the manifest',
+      severity: 'HIGH',
+      filePath: file,
+      // maskComments keeps every index, so the offset is the real one.
+      line: content.slice(0, match.index).split('\n').length,
+      message: `This file calls \`${call}\`, and ${manifestName} has no \`"socket": true\`. Foundry never opens the package channel, so every emit is dropped without an error and no listener on any other client fires.`,
+      remediation:
+        'Add `"socket": true` to the manifest, then restart the world. Foundry reads the flag when the package loads, so a running world keeps the old answer.',
+    });
+  }
+  return out;
+}
+
 export async function runSourceRules(cwd: string): Promise<RuleResult[]> {
   if (!existsSync(cwd)) return [];
   const info = await stat(cwd);
@@ -1097,6 +1165,7 @@ export async function runSourceRules(cwd: string): Promise<RuleResult[]> {
   results.push(
     ...(await rule007(manifestPath, manifestRaw, manifestParsed, sourceFiles, classToSubtypes)),
   );
+  results.push(...rule022(manifestPath, manifestRaw, manifestParsed, contents));
   return results;
 }
 

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -16,7 +16,7 @@
     "@vttforge/core": "^0.18.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.15.0",
+    "@vttforge/cli": "^0.16.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -17,7 +17,7 @@
     "@vttforge/core": "^0.18.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.15.0",
+    "@vttforge/cli": "^0.16.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -17,7 +17,7 @@
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.15.0",
+    "@vttforge/cli": "^0.16.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -18,7 +18,7 @@
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.15.0",
+    "@vttforge/cli": "^0.16.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"


### PR DESCRIPTION
Foundry opens the `module.<id>` / `system.<id>` channel only for a package whose manifest carries `"socket": true`. Without the flag, `emit` returns without throwing, the message never leaves the client, and nothing is logged. The listener on the other machine is bound and correct and never fires.

So the search goes to the handler, then the payload shape, then the user permissions. The manifest is the last place anyone looks. VTTF-AUDIT-022 is HIGH and reports once per file.

```
### `VTTF-AUDIT-022`: Socket use with no "socket": true in the manifest

- file: `scripts/main.mjs:4`
- message: This file calls `game.socket.on`, and module.json has no `"socket": true`.
  Foundry never opens the package channel, so every emit is dropped without an error
  and no listener on any other client fires.
- fix: Add `"socket": true` to the manifest, then restart the world. Foundry reads the
  flag when the package loads, so a running world keeps the old answer.
```

## What counts

The rule wants the package channel, not the socket. Core events ride the same socket under their own names and work without the flag, so a bare `game.socket.on('userActivity', ...)` is not a finding. Two things are:

- a file that names `module.<id>` or `system.<id>` alongside a `game.socket.emit` or `.on` call
- a file that calls `registerSocket`, which binds the package channel on its own

Comments are masked before matching, the way rules 011 to 019 do it, so a call quoted in a JSDoc block is documentation.

## Checked against real code

Seven packages ported to the SDK, none of which declares a socket: no findings. A module that emits on its own channel with no flag: one finding, at the right line. Six unit tests cover both directions plus the comment case and the repeat.