### PR TITLE
fix(core): say what `schemaHasResource` actually accepts

### DIFF
--- a/.changeset/olive-pianos-tap.md
+++ b/.changeset/olive-pianos-tap.md
@@ -1,0 +1,5 @@
+---
+"@vttforge/core": patch
+---
+
+`schemaHasResource` declared its first parameter as `Record<string, FieldInstance> | unknown`. A union with `unknown` is `unknown`, so the typed half did nothing and a caller got no checking from it. The parameter now says `unknown`, which is what it always was. No call changes.

--- a/packages/core/src/data/resource-field.ts
+++ b/packages/core/src/data/resource-field.ts
@@ -10,12 +10,7 @@
 
 import { VttfError } from '../errors/registry.js';
 import type { SchemaFieldOptions } from './field-options.js';
-import {
-  type FieldInstance,
-  fields,
-  type NumberFieldInstance,
-  type SchemaFieldInstance,
-} from './fields.js';
+import { fields, type NumberFieldInstance, type SchemaFieldInstance } from './fields.js';
 
 export interface ResourceFieldOptions {
   /** Starting `value`. Default `0`. */

--- a/packages/core/src/data/resource-field.ts
+++ b/packages/core/src/data/resource-field.ts
@@ -95,10 +95,7 @@ export function resourceField(options: ResourceFieldOptions = {}): ResourceField
  * `fields` hold both `value` and `max`. Reads Foundry's own field objects,
  * so it works on any schema, not only one built with `resourceField()`.
  */
-export function schemaHasResource(
-  schema: Record<string, FieldInstance> | unknown,
-  path: string,
-): boolean {
+export function schemaHasResource(schema: unknown, path: string): boolean {
   let node: unknown = schema;
   for (const segment of path.split('.')) {
     const fieldsOf = (node as { fields?: Record<string, unknown> } | undefined)?.fields;


### PR DESCRIPTION
`schemaHasResource` declared its first parameter as `Record<string, FieldInstance> | unknown`. A union with `unknown` is `unknown`, so the typed half never held a caller to anything: any value passed, and the signature read as if it did not.

The parameter now says `unknown`. That is what it was, so no call changes and nothing breaks. The body already walked the value with its own guards and is untouched. Removing the name left `FieldInstance` unused in that file, so the import goes too.

Built surface before and after:

```
- export declare function schemaHasResource(schema: Record<string, FieldInstance> | unknown, path: string): boolean;
+ export declare function schemaHasResource(schema: unknown, path: string): boolean;
```

`typecheck`, `test`, `build`, `lint` and `knip` all run clean, with the turbo cache forced off.

## The second item is not here

I said the templates ship an unformatted `scripts/main.mjs`. That was wrong. The file that fails the formatter is a fixture a CLI test writes on purpose to prove `vttforge lint` catches it, and the test is correct. What leaks is Biome writing a workflow annotation from inside that test's subprocess, which paints a red error on a run that passed. I could not reproduce it locally with `GITHUB_ACTIONS`, `CI`, or both, so there is no fix here to prove. It is cosmetic.