### PR TITLE
docs: bring the roadmap up to what shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,10 @@ The **Forge theme**: warm-dark surfaces, an ember accent, a `{ d20 }` mark, a 4-
 - ✅ Published. Every package on npm under OIDC trusted publishing, with provenance
 - ✅ Documentation. [vttforge.dev/docs](https://vttforge.dev/docs/) carries the guide, the API reference, the recipes and the error catalogue
 - ✅ Modules. Sockets and GM-authoritative requests, the module api, sub-type conversion so a module can be uninstalled without stranding data, UI injection into applications you do not own
-- 🛠️ Now. Widening the Foundry surface in `@vttforge/types` as adopters hit gaps, and closing the remaining places where a module has to write by hand what a system does not
-- 🚀 v1.0. A stable API, decorators once the toolchain allows them, and enough adopters to know which of the remaining gaps are real
+- ✅ Decorators. `@ActorDataModel`, `@ItemDataModel`, `@DocumentSheet`, `@SystemSetting` and `@OnHook`, on the standard decorators the toolchain now supports
+- ✅ Typed Foundry surface. `@vttforge/types` describes the documents, `game`, `ui`, `CONFIG`, `CONST`, `foundry.utils`, dice, chat, combat, scenes, tokens, the canvas, ApplicationV2 and a hook map that types each hook's arguments by its name. The published type declarations for `@vttforge/core` carried 91 `unknown` at 0.18.1 and carry 49 at 0.19.0, and most of what is left is the SDK's own generics rather than a Foundry type nobody wrote down
+- 🛠️ Now. Other people's code. The API is shaped and the surface is typed, so what is left is finding where it does not hold in a system I did not write
+- 🚀 v1.0. A stable API, and enough adopters to know which of the remaining gaps are real
 
 ## Where it is now
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -382,7 +382,8 @@
               <div class="rm-step done"><div class="dot"></div><div class="ver">v0.1</div><div class="nm">Core runtime · sheet bases · styles</div></div>
               <div class="rm-step done"><div class="dot"></div><div class="ver">v0.2</div><div class="nm">Vite plugin · dev loop · manifest sync</div></div>
               <div class="rm-step done"><div class="dot"></div><div class="ver">v0.3</div><div class="nm">CLI · four templates · audit · docs site</div></div>
-              <div class="rm-step now"><div class="dot"></div><div class="ver">now</div><div class="nm">Typed Foundry surface · decorators · sockets, module api, sub-type conversion and injection · adopters and the gaps they find</div></div>
+              <div class="rm-step done"><div class="dot"></div><div class="ver">v0.4</div><div class="nm">Sockets · module api · sub-types · injection · decorators · typed Foundry surface</div></div>
+              <div class="rm-step now"><div class="dot"></div><div class="ver">now</div><div class="nm">Other people's systems and modules, and the gaps they find</div></div>
               <div class="rm-step"><div class="dot"></div><div class="ver">v1.0</div><div class="nm">Stable API · full inference</div></div>
             </div>
           </div>


### PR DESCRIPTION
Two roadmap items were done and still listed as pending.

Decorators shipped and have a [guide page](https://vttforge.dev/docs/guide/decorators). The typed Foundry surface shipped in `@vttforge/types` 0.3.0, which is what the "Now" line described as ongoing work.

Both move to the shipped list. The types line carries a number a reader can check for themselves, from the published tarballs: the type declarations for `@vttforge/core` carried 91 `unknown` at 0.18.1 and carry 49 at 0.19.0.

```bash
npm view @vttforge/core@0.18.1 dist.tarball
```

What is left before 1.0 is not a feature. It is other people's systems and modules, and the gaps they find. Both the README and the landing page now say that.

## The landing page track

The track is a five-column grid, so it already wrapped: six steps rendered as five and one. Adding the shipped work as two steps made it eight, which wraps as five and three with the gradient line stranded behind the second row's cards. So the shipped work is one step, the count goes to seven, and the second row holds two cards instead of one. Checked in a browser at 1280 wide: five done on the first row, the line, then `now` and `v1.0`.

No package changes, so no changeset.