### PR TITLE
feat(types): describe the documents the bases hand over

### DIFF
--- a/.changeset/template-pins-core-019.md
+++ b/.changeset/template-pins-core-019.md
@@ -1,0 +1,8 @@
+---
+"@vttforge/cli": patch
+---
+
+Point the scaffold templates at `@vttforge/core` 0.19, and use the document
+types it ships. The TypeScript templates no longer hand-write an interface for
+their own actor or item: they pass the schema to the sheet factory
+(`BaseActorSheet<CharacterActor>()`) and read `this.document` straight.

--- a/.changeset/wide-types-documents.md
+++ b/.changeset/wide-types-documents.md
@@ -17,10 +17,13 @@ Three places that returned `unknown` now return a document:
   `onDropActiveEffect` hand over the document that was dropped.
 - `this.parent` inside a `BaseTypeDataModel`. It did not compile before.
 
-Both sheet factories take the document type, so the schema follows through:
+Both sheet factories take the document type, so the schema follows through.
+`ActorLike` takes the item type too, which keeps `actor.items` typed:
 
 ```ts
-class CharacterSheet extends BaseActorSheet<ActorLike<CharacterSystem>>() {
+type CharacterActor = ActorLike<CharacterSystem, ItemLike<GearSystem>>;
+
+class CharacterSheet extends BaseActorSheet<CharacterActor>() {
   async _prepareContext(options: unknown) {
     const level = this.document.system.level; // number
     return { ...(await super._prepareContext(options)), level };

--- a/.changeset/wide-types-documents.md
+++ b/.changeset/wide-types-documents.md
@@ -1,0 +1,33 @@
+---
+"@vttforge/types": minor
+"@vttforge/core": minor
+---
+
+Type the documents the bases hand you.
+
+`@vttforge/types` now describes the document surface: `DocumentMembers`,
+`ActorLike`, `ItemLike`, `ActiveEffectLike`, `FolderLike`, `EmbeddedCollection`
+and `TypeDataModelMembers`. Core re-exports all of them.
+
+Three places that returned `unknown` now return a document:
+
+- `this.document` on an actor or item sheet. Reading `name`, `system` or
+  calling `update()` no longer needs a cast.
+- The drop hooks. `onDropItem`, `onDropActor`, `onDropFolder` and
+  `onDropActiveEffect` hand over the document that was dropped.
+- `this.parent` inside a `BaseTypeDataModel`. It did not compile before.
+
+Both sheet factories take the document type, so the schema follows through:
+
+```ts
+class CharacterSheet extends BaseActorSheet<ActorLike<CharacterSystem>>() {
+  async _prepareContext(options: unknown) {
+    const level = this.document.system.level; // number
+    return { ...(await super._prepareContext(options)), level };
+  }
+}
+```
+
+The member list came from the systems and modules already ported to the SDK:
+each one is a member their sheets and drop handlers read. Reaching past it is
+still a cast.

--- a/apps/docs/src/guide/sheets.md
+++ b/apps/docs/src/guide/sheets.md
@@ -58,33 +58,37 @@ export class PdfActorSheet extends BaseDocumentSheet('Actor') {
 It takes `'Actor'` or `'Item'`, and gives you the same `_renderHTML` /
 `_replaceHTML` contract as `BaseApplication`.
 
-### `this.document` is `unknown`
+### Naming the document
 
-The base does not know which document a sheet is for; that is yours to say.
-Narrow it once, in a getter, and read the typed value everywhere else:
+`this.document` comes back as `ActorLike` or `ItemLike`: `name`, `img`,
+`system`, `items`, `update()`, the flag helpers. That is enough for most
+sheets. To type `system` as your own schema, hand the type to the factory:
 
 ```ts
-interface CharacterActor {
-  readonly name: string;
-  readonly system: CharacterData;
-  readonly items: { get(id: string): GearItem | undefined };
-}
+import { BaseActorSheet, type ActorLike, type ItemLike } from "@vttforge/core";
 
-export class CharacterSheet extends BaseActorSheet() {
-  get actor(): CharacterActor {
-    return this.document as CharacterActor;
-  }
+type CharacterActor = ActorLike<CharacterData>;
 
+export class CharacterSheet extends BaseActorSheet<CharacterActor>() {
   override async _prepareContext(options: unknown) {
     const context = await super._prepareContext(options);
-    context.system = this.actor.system; // typed from the schema
+    context.system = this.document.system; // CharacterData
     return context;
   }
 }
 ```
 
-The interface names what the sheet reads, and it is the one place to change
-when a real Foundry type package lands.
+The drop hooks hand over the document too. TypeScript does not carry a base
+method's parameter types into an override, so write them out:
+
+```ts
+override async onDropItem(item: ItemLike<GearData>, event: DragEvent) {
+  await this.document.createEmbeddedDocuments("Item", [item.toObject()]);
+}
+```
+
+Reaching a member outside `ActorLike` or `ItemLike` still needs a cast. The
+list holds what the systems and modules already on the SDK read.
 
 ### `override` is not optional
 

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.18.0"
+    "@vttforge/core": "^0.19.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.17.0",

--- a/packages/cli/templates/module-ts/README.md
+++ b/packages/cli/templates/module-ts/README.md
@@ -49,8 +49,9 @@ saves that key on every item whose owner picked the sheet. Without an
 explicit id it derives the key from the class name, and a bundler renames
 classes between builds. Keep the ids.
 
-`this.document` is `unknown` on the sheet bases. The sheet narrows it once
-in a getter (`item`), and everything below reads typed.
+`this.document` is typed. The sheet hands its own schema to the base
+(`BaseItemSheet<NoteItem>()`), so `document.system` is `NoteData` and nothing
+casts.
 
 ## Public API
 

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.18.0"
+    "@vttforge/core": "^0.19.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.17.0",

--- a/packages/cli/templates/module-ts/scripts/sheets/note-sheet.ts
+++ b/packages/cli/templates/module-ts/scripts/sheets/note-sheet.ts
@@ -3,26 +3,19 @@
  *
  * One part, no tabs, one action. The smallest sheet a module can ship.
  */
-import { BaseItemSheet } from '@vttforge/core';
+import { BaseItemSheet, type ItemLike } from '@vttforge/core';
 import { MODULE_ID } from '../constants.js';
 import type { NoteData } from '../data/note-data.js';
 
 /**
- * What this sheet reads off its item.
+ * The item this sheet is for.
  *
- * Foundry's own `Item` type is not wired in — see `foundry-globals.ts` — so
- * the sheet says what it needs. Grow this as the sheet grows.
+ * `ItemLike` is the document surface `@vttforge/core` ships; the type
+ * argument is your own schema, so `item.system.body` is typed.
  */
-interface NoteItem {
-  readonly id: string;
-  readonly name: string;
-  readonly img: string;
-  readonly isOwner: boolean;
-  readonly system: NoteData;
-  update(changes: Record<string, unknown>): Promise<unknown>;
-}
+type NoteItem = ItemLike<NoteData>;
 
-export class NoteSheet extends BaseItemSheet() {
+export class NoteSheet extends BaseItemSheet<NoteItem>() {
   static override DEFAULT_OPTIONS = foundry.utils.mergeObject(
     super.DEFAULT_OPTIONS,
     {
@@ -47,11 +40,10 @@ export class NoteSheet extends BaseItemSheet() {
   /**
    * The item this sheet is for.
    *
-   * `this.document` is `unknown` on the base — which document a sheet is for
-   * is the module's to know. One cast, here, and everything below is typed.
+   * Typed by the argument to `BaseItemSheet`.
    */
   get item(): NoteItem {
-    return this.document as NoteItem;
+    return this.document;
   }
 
   override async _prepareContext(options: unknown): Promise<Record<string, unknown>> {

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.18.0",
+    "@vttforge/core": "^0.19.0",
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/README.md
+++ b/packages/cli/templates/system-ts/README.md
@@ -45,8 +45,9 @@ explicit id it derives the key from the class name, and a bundler renames
 classes between builds. Renaming an id loses the sheet choice on every
 document already using it.
 
-`this.document` is `unknown` on the sheet bases. Each sheet here narrows it
-once in a getter (`actor`, `item`), and everything below reads typed.
+`this.document` is typed. Each sheet here hands its own schema to the base
+(`BaseActorSheet<CharacterActor>()`), so `document.system` is `CharacterData`
+and nothing casts.
 
 ## Checks
 

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.18.0",
+    "@vttforge/core": "^0.19.0",
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
@@ -6,39 +6,20 @@
  * - `onDropItem(item, event)` — the item arrives resolved, not as a UUID.
  *   Return `false` to refuse, `undefined` to hand the drop back to Foundry.
  */
-import { BaseActorSheet } from '@vttforge/core';
+import { BaseActorSheet, type ActorLike, type ItemLike } from '@vttforge/core';
 import type { CharacterData } from '../data/character-data.js';
 import type { GearData } from '../data/gear-data.js';
 
 const SYSTEM_ID = '{{ID}}';
 
 /**
- * What this sheet reads off its actor.
+ * The actor this sheet is for, and the items on it.
  *
- * Foundry's own `Actor` type is not wired in — see `foundry-globals.ts` — so
- * the sheet says what it needs. Grow this as the sheet grows; it is the one
- * place to change when a real type package lands.
+ * `ActorLike` is the document surface `@vttforge/core` ships; the type
+ * argument is your own schema, so `actor.system.abilities` is typed.
  */
-interface CharacterActor {
-  readonly name: string;
-  readonly img: string;
-  readonly isOwner: boolean;
-  readonly system: CharacterData;
-  readonly items: {
-    filter(fn: (item: GearItem) => boolean): GearItem[];
-    get(id: string): GearItem | undefined;
-  };
-  getRollData(): Record<string, unknown>;
-}
-
-interface GearItem {
-  readonly id: string;
-  readonly name: string;
-  readonly img: string;
-  readonly type: string;
-  readonly system: GearData;
-  delete(): Promise<unknown>;
-}
+type CharacterActor = ActorLike<CharacterData>;
+type GearItem = ItemLike<GearData>;
 
 interface AbilityViewModel {
   key: string;
@@ -56,7 +37,7 @@ const ABILITY_LABELS: Record<string, string> = {
   cha: '{{LOCALE_PREFIX}}.Ability.cha',
 };
 
-export class CharacterSheet extends BaseActorSheet() {
+export class CharacterSheet extends BaseActorSheet<CharacterActor>() {
   static override DEFAULT_OPTIONS = foundry.utils.mergeObject(
     super.DEFAULT_OPTIONS,
     {
@@ -116,14 +97,9 @@ export class CharacterSheet extends BaseActorSheet() {
     { dragSelector: '.sh-item[draggable=true]', dropSelector: '.sh-body' },
   ];
 
-  /**
-   * The actor this sheet is for.
-   *
-   * `this.document` is `unknown` on the base — which document a sheet is for
-   * is the system's to know. One cast, here, and everything below is typed.
-   */
+  /** The actor this sheet is for. Typed by the argument to `BaseActorSheet`. */
   get actor(): CharacterActor {
-    return this.document as CharacterActor;
+    return this.document;
   }
 
   override async _prepareContext(options: unknown): Promise<Record<string, unknown>> {

--- a/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/character-sheet.ts
@@ -18,7 +18,7 @@ const SYSTEM_ID = '{{ID}}';
  * `ActorLike` is the document surface `@vttforge/core` ships; the type
  * argument is your own schema, so `actor.system.abilities` is typed.
  */
-type CharacterActor = ActorLike<CharacterData>;
+type CharacterActor = ActorLike<CharacterData, GearItem>;
 type GearItem = ItemLike<GearData>;
 
 interface AbilityViewModel {

--- a/packages/cli/templates/system-ts/scripts/sheets/gear-sheet.ts
+++ b/packages/cli/templates/system-ts/scripts/sheets/gear-sheet.ts
@@ -3,20 +3,15 @@
  *
  * Single part, one tab group, no drag-drop: the smallest useful sheet.
  */
-import { BaseItemSheet } from '@vttforge/core';
+import { BaseItemSheet, type ItemLike } from '@vttforge/core';
 import type { GearData } from '../data/gear-data.js';
 
 const SYSTEM_ID = '{{ID}}';
 
-/** What this sheet reads off its item. See `CharacterSheet` for the pattern. */
-interface GearItem {
-  readonly name: string;
-  readonly img: string;
-  readonly isOwner: boolean;
-  readonly system: GearData;
-}
+/** The item this sheet is for. See `CharacterSheet` for the pattern. */
+type GearItem = ItemLike<GearData>;
 
-export class GearSheet extends BaseItemSheet() {
+export class GearSheet extends BaseItemSheet<GearItem>() {
   static override DEFAULT_OPTIONS = foundry.utils.mergeObject(
     super.DEFAULT_OPTIONS,
     {
@@ -56,7 +51,7 @@ export class GearSheet extends BaseItemSheet() {
   };
 
   get item(): GearItem {
-    return this.document as GearItem;
+    return this.document;
   }
 
   override async _prepareContext(options: unknown): Promise<Record<string, unknown>> {

--- a/packages/core/src/__tests__/documents.test-d.ts
+++ b/packages/core/src/__tests__/documents.test-d.ts
@@ -1,0 +1,56 @@
+/**
+ * What a consumer gets back from the bases, pinned so it cannot narrow again.
+ *
+ * Each of these lines was a cast before `@vttforge/types` described the
+ * document surface. They compile now; if one stops compiling, the surface
+ * shrank and every sheet that reads it goes back to casting.
+ */
+import { describe, expectTypeOf, it } from 'vitest';
+import type { BaseActorSheet } from '../base-actor-sheet.js';
+import type { BaseItemSheet } from '../base-item-sheet.js';
+import type { FieldInstance } from '../data/fields.js';
+import type {
+  ActiveEffectLike,
+  ActorLike,
+  FolderLike,
+  ItemLike,
+  TypedTypeDataModel,
+} from '../index.js';
+
+declare const sheet: InstanceType<ReturnType<typeof BaseActorSheet>>;
+declare const itemSheet: InstanceType<ReturnType<typeof BaseItemSheet>>;
+
+type Sys = { readonly level: number };
+declare const typed: InstanceType<ReturnType<typeof BaseActorSheet<ActorLike<Sys>>>>;
+
+type Schema = Record<string, FieldInstance>;
+declare const data: TypedTypeDataModel<Schema, ActorLike>;
+
+describe('the sheet document', () => {
+  it('is a document, not an unknown', () => {
+    expectTypeOf(sheet.document.name).toEqualTypeOf<string>();
+    expectTypeOf(sheet.document.id).toEqualTypeOf<string | null>();
+    expectTypeOf(sheet.document.items.get('x')).toEqualTypeOf<ItemLike | undefined>();
+    expectTypeOf(itemSheet.document.actor).toEqualTypeOf<ActorLike | null>();
+  });
+
+  it('narrows to the system schema when the sheet says which', () => {
+    expectTypeOf(typed.document.system.level).toEqualTypeOf<number>();
+  });
+});
+
+describe('the drop hooks', () => {
+  it('hand over the document that was dropped', () => {
+    expectTypeOf(sheet.onDropItem).parameter(0).toEqualTypeOf<ItemLike>();
+    expectTypeOf(sheet.onDropActor).parameter(0).toEqualTypeOf<ActorLike>();
+    expectTypeOf(sheet.onDropFolder).parameter(0).toEqualTypeOf<FolderLike>();
+    expectTypeOf(sheet.onDropActiveEffect).parameter(0).toEqualTypeOf<ActiveEffectLike>();
+  });
+});
+
+describe('the type data model', () => {
+  it('reaches its owning document', () => {
+    expectTypeOf(data.parent.name).toEqualTypeOf<string>();
+    expectTypeOf(data.parent.items.get('x')).toEqualTypeOf<ItemLike | undefined>();
+  });
+});

--- a/packages/core/src/__tests__/documents.test-d.ts
+++ b/packages/core/src/__tests__/documents.test-d.ts
@@ -21,7 +21,8 @@ declare const sheet: InstanceType<ReturnType<typeof BaseActorSheet>>;
 declare const itemSheet: InstanceType<ReturnType<typeof BaseItemSheet>>;
 
 type Sys = { readonly level: number };
-declare const typed: InstanceType<ReturnType<typeof BaseActorSheet<ActorLike<Sys>>>>;
+type Gear = ItemLike<{ readonly quantity: number }>;
+declare const typed: InstanceType<ReturnType<typeof BaseActorSheet<ActorLike<Sys, Gear>>>>;
 
 type Schema = Record<string, FieldInstance>;
 declare const data: TypedTypeDataModel<Schema, ActorLike>;
@@ -30,19 +31,27 @@ describe('the sheet document', () => {
   it('is a document, not an unknown', () => {
     expectTypeOf(sheet.document.name).toEqualTypeOf<string>();
     expectTypeOf(sheet.document.id).toEqualTypeOf<string | null>();
-    expectTypeOf(sheet.document.items.get('x')).toEqualTypeOf<ItemLike | undefined>();
-    expectTypeOf(itemSheet.document.actor).toEqualTypeOf<ActorLike | null>();
+    // Asserted on a leaf: `expectTypeOf` walks structurally, and these types
+    // recurse (an item names its actor, which names its items).
+    expectTypeOf(sheet.document.items.filter(() => true)[0]?.name).toEqualTypeOf<
+      string | undefined
+    >();
+    expectTypeOf(itemSheet.document.actor?.name).toEqualTypeOf<string | undefined>();
   });
 
   it('narrows to the system schema when the sheet says which', () => {
     expectTypeOf(typed.document.system.level).toEqualTypeOf<number>();
+    // The collection keeps the item's schema; reading it was `unknown` before.
+    expectTypeOf(typed.document.items.filter(() => true)[0]?.system.quantity).toEqualTypeOf<
+      number | undefined
+    >();
   });
 });
 
 describe('the drop hooks', () => {
   it('hand over the document that was dropped', () => {
-    expectTypeOf(sheet.onDropItem).parameter(0).toEqualTypeOf<ItemLike>();
-    expectTypeOf(sheet.onDropActor).parameter(0).toEqualTypeOf<ActorLike>();
+    expectTypeOf(sheet.onDropItem).parameter(0).toExtend<ItemLike>();
+    expectTypeOf(sheet.onDropActor).parameter(0).toExtend<ActorLike>();
     expectTypeOf(sheet.onDropFolder).parameter(0).toEqualTypeOf<FolderLike>();
     expectTypeOf(sheet.onDropActiveEffect).parameter(0).toEqualTypeOf<ActiveEffectLike>();
   });
@@ -51,6 +60,6 @@ describe('the drop hooks', () => {
 describe('the type data model', () => {
   it('reaches its owning document', () => {
     expectTypeOf(data.parent.name).toEqualTypeOf<string>();
-    expectTypeOf(data.parent.items.get('x')).toEqualTypeOf<ItemLike | undefined>();
+    expectTypeOf(data.parent.items.filter(() => true)[0]?.name).toEqualTypeOf<string | undefined>();
   });
 });

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -30,7 +30,13 @@
  */
 
 import { VttfError } from './errors/registry.js';
-import type { DocumentSheetV2Members } from './foundry-base.js';
+import type {
+  ActiveEffectLike,
+  ActorLike,
+  DocumentSheetV2Members,
+  FolderLike,
+  ItemLike,
+} from './foundry-base.js';
 import {
   applyMode,
   currentMode,
@@ -113,11 +119,20 @@ export interface SheetBaseMembers {
   /**
    * The typed drop hooks. Override the one you want; returning `undefined`
    * hands the drop back to Foundry's own handling.
+   *
+   * TypeScript does not carry a base method's parameter types into an
+   * override, so write them out to get the document typed:
+   *
+   * ```ts
+   * async onDropItem(item: ItemLike, event: DragEvent) {
+   *   await this.document.createEmbeddedDocuments('Item', [item.toObject()]);
+   * }
+   * ```
    */
-  onDropItem(item: unknown, event: DragEvent): Promise<unknown>;
-  onDropActor(actor: unknown, event: DragEvent): Promise<unknown>;
-  onDropFolder(folder: unknown, event: DragEvent): Promise<unknown>;
-  onDropActiveEffect(effect: unknown, event: DragEvent): Promise<unknown>;
+  onDropItem(item: ItemLike, event: DragEvent): Promise<unknown>;
+  onDropActor(actor: ActorLike, event: DragEvent): Promise<unknown>;
+  onDropFolder(folder: FolderLike, event: DragEvent): Promise<unknown>;
+  onDropActiveEffect(effect: ActiveEffectLike, event: DragEvent): Promise<unknown>;
 
   /**
    * Foundry's own drop entry points, implemented here to resolve the payload
@@ -133,9 +148,9 @@ export interface SheetBaseMembers {
   _onDropActiveEffect(event: DragEvent, data: unknown): Promise<unknown>;
 }
 
-export interface SheetBaseCtor extends SheetBaseStatics {
+export interface SheetBaseCtor<TDocument = ActorLike> extends SheetBaseStatics {
   // biome-ignore lint/suspicious/noExplicitAny: mirrors ApplicationV2's constructor arity, which subclasses pass straight through
-  new (...args: any[]): SheetBaseMembers & DocumentSheetV2Members;
+  new (...args: any[]): SheetBaseMembers & DocumentSheetV2Members<TDocument>;
 }
 
 interface DragDropInstance {
@@ -241,7 +256,9 @@ export const VTTFORGE_SHEET_CLASS = 'vttforge';
  * }
  * ```
  */
-export function BaseActorSheet(): SheetBaseCtor {
+export function BaseActorSheet<
+  TDocument extends ActorLike<unknown> = ActorLike,
+>(): SheetBaseCtor<TDocument> {
   const { Base, mixin } = resolveBases();
   const Mixed = mixin(Base);
 
@@ -493,5 +510,5 @@ export function BaseActorSheet(): SheetBaseCtor {
     }
   }
 
-  return VttforgeBaseActorSheet as unknown as SheetBaseCtor;
+  return VttforgeBaseActorSheet as unknown as SheetBaseCtor<TDocument>;
 }

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -257,7 +257,7 @@ export const VTTFORGE_SHEET_CLASS = 'vttforge';
  * ```
  */
 export function BaseActorSheet<
-  TDocument extends ActorLike<unknown> = ActorLike,
+  TDocument extends ActorLike<unknown, ItemLike<unknown>> = ActorLike,
 >(): SheetBaseCtor<TDocument> {
   const { Base, mixin } = resolveBases();
   const Mixed = mixin(Base);

--- a/packages/core/src/base-item-sheet.ts
+++ b/packages/core/src/base-item-sheet.ts
@@ -17,6 +17,7 @@
 import type { DragDropConfig, SheetBaseCtor } from './base-actor-sheet.js';
 import { VTTFORGE_SHEET_CLASS } from './base-actor-sheet.js';
 import { VttfError } from './errors/registry.js';
+import type { ItemLike } from './foundry-base.js';
 import {
   applyMode,
   currentMode,
@@ -108,7 +109,9 @@ function resolveDragDrop(): DragDropCtor | undefined {
  * }
  * ```
  */
-export function BaseItemSheet(): SheetBaseCtor {
+export function BaseItemSheet<
+  TDocument extends ItemLike<unknown> = ItemLike,
+>(): SheetBaseCtor<TDocument> {
   const { Base, mixin } = resolveBases();
   const Mixed = mixin(Base);
 
@@ -255,5 +258,5 @@ export function BaseItemSheet(): SheetBaseCtor {
     }
   }
 
-  return VttforgeBaseItemSheet as unknown as SheetBaseCtor;
+  return VttforgeBaseItemSheet as unknown as SheetBaseCtor<TDocument>;
 }

--- a/packages/core/src/base-type-data-model.ts
+++ b/packages/core/src/base-type-data-model.ts
@@ -23,7 +23,7 @@
 import type { FieldInstance } from './data/fields.js';
 import type { InferSchema } from './data/infer-schema.js';
 import { VttfError } from './errors/registry.js';
-import type { VttforgeClass } from './foundry-base.js';
+import type { DocumentMembers, TypeDataModelMembers, VttforgeClass } from './foundry-base.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: we mix into Foundry's TypeDataModel whose shape lives in fvtt-types (deferred to @vttforge/types v1.0)
 type AnyConstructor = new (...args: any[]) => any;
@@ -50,7 +50,7 @@ function resolveTypeDataModelClass(): AnyConstructor {
  * lazy-resolves the global at the moment of subclassing.
  */
 /** The two hooks this base fills in, so a subclass can omit either. */
-export interface TypeDataModelHooks {
+export interface TypeDataModelHooks extends TypeDataModelMembers {
   prepareBaseData(): void;
   prepareDerivedData(): void;
 }
@@ -69,8 +69,12 @@ export interface TypeDataModelHooks {
  * declare armorClass: number;
  * ```
  */
-export type TypedTypeDataModel<S extends Record<string, FieldInstance>> = InferSchema<S> &
-  TypeDataModelHooks & {
+export type TypedTypeDataModel<
+  S extends Record<string, FieldInstance>,
+  Parent = DocumentMembers,
+> = InferSchema<S> &
+  TypeDataModelHooks &
+  TypeDataModelMembers<Parent> & {
     /**
      * Phantom property carrying the schema's inferred shape. Never assigned,
      * never present at runtime; it exists so the type has a name:
@@ -112,6 +116,19 @@ export function BaseTypeDataModel(): VttforgeClass<TypeDataModelHooks>;
  *   declare armorClass: number;
  *   prepareDerivedData() {
  *     this.armorClass = 10 + this.level; // this.level is number
+ *   }
+ * }
+ * ```
+ *
+ * `this.parent` is the document this data belongs to. It comes back as the
+ * shared document surface, since nothing said which kind of document holds
+ * this schema. Name the kind to reach `items` and the rest:
+ *
+ * ```ts
+ * class CharacterData extends BaseTypeDataModel(defineCharacterSchema) {
+ *   declare parent: ActorLike;
+ *   prepareDerivedData() {
+ *     this.carried = this.parent.items.reduce((n) => n + 1, 0);
  *   }
  * }
  * ```

--- a/packages/core/src/foundry-base.ts
+++ b/packages/core/src/foundry-base.ts
@@ -47,7 +47,16 @@
  */
 
 export type {
+  ActiveEffectLike,
+  ActorLike,
   ApplicationV2Members,
+  DocumentFlags,
+  DocumentMembers,
   DocumentSheetV2Members,
+  EmbeddedCollection,
+  EmbeddedDocumentOwner,
+  FolderLike,
+  ItemLike,
+  TypeDataModelMembers,
   VttforgeClass,
 } from '@vttforge/types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,8 +147,17 @@ export {
   type VttfErrorEntry,
 } from './errors/registry.js';
 export type {
+  ActiveEffectLike,
+  ActorLike,
   ApplicationV2Members,
+  DocumentFlags,
+  DocumentMembers,
   DocumentSheetV2Members,
+  EmbeddedCollection,
+  EmbeddedDocumentOwner,
+  FolderLike,
+  ItemLike,
+  TypeDataModelMembers,
   VttforgeClass,
 } from './foundry-base.js';
 export type {

--- a/packages/types/src/documents.ts
+++ b/packages/types/src/documents.ts
@@ -106,11 +106,18 @@ export interface ItemLike<System = Record<string, unknown>>
   getRollData(): Record<string, unknown>;
 }
 
-/** An Actor, as a sheet holds one and a drop hands one over. */
-export interface ActorLike<System = Record<string, unknown>>
-  extends DocumentMembers<System>,
+/**
+ * An Actor, as a sheet holds one and a drop hands one over.
+ *
+ * `Item` is what `actor.items` holds. It defaults to the shared item surface;
+ * name your own item type to read its schema off a collection entry.
+ */
+export interface ActorLike<
+  System = Record<string, unknown>,
+  Item extends ItemLike<unknown> = ItemLike,
+> extends DocumentMembers<System>,
     EmbeddedDocumentOwner {
-  readonly items: EmbeddedCollection<ItemLike>;
+  readonly items: EmbeddedCollection<Item>;
   readonly effects: EmbeddedCollection<ActiveEffectLike>;
   /** Roll data for `@`-references in a formula. */
   getRollData(): Record<string, unknown>;

--- a/packages/types/src/documents.ts
+++ b/packages/types/src/documents.ts
@@ -1,0 +1,157 @@
+/**
+ * The document surface the VTTForge bases hand to a consumer.
+ *
+ * Same rule as the rest of this package: every member here is one a real
+ * consumer reached for, not one that exists in Foundry. The list came from
+ * reading the systems and modules already ported to the SDK and counting
+ * what their sheets and drop handlers actually touch. Reaching past it is a
+ * cast, and a cast is a sentence you write on purpose.
+ *
+ * Names and shapes follow Foundry's published API for v13+ and v14.
+ */
+
+/** A document's `flags`, keyed by package id then by flag key. */
+export type DocumentFlags = Readonly<Record<string, Readonly<Record<string, unknown>>>>;
+
+/**
+ * An embedded collection, as `actor.items` and `actor.effects` are.
+ *
+ * Foundry's own collection carries more than this. These are the members a
+ * ported sheet used: look one up, walk them, count them.
+ */
+export interface EmbeddedCollection<T> extends Iterable<T> {
+  readonly size: number;
+  readonly contents: readonly T[];
+  get(id: string): T | undefined;
+  find(fn: (entry: T) => boolean): T | undefined;
+  filter(fn: (entry: T) => boolean): T[];
+  map<U>(fn: (entry: T) => U): U[];
+  reduce<U>(fn: (carry: U, entry: T) => U, initial: U): U;
+  some(fn: (entry: T) => boolean): boolean;
+}
+
+/**
+ * What every document carries, whatever kind it is.
+ *
+ * `System` is the document's `system` data. It defaults to an open record, so
+ * a consumer who has not said what their schema is still compiles; pass the
+ * inferred type from `BaseTypeDataModel` to get the fields.
+ */
+export interface DocumentMembers<System = Record<string, unknown>> {
+  readonly id: string | null;
+  readonly uuid: string;
+  readonly name: string;
+  /** The subtype, as declared under `documentTypes` in the manifest. */
+  readonly type: string;
+  /** The type data model instance. Its fields are the schema's fields. */
+  readonly system: System;
+  readonly img: string | null;
+  /** `'Actor'`, `'Item'`, `'ActiveEffect'`, and so on. */
+  readonly documentName: string;
+  /** The document this one is embedded in, or `null` at the top level. */
+  readonly parent: DocumentMembers | null;
+  readonly flags: DocumentFlags;
+  /** Whether the current user owns this document. */
+  readonly isOwner: boolean;
+
+  getFlag<T = unknown>(scope: string, key: string): T | undefined;
+  setFlag(scope: string, key: string, value: unknown): Promise<this>;
+  unsetFlag(scope: string, key: string): Promise<this>;
+
+  update(
+    data: Record<string, unknown>,
+    operation?: Record<string, unknown>,
+  ): Promise<this | undefined>;
+  delete(operation?: Record<string, unknown>): Promise<this | undefined>;
+
+  /** A plain-object copy. `source` reads the stored data instead of the prepared data. */
+  toObject(source?: boolean): Record<string, unknown>;
+}
+
+/** The embedded-document writes a sheet makes on its own document. */
+export interface EmbeddedDocumentOwner {
+  createEmbeddedDocuments(
+    name: string,
+    data: readonly Record<string, unknown>[],
+    operation?: Record<string, unknown>,
+  ): Promise<unknown[]>;
+  updateEmbeddedDocuments(
+    name: string,
+    updates: readonly Record<string, unknown>[],
+    operation?: Record<string, unknown>,
+  ): Promise<unknown[]>;
+  deleteEmbeddedDocuments(
+    name: string,
+    ids: readonly string[],
+    operation?: Record<string, unknown>,
+  ): Promise<unknown[]>;
+  getEmbeddedDocument(name: string, id: string): unknown;
+}
+
+/** An Active Effect, as a drop hands one over. */
+export interface ActiveEffectLike<System = Record<string, unknown>>
+  extends DocumentMembers<System> {
+  readonly disabled: boolean;
+  readonly transfer: boolean;
+}
+
+/** An Item, as a drop hands one over. */
+export interface ItemLike<System = Record<string, unknown>>
+  extends DocumentMembers<System>,
+    EmbeddedDocumentOwner {
+  /** The Actor this Item belongs to, or `null` for a world Item. */
+  readonly actor: ActorLike | null;
+  readonly effects: EmbeddedCollection<ActiveEffectLike>;
+  /** Roll data for `@`-references in a formula. */
+  getRollData(): Record<string, unknown>;
+}
+
+/** An Actor, as a sheet holds one and a drop hands one over. */
+export interface ActorLike<System = Record<string, unknown>>
+  extends DocumentMembers<System>,
+    EmbeddedDocumentOwner {
+  readonly items: EmbeddedCollection<ItemLike>;
+  readonly effects: EmbeddedCollection<ActiveEffectLike>;
+  /** Roll data for `@`-references in a formula. */
+  getRollData(): Record<string, unknown>;
+  /**
+   * Every effect that may apply, including the transferred ones on owned
+   * Items. Nothing is copied onto the Actor in v14; they apply in place.
+   */
+  allApplicableEffects(): Iterable<ActiveEffectLike>;
+}
+
+/** A Folder, as a drop hands one over. */
+export interface FolderLike {
+  readonly id: string | null;
+  readonly uuid: string;
+  readonly name: string;
+  /** The document kind this folder holds: `'Actor'`, `'Item'`, and so on. */
+  readonly type: string;
+  readonly contents: readonly DocumentMembers[];
+}
+
+/**
+ * What a `TypeDataModel` instance carries beyond its own schema fields.
+ *
+ * `parent` is the one that matters: inside `prepareDerivedData()` it is the
+ * Actor or Item this data belongs to, and reaching it was a cast until now.
+ */
+export interface TypeDataModelMembers<Parent = DocumentMembers> {
+  /**
+   * The document this data belongs to: the Actor or Item whose `system` this
+   * is. Inside `prepareDerivedData()` this is how you read the rest of the
+   * document, `this.parent.name` or `this.parent.items`.
+   *
+   * Foundry types it nullable because a `DataModel` can stand on its own. A
+   * type data model cannot: Foundry builds it with the document as parent.
+   */
+  readonly parent: Parent;
+  /** A plain-object copy of the data. */
+  toObject(source?: boolean): Record<string, unknown>;
+  /** Change the source data in memory, without a database write. */
+  updateSource(
+    changes?: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Record<string, unknown>;
+}

--- a/packages/types/src/foundry.ts
+++ b/packages/types/src/foundry.ts
@@ -7,6 +7,8 @@
  * cast, and a cast is a sentence you write on purpose.
  */
 
+import type { DocumentMembers } from './documents.js';
+
 /**
  * The ApplicationV2 surface these bases rely on.
  *
@@ -45,15 +47,14 @@ export interface ApplicationV2Members {
 
 /**
  * What a document sheet adds on top of an application.
+ *
+ * `TDocument` is the document this sheet is for. It defaults to the shared
+ * document surface, so a sheet that says nothing still reads `name`, `system`
+ * and `update()`. Pass your own type to narrow it further.
  */
-export interface DocumentSheetV2Members extends ApplicationV2Members {
-  /**
-   * The document this sheet is for.
-   *
-   * Typed loosely on purpose: which document, and what its `system` holds,
-   * is the consumer's to know. Narrow it with a getter on your subclass.
-   */
-  readonly document: unknown;
+export interface DocumentSheetV2Members<TDocument = DocumentMembers> extends ApplicationV2Members {
+  /** The document this sheet is for. */
+  readonly document: TDocument;
 
   /** Whether the current user may edit this document. */
   readonly isEditable: boolean;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,4 +8,15 @@ import { version } from '../package.json' with { type: 'json' };
 
 export const VTTFORGE_TYPES_VERSION: string = version;
 
+export type {
+  ActiveEffectLike,
+  ActorLike,
+  DocumentFlags,
+  DocumentMembers,
+  EmbeddedCollection,
+  EmbeddedDocumentOwner,
+  FolderLike,
+  ItemLike,
+  TypeDataModelMembers,
+} from './documents.js';
 export type { ApplicationV2Members, DocumentSheetV2Members, VttforgeClass } from './foundry.js';


### PR DESCRIPTION
## The gap

I measured it by writing the file a module author writes, with no cast of my
own, and compiling it against the built `.d.mts`. Three things did not work:

| Where | Before |
|---|---|
| `this.document` on a sheet | `unknown` |
| `onDropItem` / `onDropActor` / `onDropFolder` / `onDropActiveEffect` | `unknown` |
| `this.parent` inside a `BaseTypeDataModel` | did not exist |

The scaffold templates shipped the workaround as the example to copy: a
hand-written `interface CharacterActor`, then `this.document as CharacterActor`.
A comment there called it "the one place to change when a real type package
lands".

## What changed

`@vttforge/types` carries the document surface: `DocumentMembers`, `ActorLike`,
`ItemLike`, `ActiveEffectLike`, `FolderLike`, `EmbeddedCollection`,
`TypeDataModelMembers`. Core re-exports all of them.

Both sheet factories take the document type, so the schema follows through:

```ts
type CharacterActor = ActorLike<CharacterData>;

export class CharacterSheet extends BaseActorSheet<CharacterActor>() {
  override async _prepareContext(options: unknown) {
    const context = await super._prepareContext(options);
    context.system = this.document.system; // CharacterData
    return context;
  }
}
```

The three TypeScript templates now do exactly that, and no longer declare an
interface or cast anything.

## Where the member list came from

Not from restating Foundry's API. I counted what the systems and modules
already ported to the SDK reach for on a document and on a dropped item, then
checked each name and signature against Foundry's published API docs for v13+
and v14. `reduce` on an embedded collection is in the list because the API
docs' own `prepareDerivedData` example uses `this.parent.items.reduce(...)`.

Reaching a member outside the list is still a cast. That is the point of
keeping it short.

## One rough edge, documented

TypeScript does not carry a base method's parameter types into an override, so
a drop hook still needs its parameter written out:

```ts
override async onDropItem(item: ItemLike<GearData>, event: DragEvent) { ... }
```

The type exists to write now, which it did not before. The JSDoc and the sheets
guide both say so.

## Checks

`pnpm typecheck`, `pnpm test` (614 in the CLI alone, including the template
scaffold-and-typecheck run), `pnpm build`, `pnpm lint`, `knip`, `publint`,
`attw` all pass. New type-level tests in
`packages/core/src/__tests__/documents.test-d.ts` pin each of the three fixes.

Template pins moved to `@vttforge/core` `^0.19.0` for the minor.