### PR TITLE
feat(types): type the registry of every setting a world declared

### DIFF
--- a/.changeset/settings-registry-type.md
+++ b/.changeset/settings-registry-type.md
@@ -1,0 +1,17 @@
+---
+'@vttforge/types': minor
+---
+
+`game.settings.settings` is typed. It is the map of every setting the world
+registered, keyed `namespace.key`, and the only way to reach settings that
+belong to a package you did not write. Read it to enumerate, report on or copy
+what a world holds.
+
+**Breaking:** `settings` is required on `GameSettingsApi`. Code that builds a
+settings object by hand, which in practice means a test fake, no longer
+compiles without it. Add `settings: new Map()` to the fake.
+
+The new `RegisteredSetting` type describes one entry: the config as registered,
+plus the `id`, `namespace`, `key`, `scope` and `default` that registration
+fills in. `scope` and `default` are not optional there, because registration
+falls back to `client` and to `null` when the caller leaves them out.

--- a/.changeset/settings-registry-type.md
+++ b/.changeset/settings-registry-type.md
@@ -11,7 +11,5 @@ what a world holds.
 settings object by hand, which in practice means a test fake, no longer
 compiles without it. Add `settings: new Map()` to the fake.
 
-The new `RegisteredSetting` type describes one entry: the config as registered,
-plus the `id`, `namespace`, `key`, `scope` and `default` that registration
-fills in. `scope` and `default` are not optional there, because registration
-falls back to `client` and to `null` when the caller leaves them out.
+The new `RegisteredSetting` type is `SettingConfig` plus the `id`, `namespace`
+and `key` that registration fills in.

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Thumbs.db
 
 # Generated API reference (apps/docs/scripts/typedoc.mjs)
 apps/docs/src/reference/*/
+
+# firecrawl scrape output — research scratch, never tracked
+.firecrawl/

--- a/packages/core/src/__tests__/globals.test-d.ts
+++ b/packages/core/src/__tests__/globals.test-d.ts
@@ -12,6 +12,8 @@ import type {
   FoundryConstants,
   FoundryUtils,
   Game,
+  RegisteredSetting,
+  SettingScope,
   UiApi,
 } from '../index.js';
 
@@ -25,6 +27,19 @@ describe('game', () => {
   it('types the settings round trip', () => {
     expectTypeOf(game.settings.get<number>('my-module', 'schemaVersion')).toEqualTypeOf<number>();
     expectTypeOf(game.settings.register).parameter(0).toEqualTypeOf<string>();
+  });
+
+  it('reads the registry of every setting the world declared', () => {
+    expectTypeOf(game.settings.settings.size).toEqualTypeOf<number>();
+    expectTypeOf(game.settings.settings.get).parameter(0).toEqualTypeOf<string>();
+    const entry: RegisteredSetting | undefined =
+      game.settings.settings.get('my-module.schemaVersion');
+    expectTypeOf(entry?.id).toEqualTypeOf<string | undefined>();
+    expectTypeOf(entry?.namespace).toEqualTypeOf<string | undefined>();
+    expectTypeOf(entry?.key).toEqualTypeOf<string | undefined>();
+    expectTypeOf(entry?.scope).toEqualTypeOf<SettingScope | undefined>();
+    // Registration fills both in, so neither is optional on a stored entry.
+    expectTypeOf(entry?.default).toEqualTypeOf<unknown>();
   });
 
   it('types the collections by document', () => {

--- a/packages/core/src/__tests__/migrations.test.ts
+++ b/packages/core/src/__tests__/migrations.test.ts
@@ -13,6 +13,9 @@ function makeSettings(initial: Record<string, string> = {}): GameSettingsApi & {
   return {
     store,
     registerSpy,
+    // The runner never enumerates. The registry is here because the interface
+    // requires it, not because this fake fills it.
+    settings: new Map(),
     register(namespace: string, key: string, config: unknown): void {
       registerSpy(namespace, key, config);
     },

--- a/packages/core/src/foundry-globals.ts
+++ b/packages/core/src/foundry-globals.ts
@@ -62,6 +62,7 @@ export type {
   PackageHandle,
   Point,
   QueryHandlers,
+  RegisteredSetting,
   RollConstructor,
   RollEvaluateOptions,
   RollLike,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -221,6 +221,7 @@ export type {
   PackageHandle,
   Point,
   QueryHandlers,
+  RegisteredSetting,
   RollConstructor,
   RollEvaluateOptions,
   RollLike,

--- a/packages/types/src/globals.ts
+++ b/packages/types/src/globals.ts
@@ -101,7 +101,34 @@ export interface SettingMenuConfig {
   readonly restricted?: boolean;
 }
 
+/**
+ * One entry of the settings registry: what `register` was given, plus the
+ * three fields it fills in.
+ *
+ * `scope` is always present here even though `SettingConfig` makes it
+ * optional, because registration falls back to `client` when the caller omits
+ * it or passes a name that is not a scope. `default` is `null` rather than
+ * missing for the same reason: a setting value may be `null` and may not be
+ * `undefined`.
+ */
+export interface RegisteredSetting<T = unknown> extends SettingConfig<T> {
+  /** `namespace.key`, the id the registry is keyed by. */
+  readonly id: string;
+  readonly namespace: string;
+  readonly key: string;
+  readonly scope: SettingScope;
+  readonly default: T;
+}
+
 export interface GameSettingsApi {
+  /**
+   * Every setting registered in this world, keyed `namespace.key`.
+   *
+   * The only way to reach settings belonging to a package you did not write.
+   * Read it to enumerate, report on or copy what a world holds; write through
+   * `register`, `get` and `set`, never through the map.
+   */
+  readonly settings: ReadonlyMap<string, RegisteredSetting>;
   register<T>(namespace: string, key: string, data: SettingConfig<T>): void;
   registerMenu(namespace: string, key: string, data: SettingMenuConfig): void;
   get<T = unknown>(namespace: string, key: string, options?: { document?: boolean }): T;

--- a/packages/types/src/globals.ts
+++ b/packages/types/src/globals.ts
@@ -105,19 +105,17 @@ export interface SettingMenuConfig {
  * One entry of the settings registry: what `register` was given, plus the
  * three fields it fills in.
  *
- * `scope` is always present here even though `SettingConfig` makes it
- * optional, because registration falls back to `client` when the caller omits
- * it or passes a name that is not a scope. `default` is `null` rather than
- * missing for the same reason: a setting value may be `null` and may not be
- * `undefined`.
+ * Registration normalises as it stores. It falls back to the `client` scope
+ * when the caller names one that does not exist, and to a `null` default when
+ * there is none, because a setting value may be `null` and may not be
+ * `undefined`. So an entry read back here always carries a real scope and a
+ * real default, whatever the call passed.
  */
 export interface RegisteredSetting<T = unknown> extends SettingConfig<T> {
   /** `namespace.key`, the id the registry is keyed by. */
   readonly id: string;
   readonly namespace: string;
   readonly key: string;
-  readonly scope: SettingScope;
-  readonly default: T;
 }
 
 export interface GameSettingsApi {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -65,6 +65,7 @@ export type {
   NotificationType,
   PackageHandle,
   QueryHandlers,
+  RegisteredSetting,
   SettingConfig,
   SettingMenuConfig,
   SettingScope,


### PR DESCRIPTION
First of four. They come from building a module on the SDK from scratch, outside this repo, and hitting what a consumer hits.

**Merge order: this one, then #246, then #247, then #248.** The four branches are stacked, each cut from the one before, so #248's diff against `main` contains all four commits. This repo squash-merges, so after each one lands the next needs a rebase before it will merge cleanly. Say the word and I will rebase them in order.

## The problem

`game.settings.settings` maps `namespace.key` to every setting registered in a world. It is the only way to reach a setting belonging to a package you did not write, so anything that enumerates, reports on or copies a world's configuration needs it. `GameSettingsApi` did not have it, and the module had to declare the shape by hand.

## The change

`settings` is now on `GameSettingsApi`, typed `ReadonlyMap<string, RegisteredSetting>`.

`RegisteredSetting` is `SettingConfig` plus the `id`, `namespace` and `key` that registration fills in.

## Breaking

`settings` is required, so code that builds a settings object by hand no longer compiles without it. In practice that means a test fake. The fix is one line: `settings: new Map()`. The fake in this repo's migration tests got exactly that.

Nothing that only reads `game.settings` is affected.

## Verified

`pnpm typecheck`, `pnpm test` and `pnpm lint` with `--force`, so no cached task reported a result it did not compute. A type test pins the registry key type, the entry fields and the scope.