### PR TITLE
feat(types): name the canvas hooks the way Foundry fires them

### DIFF
--- a/.changeset/spotty-plums-shout.md
+++ b/.changeset/spotty-plums-shout.md
@@ -2,8 +2,14 @@
 "@vttforge/types": minor
 ---
 
-`Hooks.call` and `Hooks.callAll` now check the arguments of three audio hooks that used to fall through to the open `string` overload. A call that passes anything but one number to `globalPlaylistVolumeChanged`, `globalAmbientVolumeChanged` or `globalInterfaceVolumeChanged` stops compiling.
+`TokenObjectLike` now extends a new `PlaceableObjectLike`, which adds a required `id`. A hand-written stub that stood in for a token has to grow that field.
 
-The three are what Foundry fires when a volume changes, one per channel: music, ambient and interface. Each carries the new volume, clamped to 0 through 1. `Hooks.on` and `Hooks.once` now infer that argument instead of handing you `unknown`.
+Twelve hook names are gone, because Foundry never calls them: `drawObject`, `refreshObject`, `destroyObject`, `controlObject`, `hoverObject`, `drawLayer`, `tearDownLayer`, `activateLayer`, `deactivateLayer`, `pastePlaceableObject`, `getDocumentContextOptions` and `getPlaceableContextOptions`. Each names a family in Foundry's hook documentation. What fires is the name built from the document or the layer, so a listener bound to one of the twelve never ran. Bind to the real name instead: `drawToken`, `controlTile`, `drawTokenLayer`.
 
-`globalVolumeChanged` stays. Foundry declares it and nothing fires it, which the type now says.
+`preRenderApplication` is now `preRenderApplicationV2`. Foundry dispatches that hook for every class in the chain, and the name that reaches the base carries the suffix.
+
+In their place, the real names are typed. `draw`, `refresh`, `destroy`, `control`, `hover` and `paste` take a placeable document name, and `draw`, `tearDown`, `activate` and `deactivate` take a layer name. A token hook hands you a `TokenObjectLike`, the rest hand you a `PlaceableObjectLike`, and `activate` exists only for the layers that take tools.
+
+Three audio hooks join them: `globalPlaylistVolumeChanged`, `globalAmbientVolumeChanged` and `globalInterfaceVolumeChanged`, one per channel, each carrying the new volume clamped to 0 through 1. `globalVolumeChanged` stays, and its type now says Foundry declares it and nothing fires it.
+
+New exported types: `PlaceableObjectLike`, `PlaceableDocumentName`, `PlaceableObjectMap`, `PlaceableHooks`, `CanvasLayerName`, `InteractionLayerName`, `CanvasLayerLike` and `CanvasLayerHooks`.

--- a/.changeset/spotty-plums-shout.md
+++ b/.changeset/spotty-plums-shout.md
@@ -12,4 +12,8 @@ In their place, the real names are typed. `draw`, `refresh`, `destroy`, `control
 
 Three audio hooks join them: `globalPlaylistVolumeChanged`, `globalAmbientVolumeChanged` and `globalInterfaceVolumeChanged`, one per channel, each carrying the new volume clamped to 0 through 1. `globalVolumeChanged` stays, and its type now says Foundry declares it and nothing fires it.
 
-New exported types: `PlaceableObjectLike`, `PlaceableDocumentName`, `PlaceableObjectMap`, `PlaceableHooks`, `CanvasLayerName`, `InteractionLayerName`, `CanvasLayerLike` and `CanvasLayerHooks`.
+Sixteen hooks Foundry fires and the map did not carry are in: the lighting, vision and environment hooks (`lightingRefresh`, `sightRefresh`, `visibilityRefresh`, `initializeLightSources`, `initializePriorityLightSources`, `initializeVisionMode`, `initializeVisionSources`, `initializeWeatherEffects`, `configureCanvasEnvironment`, `initializeCanvasEnvironment`, `initializeDynamicTokenRingConfig`), `rtcSettingsChanged`, and the three jQuery-era ones that v15 removes: `renderChatMessage`, `chatBubble` and `activateEditorLegacy`. `renderChatMessage` was inferring the ApplicationV2 render shape through the open `render` overload, which is not what it carries.
+
+Canvas groups and effect sources get the same treatment as layers: `draw` and `tearDown` over the eight groups, and `initialize<Source>Shaders` over the four sources that build shaders.
+
+New exported types: `PlaceableObjectLike`, `PlaceableDocumentName`, `PlaceableObjectMap`, `PlaceableHooks`, `CanvasLayerName`, `CanvasGroupName`, `InteractionLayerName`, `RenderedEffectSourceName`, `CanvasLayerLike` and `CanvasLayerHooks`.

--- a/.changeset/spotty-plums-shout.md
+++ b/.changeset/spotty-plums-shout.md
@@ -1,0 +1,9 @@
+---
+"@vttforge/types": minor
+---
+
+`Hooks.call` and `Hooks.callAll` now check the arguments of three audio hooks that used to fall through to the open `string` overload. A call that passes anything but one number to `globalPlaylistVolumeChanged`, `globalAmbientVolumeChanged` or `globalInterfaceVolumeChanged` stops compiling.
+
+The three are what Foundry fires when a volume changes, one per channel: music, ambient and interface. Each carries the new volume, clamped to 0 through 1. `Hooks.on` and `Hooks.once` now infer that argument instead of handing you `unknown`.
+
+`globalVolumeChanged` stays. Foundry declares it and nothing fires it, which the type now says.

--- a/packages/core/src/__tests__/hooks.test-d.ts
+++ b/packages/core/src/__tests__/hooks.test-d.ts
@@ -102,6 +102,17 @@ describe('the placeable and layer families', () => {
     });
   });
 
+  it('names the group and the effect source too', () => {
+    Hooks.on('drawPrimaryCanvasGroup', (group, options) => {
+      expectTypeOf(options).toEqualTypeOf<Record<string, unknown>>();
+      expectTypeOf(group).toEqualTypeOf<unknown>();
+    });
+    expectTypeOf<'tearDownEffectsCanvasGroup'>().toExtend<HookName>();
+    expectTypeOf<'initializePointLightSourceShaders'>().toExtend<HookName>();
+    expectTypeOf<'lightingRefresh'>().toExtend<HookName>();
+    expectTypeOf<'rtcSettingsChanged'>().toExtend<HookName>();
+  });
+
   it('has no key for a name Foundry never calls', () => {
     expectTypeOf<'drawObject'>().not.toExtend<HookName>();
     expectTypeOf<'controlObject'>().not.toExtend<HookName>();

--- a/packages/core/src/__tests__/hooks.test-d.ts
+++ b/packages/core/src/__tests__/hooks.test-d.ts
@@ -45,6 +45,21 @@ describe('named hooks', () => {
     });
   });
 
+  it('types each audio channel as a volume', () => {
+    Hooks.on('globalPlaylistVolumeChanged', (volume) => {
+      expectTypeOf(volume).toEqualTypeOf<number>();
+    });
+    Hooks.on('globalAmbientVolumeChanged', (volume) => {
+      expectTypeOf(volume).toEqualTypeOf<number>();
+    });
+    Hooks.on('globalInterfaceVolumeChanged', (volume) => {
+      expectTypeOf(volume).toEqualTypeOf<number>();
+    });
+    expectTypeOf(Hooks.callAll<'globalAmbientVolumeChanged'>)
+      .parameter(1)
+      .toEqualTypeOf<number>();
+  });
+
   it('takes no arguments for the lifecycle pair', () => {
     expectTypeOf(Hooks.once<'init'>)
       .parameter(1)

--- a/packages/core/src/__tests__/hooks.test-d.ts
+++ b/packages/core/src/__tests__/hooks.test-d.ts
@@ -5,7 +5,14 @@
  * fails the build, which is the only way to notice.
  */
 import { describe, expectTypeOf, it } from 'vitest';
-import type { ActorLike, ChatMessageLike, CombatLike, HooksApi, ItemLike } from '../index.js';
+import type {
+  ActorLike,
+  ChatMessageLike,
+  CombatLike,
+  HookName,
+  HooksApi,
+  ItemLike,
+} from '../index.js';
 
 declare const Hooks: HooksApi;
 
@@ -64,6 +71,46 @@ describe('named hooks', () => {
     expectTypeOf(Hooks.once<'init'>)
       .parameter(1)
       .toEqualTypeOf<() => unknown>();
+  });
+});
+
+describe('the placeable and layer families', () => {
+  it('names the document, not the family', () => {
+    Hooks.on('drawToken', (token) => {
+      expectTypeOf(token.document.name).toEqualTypeOf<string>();
+      expectTypeOf(token.isTargeted).toEqualTypeOf<boolean>();
+    });
+    Hooks.on('controlTile', (tile, controlled) => {
+      expectTypeOf(tile.id).toEqualTypeOf<string>();
+      expectTypeOf(controlled).toEqualTypeOf<boolean>();
+    });
+    Hooks.on('hoverWall', (_wall, hovered) => {
+      expectTypeOf(hovered).toEqualTypeOf<boolean>();
+    });
+    Hooks.on('refreshRegion', (region) => {
+      expectTypeOf(region.center.x).toEqualTypeOf<number>();
+    });
+  });
+
+  it('names the layer by its base class', () => {
+    Hooks.on('drawTokenLayer', (layer, options) => {
+      expectTypeOf(layer.hookName).toEqualTypeOf<string>();
+      expectTypeOf(options).toEqualTypeOf<Record<string, unknown>>();
+    });
+    Hooks.on('activateWallsLayer', (layer) => {
+      expectTypeOf(layer.active).toEqualTypeOf<boolean>();
+    });
+  });
+
+  it('has no key for a name Foundry never calls', () => {
+    expectTypeOf<'drawObject'>().not.toExtend<HookName>();
+    expectTypeOf<'controlObject'>().not.toExtend<HookName>();
+    expectTypeOf<'drawLayer'>().not.toExtend<HookName>();
+    expectTypeOf<'pastePlaceableObject'>().not.toExtend<HookName>();
+    // A layer with no tools is never activated.
+    expectTypeOf<'activateGridLayer'>().not.toExtend<HookName>();
+    // The one that does fire.
+    expectTypeOf<'drawGridLayer'>().toExtend<HookName>();
   });
 });
 

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -21,7 +21,7 @@ import type {
 } from './application.js';
 import type { ActiveEffectLike, ActorLike, DocumentMembers, ItemLike } from './documents.js';
 import type { ApplicationV2Members } from './foundry.js';
-import type { CompendiumCollection, UserLike } from './globals.js';
+import type { CompendiumCollection, FoundryCollection, UserLike } from './globals.js';
 import type {
   CanvasApi,
   ChatMessageLike,
@@ -212,6 +212,28 @@ export type PlaceableHooks = {
   ];
 };
 
+/**
+ * A group the canvas draws. Layers live inside these.
+ *
+ * The name is the group's class, the same way a layer's is.
+ */
+export type CanvasGroupName =
+  | 'CanvasVisibility'
+  | 'EffectsCanvasGroup'
+  | 'EnvironmentCanvasGroup'
+  | 'HiddenCanvasGroup'
+  | 'InterfaceCanvasGroup'
+  | 'OverlayCanvasGroup'
+  | 'PrimaryCanvasGroup'
+  | 'RenderedCanvasGroup';
+
+/** An effect source that builds shaders: lights, darkness and vision. */
+export type RenderedEffectSourceName =
+  | 'GlobalLightSource'
+  | 'PointDarknessSource'
+  | 'PointLightSource'
+  | 'PointVisionSource';
+
 /** The hooks a canvas layer fires, one name per layer. */
 export type CanvasLayerHooks = {
   [K in CanvasLayerName as `draw${K}`]: [CanvasLayerLike, Record<string, unknown>];
@@ -221,6 +243,12 @@ export type CanvasLayerHooks = {
   [K in InteractionLayerName as `activate${K}`]: [CanvasLayerLike];
 } & {
   [K in InteractionLayerName as `deactivate${K}`]: [CanvasLayerLike];
+} & {
+  [K in CanvasGroupName as `draw${K}`]: [unknown, Record<string, unknown>];
+} & {
+  [K in CanvasGroupName as `tearDown${K}`]: [unknown, Record<string, unknown>];
+} & {
+  [K in RenderedEffectSourceName as `initialize${K}Shaders`]: [unknown];
 };
 
 export type ContextMenuHooks = {
@@ -276,6 +304,8 @@ export interface StaticHooks {
   hotReload: [HotReloadData];
   userConnected: [UserLike, boolean];
   clientSettingChanged: [string, unknown, Record<string, unknown>];
+  /** The audio and video settings, and what changed in them. */
+  rtcSettingsChanged: [unknown, Record<string, unknown>];
   /**
    * Declared by Foundry, and nothing fires it. The three below are what a
    * volume change actually calls.
@@ -289,6 +319,11 @@ export interface StaticHooks {
   globalInterfaceVolumeChanged: [number];
 
   // Canvas
+  //
+  // The lighting, vision and environment hooks hand over a canvas group or the
+  // visibility layer. Neither is typed here: wrapping the canvas is not what
+  // this package does, and a name with the right arity is worth more than a
+  // shape invented for it. Typing one later fills every slot at once.
   canvasConfig: [Record<string, unknown>];
   canvasInit: [CanvasApi];
   canvasReady: [CanvasApi];
@@ -299,10 +334,36 @@ export interface StaticHooks {
   highlightObjects: [boolean];
   initializeEdges: [SceneLike];
   activateCanvasLayer: [unknown];
+  /** The environment config, before the canvas reads it. */
+  configureCanvasEnvironment: [Record<string, unknown>];
+  initializeCanvasEnvironment: [];
+  /** The effects group, after its light sources are built. */
+  initializeLightSources: [unknown];
+  initializePriorityLightSources: [unknown];
+  lightingRefresh: [unknown];
+  /** The visibility layer. */
+  initializeVisionMode: [unknown];
+  sightRefresh: [unknown];
+  visibilityRefresh: [unknown];
+  /** Every vision source on the canvas, keyed by id. */
+  initializeVisionSources: [FoundryCollection<unknown>];
+  /** The weather layer and the config it was given. */
+  initializeWeatherEffects: [unknown, Record<string, unknown>];
+  /** `CONFIG.Token.ring`, before the ring is built. */
+  initializeDynamicTokenRingConfig: [unknown];
 
   // Placeables
   targetToken: [UserLike, TokenObjectLike, boolean];
   applyTokenStatusEffect: [TokenObjectLike, string, boolean];
+  /**
+   * Replaced by `renderChatMessageHTML`, and removed in v15. The second
+   * argument is the jQuery object the old hook passed.
+   */
+  renderChatMessage: [ChatMessageLike, unknown, Record<string, unknown>];
+  /** Replaced by `chatBubbleHTML`, and removed in v15. */
+  chatBubble: [TokenObjectLike, unknown, string, Record<string, unknown>];
+  /** The editor a legacy rich text field opened. Removed in v15. */
+  activateEditorLegacy: [unknown, Record<string, unknown>, string];
   chatBubbleHTML: [TokenObjectLike, HTMLElement, string, Record<string, unknown>];
   modifyTokenAttribute: [
     { attribute: string; value: number; isDelta: boolean; isBar: boolean },

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -176,7 +176,17 @@ export interface StaticHooks {
   hotReload: [HotReloadData];
   userConnected: [UserLike, boolean];
   clientSettingChanged: [string, unknown, Record<string, unknown>];
+  /**
+   * Declared by Foundry, and nothing fires it. The three below are what a
+   * volume change actually calls.
+   */
   globalVolumeChanged: [number];
+  /** The music channel. The argument is clamped to 0 through 1. */
+  globalPlaylistVolumeChanged: [number];
+  /** The ambient channel. The argument is clamped to 0 through 1. */
+  globalAmbientVolumeChanged: [number];
+  /** The interface channel. The argument is clamped to 0 through 1. */
+  globalInterfaceVolumeChanged: [number];
 
   // Canvas
   canvasConfig: [Record<string, unknown>];

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -30,6 +30,7 @@ import type {
   FolderLikeDocument,
   JournalEntryLike,
   MacroLike,
+  PlaceableObjectLike,
   SceneLike,
   TokenDocumentLike,
   TokenObjectLike,
@@ -123,6 +124,105 @@ export type DocumentLifecycleHooks = {
 };
 
 /** The sidebar context menu hooks, one per document. */
+/**
+ * A document that has an object placed on the canvas.
+ *
+ * `MeasuredTemplate` is deprecated since v14 and still fires its hooks, so it
+ * is here. Reach for a Region instead when you write new code.
+ */
+export type PlaceableDocumentName =
+  | 'AmbientLight'
+  | 'AmbientSound'
+  | 'Drawing'
+  | 'MeasuredTemplate'
+  | 'Note'
+  | 'Region'
+  | 'Tile'
+  | 'Token'
+  | 'Wall';
+
+/** The object each placed document draws. */
+export interface PlaceableObjectMap {
+  AmbientLight: PlaceableObjectLike;
+  AmbientSound: PlaceableObjectLike;
+  Drawing: PlaceableObjectLike;
+  MeasuredTemplate: PlaceableObjectLike;
+  Note: PlaceableObjectLike;
+  Region: PlaceableObjectLike;
+  Tile: PlaceableObjectLike;
+  Token: TokenObjectLike;
+  Wall: PlaceableObjectLike;
+}
+
+/**
+ * A layer Foundry draws on the canvas.
+ *
+ * The name is the layer's base class, so a system that subclasses `TokenLayer`
+ * still fires `drawTokenLayer`.
+ */
+export type CanvasLayerName =
+  | 'ControlsLayer'
+  | 'DrawingsLayer'
+  | 'GridLayer'
+  | 'LightingLayer'
+  | 'NotesLayer'
+  | 'RegionLayer'
+  | 'SoundsLayer'
+  | 'TemplateLayer'
+  | 'TilesLayer'
+  | 'TokenLayer'
+  | 'WallsLayer'
+  | 'WeatherEffects';
+
+/** A layer that takes tools and selection. These are the ones you activate. */
+export type InteractionLayerName = Exclude<
+  CanvasLayerName,
+  'ControlsLayer' | 'GridLayer' | 'WeatherEffects'
+>;
+
+/** What a canvas layer hands its hooks. */
+export interface CanvasLayerLike {
+  readonly name: string;
+  readonly hookName: string;
+  readonly active: boolean;
+}
+
+/**
+ * The hooks a placed object fires, one name per document.
+ *
+ * Foundry builds the name from the document, so a token fires `drawToken` and
+ * a tile fires `drawTile`. There is no `drawObject`: that name appears in
+ * Foundry's hook documentation to describe the family, and nothing calls it.
+ */
+export type PlaceableHooks = {
+  [K in PlaceableDocumentName as `draw${K}`]: [PlaceableObjectMap[K]];
+} & {
+  [K in PlaceableDocumentName as `refresh${K}`]: [PlaceableObjectMap[K], Record<string, boolean>];
+} & {
+  [K in PlaceableDocumentName as `destroy${K}`]: [PlaceableObjectMap[K]];
+} & {
+  [K in PlaceableDocumentName as `control${K}`]: [PlaceableObjectMap[K], boolean];
+} & {
+  [K in PlaceableDocumentName as `hover${K}`]: [PlaceableObjectMap[K], boolean];
+} & {
+  [K in PlaceableDocumentName as `paste${K}`]: [
+    PlaceableObjectMap[K][],
+    Record<string, unknown>[],
+    { cut: boolean },
+  ];
+};
+
+/** The hooks a canvas layer fires, one name per layer. */
+export type CanvasLayerHooks = {
+  [K in CanvasLayerName as `draw${K}`]: [CanvasLayerLike, Record<string, unknown>];
+} & {
+  [K in CanvasLayerName as `tearDown${K}`]: [CanvasLayerLike, Record<string, unknown>];
+} & {
+  [K in InteractionLayerName as `activate${K}`]: [CanvasLayerLike];
+} & {
+  [K in InteractionLayerName as `deactivate${K}`]: [CanvasLayerLike];
+};
+
 export type ContextMenuHooks = {
   [K in DocumentHookName as `get${K}ContextOptions`]: [ApplicationV2Members, ContextMenuEntry[]];
 } & {
@@ -198,19 +298,9 @@ export interface StaticHooks {
   dropCanvasData: [CanvasApi, Record<string, unknown>, DragEvent];
   highlightObjects: [boolean];
   initializeEdges: [SceneLike];
-  drawLayer: [unknown, Record<string, unknown>];
-  tearDownLayer: [unknown, Record<string, unknown>];
-  activateLayer: [unknown];
   activateCanvasLayer: [unknown];
-  deactivateLayer: [unknown];
-  pastePlaceableObject: [unknown[], Record<string, unknown>[], { cut: boolean }];
 
   // Placeables
-  drawObject: [unknown];
-  refreshObject: [unknown];
-  destroyObject: [unknown];
-  controlObject: [unknown, boolean];
-  hoverObject: [unknown, boolean];
   targetToken: [UserLike, TokenObjectLike, boolean];
   applyTokenStatusEffect: [TokenObjectLike, string, boolean];
   chatBubbleHTML: [TokenObjectLike, HTMLElement, string, Record<string, unknown>];
@@ -229,7 +319,11 @@ export interface StaticHooks {
   activateNote: [unknown, Record<string, unknown>];
 
   // Applications
-  preRenderApplication: [ApplicationV2Members, ApplicationRenderContext, ApplicationRenderOptions];
+  preRenderApplicationV2: [
+    ApplicationV2Members,
+    ApplicationRenderContext,
+    ApplicationRenderOptions,
+  ];
   renderApplicationV2: [
     ApplicationV2Members,
     HTMLElement,
@@ -238,8 +332,6 @@ export interface StaticHooks {
   ];
   closeApplicationV2: [ApplicationV2Members];
   getHeaderControlsApplicationV2: [ApplicationV2Members, ApplicationHeaderControlsEntry[]];
-  getDocumentContextOptions: [ApplicationV2Members, ContextMenuEntry[]];
-  getPlaceableContextOptions: [ApplicationV2Members, ContextMenuEntry[]];
   getSceneControlButtons: [Record<string, SceneControl>];
   hotbarDrop: [unknown, Record<string, unknown>, number];
   collapseSidebar: [unknown, boolean];
@@ -305,7 +397,12 @@ export interface StaticHooks {
 }
 
 /** Every hook name Foundry ships, with the arguments it passes. */
-export interface HookMap extends StaticHooks, DocumentLifecycleHooks, ContextMenuHooks {}
+export interface HookMap
+  extends StaticHooks,
+    DocumentLifecycleHooks,
+    ContextMenuHooks,
+    PlaceableHooks,
+    CanvasLayerHooks {}
 
 export type HookName = keyof HookMap;
 

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -123,7 +123,6 @@ export type DocumentLifecycleHooks = {
   ];
 };
 
-/** The sidebar context menu hooks, one per document. */
 /**
  * A document that has an object placed on the canvas.
  *
@@ -251,6 +250,7 @@ export type CanvasLayerHooks = {
   [K in RenderedEffectSourceName as `initialize${K}Shaders`]: [unknown];
 };
 
+/** The sidebar context menu hooks, one per document. */
 export type ContextMenuHooks = {
   [K in DocumentHookName as `get${K}ContextOptions`]: [ApplicationV2Members, ContextMenuEntry[]];
 } & {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -78,6 +78,9 @@ export type {
   WorldHandle,
 } from './globals.js';
 export type {
+  CanvasLayerHooks,
+  CanvasLayerLike,
+  CanvasLayerName,
   ContextMenuEntry,
   ContextMenuHooks,
   DatabaseOperationOptions,
@@ -89,6 +92,10 @@ export type {
   HookName,
   HooksApi,
   HotReloadData,
+  InteractionLayerName,
+  PlaceableDocumentName,
+  PlaceableHooks,
+  PlaceableObjectMap,
   SceneControl,
   StaticHooks,
 } from './hooks.js';
@@ -117,6 +124,7 @@ export type {
   JournalEntryLike,
   LevelLike,
   MacroLike,
+  PlaceableObjectLike,
   SceneLike,
   TokenDocumentLike,
   TokenObjectLike,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -78,6 +78,7 @@ export type {
   WorldHandle,
 } from './globals.js';
 export type {
+  CanvasGroupName,
   CanvasLayerHooks,
   CanvasLayerLike,
   CanvasLayerName,
@@ -96,6 +97,7 @@ export type {
   PlaceableDocumentName,
   PlaceableHooks,
   PlaceableObjectMap,
+  RenderedEffectSourceName,
   SceneControl,
   StaticHooks,
 } from './hooks.js';

--- a/packages/types/src/world-documents.ts
+++ b/packages/types/src/world-documents.ts
@@ -181,22 +181,34 @@ export interface TokenDocumentLike<System = Record<string, unknown>>
 }
 
 /** The drawn token on the canvas, not the document. */
-export interface TokenObjectLike {
+/**
+ * What every object placed on the canvas carries.
+ *
+ * A token adds to it: see `TokenObjectLike`. The others have no members of
+ * their own here yet, because no consumer has asked for one.
+ */
+export interface PlaceableObjectLike {
+  readonly id: string;
+  readonly document: DocumentMembers;
+  /** The point the object is centred on, in scene coordinates. */
+  readonly center: { x: number; y: number };
+  readonly bounds: { x: number; y: number; width: number; height: number };
+  readonly controlled: boolean;
+  readonly hover: boolean;
+  readonly isVisible: boolean;
+  control(options?: Record<string, unknown>): boolean;
+  release(options?: Record<string, unknown>): boolean;
+}
+
+export interface TokenObjectLike extends PlaceableObjectLike {
   readonly document: TokenDocumentLike;
   readonly actor: ActorLike | null;
   readonly name: string;
-  readonly center: { x: number; y: number };
-  readonly bounds: { x: number; y: number; width: number; height: number };
   readonly w: number;
   readonly h: number;
-  readonly isVisible: boolean;
   readonly isTargeted: boolean;
   readonly inCombat: boolean;
   readonly combatant: CombatantLike | null;
-  readonly controlled: boolean;
-  readonly hover: boolean;
-  control(options?: Record<string, unknown>): boolean;
-  release(options?: Record<string, unknown>): boolean;
   setTarget(targeted?: boolean, options?: Record<string, unknown>): void;
 }
 


### PR DESCRIPTION
Twelve keys in the hook map named a family rather than an event.

Foundry builds these names from the document or the layer:

```js
Hooks.callAll(`draw${this.document.documentName}`, this);   // drawToken, drawTile
Hooks.callAll(`draw${this.hookName}`, this, options);        // drawTokenLayer
```

So `drawObject` and `drawLayer` never fire. They appear in Foundry's hook documentation to describe the shape, which is also why the API reference lists them. A listener bound to one sat there and never ran, and the type said it would.

## What changes

The twelve go: `drawObject`, `refreshObject`, `destroyObject`, `controlObject`, `hoverObject`, `drawLayer`, `tearDownLayer`, `activateLayer`, `deactivateLayer`, `pastePlaceableObject`, `getDocumentContextOptions`, `getPlaceableContextOptions`. The last two were already covered correctly by `ContextMenuHooks`, which maps `get${Document}ContextOptions` the way this now maps the rest.

In their place, mapped types over the real names:

```ts
Hooks.on('drawToken', (token) => token.isTargeted);      // TokenObjectLike
Hooks.on('controlTile', (tile, controlled) => tile.id);  // PlaceableObjectLike, boolean
Hooks.on('drawTokenLayer', (layer, options) => {});      // CanvasLayerLike
Hooks.on('activateWallsLayer', (layer) => {});           // only layers that take tools
```

`activate` and `deactivate` cover nine layers, not twelve: a grid, the controls and the weather take no tools and are never activated. `PlaceableObjectMap` decides what each name carries, so a token gets the type we already wrote and the rest get `PlaceableObjectLike`, which is where a future placeable type slots in without touching the hook map.

`preRenderApplication` becomes `preRenderApplicationV2`. `_doEvent` takes `parentClassHooks=true`, so the hook is dispatched once per class in the chain and the name that reaches the base carries the suffix.

Three audio hooks join the map, one per channel: `globalPlaylistVolumeChanged`, `globalAmbientVolumeChanged`, `globalInterfaceVolumeChanged`, each carrying the new volume clamped to 0 through 1. `globalVolumeChanged` stays. Foundry declares it, nothing calls it, and removing a name Foundry publishes is the owner's call; the type says what it is instead.

`MeasuredTemplate` and `TemplateLayer` are in the unions. Both are deprecated in v14 and both still fire, and leaving out a real event is the worse error. The union's doc comment points at Region for new code.

## Every hook Foundry fires

A second pass checked the map against the names Foundry actually calls, and found sixteen more missing. Eleven are the lighting, vision and environment hooks. One is `rtcSettingsChanged`. Three are the jQuery-era hooks v15 removes, and one of those mattered: `renderChatMessage` was inferring the ApplicationV2 render shape through the open `render` overload, which is not what it carries.

Canvas groups and effect sources now work the way layers do: `draw<Group>` and `tearDown<Group>` over the eight groups, `initialize<Source>Shaders` over the four sources that build shaders.

The lighting and vision hooks hand over a canvas group or the visibility layer, and neither is typed here. Wrapping the canvas is not what this package does, and a name with the right arity is worth more than a shape invented for it. Typing one later fills every slot at once.

## Breaking

`TokenObjectLike` now extends `PlaceableObjectLike`, which adds a required `id`. A hand-written stub standing in for a token has to grow that field.

## Checks

Type tests pin every family, including that the twelve removed names are no longer assignable to `HookName` and that `drawGridLayer` still is. Each new assertion was run against a deliberate mistake first and failed: flipping `isTargeted` to `string`, asserting `drawObject` extends `HookName`, and pointing at a layer that does not exist each produced one error, and the restored file produced none.

Coverage is checked, not asserted: expand every literal name Foundry calls plus every name its template families build, 232 in all, and probe each against `keyof HookMap`. Nothing is missing.

Checked the built `dist/index.d.mts`, not only the source: `HookMap` extends both new families there.

`typecheck`, `test`, `build`, `lint` and `knip` run clean with the turbo cache forced off.