### PR TITLE
fix(cli): refuse a flag we do not know and a value we do not accept

### DIFF
--- a/.changeset/cli-strict-flags.md
+++ b/.changeset/cli-strict-flags.md
@@ -1,0 +1,29 @@
+---
+'@vttforge/cli': minor
+---
+
+A call that used to succeed now exits 1. `vttforge init` refuses a flag it
+does not know and a value it does not accept, instead of carrying on. A script
+or a CI job passing either one starts failing on upgrade, which is the point:
+it was not doing what it asked for.
+
+Two ways to lose. An unknown flag was collected and ignored, so
+`vttforge init app --template module-ts` exited 0 and scaffolded a system: the
+flag does not exist, and nothing said so. A known flag with an unrecognised
+value fell back to the default, so `--type modul` also produced a system, with
+`system.json` and every system template file in it. Both surface much later,
+usually in Foundry.
+
+`--type` and `--lang` now list what they take, in the error and in `--help`.
+An unknown flag names itself and the command's real flags. Both exit 1 and
+write nothing. Every command carries the unknown-flag check, not only `init`.
+
+`vttforge migrate` had the same fallback on `--style` and `--lang`, where a
+typo wrote the wrong kind of file. Both are checked now too.
+
+`create-vttforge` does the same. It used to skip unknown flags on purpose, to
+keep the create flow from crashing; the cost was a scaffold that silently
+ignored what was asked for.
+
+The project templates pin `@vttforge/cli` by minor, so they move to the
+release that carries this.

--- a/packages/cli/src/__tests__/cli-args.test.ts
+++ b/packages/cli/src/__tests__/cli-args.test.ts
@@ -160,3 +160,52 @@ describe('migrate args', () => {
     expect(args.write).toBe(true);
   });
 });
+
+describe('a value the flag does not accept', () => {
+  it.each([
+    ['--type', 'modul', 'system, module'],
+    ['--lang', 'typescript', 'ts, js'],
+  ])('refuses %s %s and lists what it takes', (flag, value, expected) => {
+    // Before, the parser handed the typo through and the scaffolder fell back
+    // to its default: `--type modul` built a system, exit code 0.
+    expect(() => parse(init, ['my-sys', flag, value])).toThrow(
+      new RegExp(
+        `${flag.slice(2)}[\\s\\S]*${value}[\\s\\S]*${expected.split(', ').join('[\\s\\S]*')}`,
+      ),
+    );
+  });
+
+  it.each([
+    ['--type', 'module'],
+    ['--type', 'system'],
+    ['--lang', 'ts'],
+    ['--lang', 'js'],
+  ])('takes %s %s', (flag, value) => {
+    expect(() => parse(init, ['my-sys', flag, value])).not.toThrow();
+  });
+
+  it('leaves the flag out entirely alone, so the prompt still runs', () => {
+    const args = parse(init, ['my-sys']);
+    expect(args.type).toBeUndefined();
+    expect(args.lang).toBeUndefined();
+  });
+});
+
+describe('migrate values', () => {
+  it.each([
+    ['--style', 'sdkk', 'plain[\\s\\S]*sdk'],
+    ['--lang', 'typescript', 'js[\\s\\S]*ts'],
+  ])('refuses %s %s', (flag, value, expected) => {
+    // Both used to fall back to their default and write the wrong output.
+    expect(() => parse(migrate, ['--data-models', flag, value])).toThrow(new RegExp(expected));
+  });
+
+  it.each([
+    ['--style', 'sdk'],
+    ['--style', 'plain'],
+    ['--lang', 'ts'],
+    ['--lang', 'js'],
+  ])('takes %s %s', (flag, value) => {
+    expect(() => parse(migrate, ['--data-models', flag, value])).not.toThrow();
+  });
+});

--- a/packages/cli/src/__tests__/init-non-interactive.test.ts
+++ b/packages/cli/src/__tests__/init-non-interactive.test.ts
@@ -91,3 +91,36 @@ describe('runInit without a terminal', () => {
     expect(readJson(cwd, 'forced', 'module.json').id).toBe('forced');
   });
 });
+
+describe('a type or lang the scaffolder does not recognise', () => {
+  // `create-vttforge` calls runInit directly, so the check has to live here
+  // and not only in the argument parser.
+  it.each([
+    ['type', 'modul', /--type expects `system` or `module`, got `modul`/],
+    ['lang', 'typescript', /--lang expects `ts` or `js`, got `typescript`/],
+  ])('refuses %s=%s and says what it takes', async (key, value, expected) => {
+    await expect(
+      runInit({
+        cwd,
+        name: 'app',
+        [key]: value,
+        noInstall: true,
+        noGit: true,
+      } as Parameters<typeof runInit>[0]),
+    ).rejects.toThrow(expected);
+  });
+
+  it('scaffolds nothing when it refuses', async () => {
+    await expect(
+      runInit({ cwd, name: 'app', type: 'modul' as 'module', noInstall: true, noGit: true }),
+    ).rejects.toBeInstanceOf(ScaffoldError);
+    // The failure people hit: a typo in --type produced a system, quietly.
+    expect(() => readJson(cwd, 'app', 'system.json')).toThrow();
+    expect(() => readJson(cwd, 'app', 'module.json')).toThrow();
+  });
+
+  it('still defaults when the option is simply absent', async () => {
+    await runInit({ cwd, name: 'app', noInstall: true, noGit: true });
+    expect(readJson(cwd, 'app', 'system.json').type).toBe('system');
+  });
+});

--- a/packages/cli/src/__tests__/strict-args.test.ts
+++ b/packages/cli/src/__tests__/strict-args.test.ts
@@ -1,0 +1,96 @@
+/**
+ * A flag the command does not define used to be collected, ignored and
+ * forgotten. `vttforge init app --typ module` scaffolded a system and exited
+ * 0, and a README naming a flag that no longer exists did the same.
+ */
+import type { ArgsDef } from 'citty';
+import { parseArgs } from 'citty';
+import { describe, expect, it } from 'vitest';
+import { audit, build, dev, init, lint, migrate } from '../cli.js';
+import { unknownArgs } from '../strict-args.js';
+
+const defOf = (cmd: { args?: unknown }) => (cmd.args ?? {}) as ArgsDef;
+const unknownIn = (cmd: { args?: unknown }, argv: string[]) =>
+  unknownArgs(parseArgs(argv, defOf(cmd)) as Record<string, unknown>, defOf(cmd));
+
+describe('unknownArgs', () => {
+  it('names a flag the command does not define', () => {
+    expect(unknownIn(init, ['app', '--type', 'module', '--wat=42'])).toEqual(['wat']);
+  });
+
+  it('names every one of them, in the order given', () => {
+    expect(unknownIn(init, ['app', '--wat=1', '--nope=2'])).toEqual(['wat', 'nope']);
+  });
+
+  it('says nothing about a command called correctly', () => {
+    expect(
+      unknownIn(init, [
+        'app',
+        '--type',
+        'module',
+        '--lang',
+        'ts',
+        '-y',
+        '--no-install',
+        '--no-git',
+      ]),
+    ).toEqual([]);
+  });
+
+  it('takes an alias, and either case of a two-word flag', () => {
+    // The parser answers to a flag under several keys at once. Every one of
+    // them has to pass, or a correct call would be refused.
+    expect(unknownIn(dev, ['--data-dir', '/x'])).toEqual([]);
+    expect(unknownIn(dev, ['--foundry-data', '/x'])).toEqual([]);
+    expect(unknownIn(dev, ['--foundryData', '/x'])).toEqual([]);
+  });
+
+  it('leaves the positional alone', () => {
+    expect(unknownIn(init, ['my-module'])).toEqual([]);
+  });
+
+  it.each([
+    ['init', init],
+    ['dev', dev],
+    ['build', build],
+    ['lint', lint],
+    ['audit', audit],
+    ['migrate', migrate],
+  ])('%s carries the check', (_name, cmd) => {
+    // The plugin has to be on each command. A subcommand runs its own plugin
+    // list, not its parent's, so putting it on the root would cover nothing.
+    const plugins = (cmd as { plugins?: Array<{ name?: string }> }).plugins ?? [];
+    expect(plugins.map((plugin) => plugin.name)).toContain('vttforge:strict-args');
+  });
+
+  it.each([
+    ['init', init],
+    ['dev', dev],
+    ['build', build],
+    ['lint', lint],
+    ['audit', audit],
+    ['migrate', migrate],
+  ])('%s defines no cleanup hook', (_name, cmd) => {
+    // The plugin refuses an unknown flag by exiting, which walks past
+    // citty's cleanup hooks. Nothing defines one today. The day something
+    // does, this fails, and the plugin has to stop exiting rather than
+    // skipping a teardown in silence.
+    expect((cmd as { cleanup?: unknown }).cleanup).toBeUndefined();
+  });
+
+  it.each([
+    ['init', init],
+    ['dev', dev],
+    ['build', build],
+    ['lint', lint],
+    ['audit', audit],
+    ['migrate', migrate],
+  ])('%s still accepts every flag it declares', (_name, cmd) => {
+    // Guards the fold: a declared flag must never read as unknown.
+    const names = Object.entries(defOf(cmd))
+      .filter(([, def]) => (def as { type?: string }).type !== 'positional')
+      .map(([name]) => name);
+    const args = Object.fromEntries(names.map((name) => [name, 'x']));
+    expect(unknownArgs(args, defOf(cmd))).toEqual([]);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,8 +15,10 @@ import { runInit, ScaffoldError } from './commands/init.js';
 import { runLintCommand } from './commands/lint.js';
 import { runMigrateCommand } from './commands/migrate.js';
 import { VTTFORGE_CLI_VERSION } from './index.js';
+import { strictArgs } from './strict-args.js';
 
 export const init = defineCommand({
+  plugins: [strictArgs],
   meta: {
     name: 'init',
     description: 'Scaffold a new Foundry VTT system or module from a VTTForge template',
@@ -27,12 +29,18 @@ export const init = defineCommand({
       description: 'Directory name for the new system/module (also the default manifest id)',
       required: false,
     },
+    // `enum` rather than `string`: citty then refuses a value that is not on
+    // the list and says which ones are, and `--help` prints them. As a plain
+    // string a typo fell through to the default and scaffolded the wrong
+    // thing without a word.
     type: {
-      type: 'string',
+      type: 'enum',
+      options: ['system', 'module'],
       description: 'Package type: system | module',
     },
     lang: {
-      type: 'string',
+      type: 'enum',
+      options: ['ts', 'js'],
       description: 'Language: ts | js',
     },
     id: {
@@ -105,6 +113,7 @@ export const init = defineCommand({
 });
 
 export const dev = defineCommand({
+  plugins: [strictArgs],
   meta: {
     name: 'dev',
     description: 'Symlink dist/ into Foundry Data and run vite build --watch',
@@ -145,6 +154,7 @@ export const dev = defineCommand({
 });
 
 export const build = defineCommand({
+  plugins: [strictArgs],
   meta: {
     name: 'build',
     description: 'Run vite build (production) and emit <id>-<version>.zip for foundryvtt.com',
@@ -160,6 +170,7 @@ export const build = defineCommand({
 });
 
 export const lint = defineCommand({
+  plugins: [strictArgs],
   meta: {
     name: 'lint',
     description: 'Run Biome (shipped with the CLI) over the project, then the v14 audit',
@@ -205,6 +216,7 @@ export const lint = defineCommand({
 });
 
 export const audit = defineCommand({
+  plugins: [strictArgs],
   meta: {
     name: 'audit',
     description:
@@ -247,6 +259,7 @@ export const audit = defineCommand({
 });
 
 export const migrate = defineCommand({
+  plugins: [strictArgs],
   meta: {
     name: 'migrate',
     description:
@@ -279,13 +292,17 @@ export const migrate = defineCommand({
       description:
         'Also generate a data model per template.json type (template.json is deprecated since v14)',
     },
+    // `enum`, for the same reason as `init`: as plain strings a typo landed
+    // on the default and wrote the wrong thing without a word.
     style: {
-      type: 'string',
+      type: 'enum',
+      options: ['plain', 'sdk'],
       default: 'plain',
       description: 'For --data-models: "plain" Foundry classes, or "sdk" classes on @vttforge/core',
     },
     lang: {
-      type: 'string',
+      type: 'enum',
+      options: ['js', 'ts'],
       default: 'js',
       description: 'For --data-models and --sheets: "js" writes .mjs, "ts" writes .ts',
     },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -198,8 +198,19 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
   }
 
   // --- type ------------------------------------------------------------------
+  // A value we do not recognise is a typo, and the two failures it used to
+  // cause were both quiet: without a terminal it fell through to the default
+  // and scaffolded a system, and with one it threw the answer away and asked
+  // the question again. Either way the flag the user passed did nothing and
+  // said nothing.
+  // Widened on purpose. The union is the contract for a programmatic caller;
+  // argv is a string and may hold anything.
+  const requestedType: string | undefined = options.type;
+  if (requestedType !== undefined && requestedType !== 'system' && requestedType !== 'module') {
+    bail(`--type expects \`system\` or \`module\`, got \`${requestedType}\`.`);
+  }
   let type = options.type;
-  if (type !== 'system' && type !== 'module' && !interactive) {
+  if (type === undefined && !interactive) {
     type = 'system';
   }
   if (type !== 'system' && type !== 'module') {
@@ -219,8 +230,12 @@ export async function runInit(options: InitOptions = {}): Promise<void> {
   }
 
   // --- lang ------------------------------------------------------------------
+  const requestedLang: string | undefined = options.lang;
+  if (requestedLang !== undefined && requestedLang !== 'ts' && requestedLang !== 'js') {
+    bail(`--lang expects \`ts\` or \`js\`, got \`${requestedLang}\`.`);
+  }
   let lang = options.lang;
-  if (lang !== 'ts' && lang !== 'js' && !interactive) {
+  if (lang === undefined && !interactive) {
     lang = 'ts';
   }
   if (lang !== 'ts' && lang !== 'js') {

--- a/packages/cli/src/strict-args.ts
+++ b/packages/cli/src/strict-args.ts
@@ -1,0 +1,78 @@
+/**
+ * Refuse a flag the command does not define.
+ *
+ * The argument parser collects anything that looks like a flag, whether or
+ * not the command declared it, and hands the whole lot to `run`. A command
+ * reads the keys it knows and never looks at the rest, so a typo does
+ * nothing and says nothing: `vttforge init app --typ module` scaffolds a
+ * system, exit code 0. The user finds out much later, usually from Foundry.
+ *
+ * This plugin runs before the command and stops on the first unknown flag.
+ */
+
+import { type ArgsDef, type CittyPlugin, defineCittyPlugin } from 'citty';
+
+/**
+ * One spelling of a flag name, for comparison.
+ *
+ * The parser answers to a flag under several keys: the declared name, its
+ * aliases, and the camelCase and kebab-case forms of each. Folding case and
+ * dropping the dashes covers all of them with one rule. It accepts a few
+ * spellings the parser would not produce on its own, which is the safe
+ * direction to be loose in: this check can then never reject a flag the
+ * command really does define.
+ */
+function fold(name: string): string {
+  return name.toLowerCase().replaceAll('-', '');
+}
+
+function acceptedNames(argsDef: ArgsDef): Set<string> {
+  const accepted = new Set<string>();
+  for (const [name, def] of Object.entries(argsDef)) {
+    accepted.add(fold(name));
+    const alias = (def as { alias?: string | string[] }).alias;
+    for (const entry of Array.isArray(alias) ? alias : alias ? [alias] : []) {
+      accepted.add(fold(entry));
+    }
+  }
+  return accepted;
+}
+
+/** The flags passed that the command does not define, in the order given. */
+export function unknownArgs(args: Record<string, unknown>, argsDef: ArgsDef): string[] {
+  const accepted = acceptedNames(argsDef);
+  return Object.keys(args).filter((key) => key !== '_' && !accepted.has(fold(key)));
+}
+
+/**
+ * Add to a command's `plugins`. It has to go on each command rather than on
+ * the root: a subcommand runs through its own plugin list, not its parent's.
+ */
+export const strictArgs: CittyPlugin = defineCittyPlugin({
+  name: 'vttforge:strict-args',
+  setup({ args, cmd }) {
+    // Resolved by the time a plugin runs. A command whose args are a promise
+    // or a function is not one of ours.
+    const argsDef = typeof cmd.args === 'object' && cmd.args !== null ? (cmd.args as ArgsDef) : {};
+    const unknown = unknownArgs(args as Record<string, unknown>, argsDef);
+    if (unknown.length === 0) return;
+
+    const named = unknown.map((flag) => `--${flag}`).join(', ');
+    const known = Object.keys(argsDef)
+      .filter((name) => (argsDef[name] as { type?: string }).type !== 'positional')
+      .map((name) => `--${name}`)
+      .join(', ');
+    // Resolved, like `args`, by the time a plugin runs.
+    const meta = cmd.meta as { name?: string } | undefined;
+    const label = meta?.name ? ` ${meta.name}` : '';
+    console.error(
+      `Unknown ${unknown.length === 1 ? 'flag' : 'flags'} for \`vttforge${label}\`: ${named}.`,
+    );
+    console.error(`This command takes: ${known}.`);
+    // Exiting here skips citty's `cleanup` hooks. No command defines one,
+    // and a test holds that true: a command that starts a watcher or a
+    // server would need its teardown to run, and this would walk past it.
+    // citty does not export `CLIError`, and any other throw prints a stack.
+    process.exit(1);
+  },
+}) as CittyPlugin;

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -16,7 +16,7 @@
     "@vttforge/core": "^0.18.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.16.0",
+    "@vttforge/cli": "^0.17.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -17,7 +17,7 @@
     "@vttforge/core": "^0.18.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.16.0",
+    "@vttforge/cli": "^0.17.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -17,7 +17,7 @@
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.16.0",
+    "@vttforge/cli": "^0.17.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -18,7 +18,7 @@
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {
-    "@vttforge/cli": "^0.16.0",
+    "@vttforge/cli": "^0.17.0",
     "@vttforge/vite-plugin": "^0.5.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"

--- a/packages/create-vttforge/bin.mjs
+++ b/packages/create-vttforge/bin.mjs
@@ -49,8 +49,12 @@ for (let i = 0; i < args.length; i += 1) {
     continue;
   }
   if (arg.startsWith('-')) {
-    // Unknown flag — skip silently rather than crash the create-* flow.
-    continue;
+    // Skipping this used to be deliberate, to keep the create-* flow from
+    // crashing. It cost more than it saved: the flag did nothing, nothing
+    // was printed, and the scaffold came out as whatever the defaults are.
+    console.error(`Unknown flag: ${arg}.`);
+    console.error('This command takes: --type (-t), --lang (-l), --no-install, --no-git.');
+    process.exit(1);
   }
   if (name === undefined) {
     name = arg;


### PR DESCRIPTION
Found while verifying the 0.18.0 release: my first scaffold attempt passed a flag that does not exist, and I got a system back with no complaint.

Two ways to lose, both quiet.

**An unknown flag was collected, ignored and forgotten.** `vttforge init app --template module-ts` exited 0 and scaffolded a system. That flag does not exist. A README naming an old flag did the same.

**A known flag with an unrecognised value fell back to its default.** `vttforge init app --type modul` also produced a system, `system.json` and every system template file in it. The user finds out much later, usually from Foundry.

## After

```
$ vttforge init app --type module --lang ts --wat=42
Unknown flag for `vttforge init`: --wat.
This command takes: --type, --lang, --id, --title, --description, --author, --license, --yes, --install, --git.

$ vttforge init app --type modul
Invalid value for argument: --type (modul). Expected one of: system, module.
```

Both exit 1 and write nothing. `--help` now prints `--type=<system|module>`.

## How

`--type` and `--lang` are enum arguments, so the parser rejects the value itself and lists what it takes. An unknown flag is caught by a plugin that goes on each command, not the root: a subcommand runs its own plugin list, not its parent's, so the root alone would cover nothing.

The value check also lives in `runInit`. `create-vttforge` calls that directly rather than through the parser, so the parser alone would leave the `pnpm create` path exactly as it was. That wrapper used to skip unknown flags on purpose, to keep the create flow from crashing; the cost was a scaffold that ignored what was asked for. It reports and stops now.

`vttforge migrate` had the same fallback on `--style` and `--lang`, one definition block away, where a typo wrote the wrong kind of file. Fixed with it. I stopped there rather than sweeping every string flag in the CLI.

## One thing worth knowing

The plugin refuses by exiting, which walks past citty's `cleanup` hooks. citty does not export `CLIError`, and any other throw prints a stack instead of a message. No command defines a cleanup hook today, and a test now holds that true: the day someone adds one to tear down a watcher or a server, that test fails and the plugin has to stop exiting rather than skip a teardown in silence.

## Checked

26 unit cases across the parser, the plugin and `runInit`, plus the built binary: three bad calls refused with nothing written, a correct call still produces `module.json`, the `create-vttforge` wrapper refuses both an unknown flag and a bad value while `-t` / `-l` still work, and `migrate --data-models` and `--sheets` still run on their defaults. That last one matters because those flags carry defaults and `init`'s do not, so the enum validation runs against a value `init` never supplies.

Breaking on a 0.x line, so the changeset is a minor and leads with it: a script passing either mistake starts failing on upgrade, which is the point.