### PR TITLE
feat(core): BaseHandlebarsApplication, for a window whose markup is a template

### DIFF
--- a/.changeset/handlebars-application-base.md
+++ b/.changeset/handlebars-application-base.md
@@ -1,0 +1,26 @@
+---
+'@vttforge/core': minor
+---
+
+`BaseHandlebarsApplication()` builds an `ApplicationV2` with the Handlebars
+mixin already applied.
+
+`BaseActorSheet` and `BaseItemSheet` carried the mixin; `BaseApplication` did
+not. So a standalone templated window, a config screen, a picker, a report,
+had no typed base and had to reach into the untyped `foundry.*` global for the
+mixin or hand-roll `_renderHTML` around `renderTemplate`.
+
+```ts
+class ReportWindow extends BaseHandlebarsApplication() {
+  static PARTS = { body: { template: 'modules/my-module/templates/report.hbs' } };
+  async _prepareContext() {
+    return { rows: collectRows() };
+  }
+}
+```
+
+A subclass that declares no `static PARTS` throws `VTTF-0002` when it is
+constructed. Without the check the window opens, renders nothing and says
+nothing about why.
+
+`BaseApplication` is unchanged. Use it when the markup comes from code.

--- a/.changeset/handlebars-application-base.md
+++ b/.changeset/handlebars-application-base.md
@@ -13,11 +13,16 @@ mixin or hand-roll `_renderHTML` around `renderTemplate`.
 ```ts
 class ReportWindow extends BaseHandlebarsApplication() {
   static PARTS = { body: { template: 'modules/my-module/templates/report.hbs' } };
-  async _prepareContext() {
+  override async _prepareContext() {
     return { rows: collectRows() };
   }
 }
 ```
+
+`override` is required, not merely allowed. The factory reports what it adds,
+so TypeScript sees the member being replaced, and a scaffolded project sets
+`noImplicitOverride`. The `BaseActorSheet` and `BaseItemSheet` examples were
+missing the same word on `DEFAULT_OPTIONS`, and now carry it.
 
 A subclass that declares no `static PARTS` throws `VTTF-0002` when it is
 constructed. Without the check the window opens, renders nothing and says

--- a/.changeset/pin-core-020.md
+++ b/.changeset/pin-core-020.md
@@ -1,0 +1,8 @@
+---
+'@vttforge/cli': patch
+---
+
+The scaffold templates pin `@vttforge/core` at `^0.20.0`, the version the
+pending release publishes. On a 0.x line a caret pins the minor, so the old
+`^0.19.0` would scaffold a project that cannot resolve the core it is written
+against.

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.19.0"
+    "@vttforge/core": "^0.20.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.17.0",

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.19.0"
+    "@vttforge/core": "^0.20.0"
   },
   "devDependencies": {
     "@vttforge/cli": "^0.17.0",

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -13,7 +13,7 @@
     "format": "vttforge lint --fix"
   },
   "dependencies": {
-    "@vttforge/core": "^0.19.0",
+    "@vttforge/core": "^0.20.0",
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vttforge/core": "^0.19.0",
+    "@vttforge/core": "^0.20.0",
     "@vttforge/styles": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/base-handlebars-application.test.ts
+++ b/packages/core/src/__tests__/base-handlebars-application.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+/**
+ * BaseHandlebarsApplication exists because a standalone templated window had
+ * no typed base. The cases that matter are the ones proving the mixin is
+ * applied and the empty-window trap is gone.
+ *
+ * The trap was met for real building a module on the SDK: a window with the
+ * mixin and no `PARTS` opens, draws nothing, and reports nothing.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BaseHandlebarsApplication } from '../base-handlebars-application.js';
+import { VttfError } from '../errors/registry.js';
+
+class FakeApplicationV2 {}
+
+/** Stands in for Foundry's mixin: marks the class and adds the part hook. */
+function fakeMixin(Base: new (...args: unknown[]) => object): new (...args: unknown[]) => object {
+  return class extends Base {
+    static mixed = true;
+    async _preparePartContext(_partId: string, context: unknown): Promise<unknown> {
+      return context;
+    }
+  };
+}
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).foundry = {
+    applications: {
+      api: { ApplicationV2: FakeApplicationV2, HandlebarsApplicationMixin: fakeMixin },
+    },
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).foundry;
+});
+
+const PARTS = { body: { template: 'modules/x/templates/body.hbs' } };
+
+describe('BaseHandlebarsApplication', () => {
+  it('throws VTTF-0002 when ApplicationV2 is missing', () => {
+    delete (globalThis as Record<string, unknown>).foundry;
+    expect(() => BaseHandlebarsApplication()).toThrow(VttfError);
+  });
+
+  it('throws VTTF-0002 when the Handlebars mixin is missing', () => {
+    (globalThis as Record<string, unknown>).foundry = {
+      applications: { api: { ApplicationV2: FakeApplicationV2 } },
+    };
+    expect(() => BaseHandlebarsApplication()).toThrow(VttfError);
+  });
+
+  it('applies the mixin rather than extending ApplicationV2 bare', () => {
+    class Window extends BaseHandlebarsApplication() {
+      static PARTS = PARTS;
+    }
+    expect((Window as unknown as { mixed?: boolean }).mixed).toBe(true);
+    expect(new Window()).toBeInstanceOf(FakeApplicationV2);
+  });
+
+  it('refuses to construct a window that declares no PARTS', () => {
+    class Window extends BaseHandlebarsApplication() {}
+    expect(() => new Window()).toThrow(VttfError);
+    expect(() => new Window()).toThrow(/static PARTS/);
+  });
+
+  it('refuses an empty PARTS, which renders the same nothing', () => {
+    class Window extends BaseHandlebarsApplication() {
+      static PARTS = {};
+    }
+    expect(() => new Window()).toThrow(VttfError);
+  });
+
+  it('names the subclass in the error, not the base', () => {
+    class ReportWindow extends BaseHandlebarsApplication() {}
+    expect(() => new ReportWindow()).toThrow(/ReportWindow/);
+  });
+});

--- a/packages/core/src/__tests__/base-handlebars-application.test.ts
+++ b/packages/core/src/__tests__/base-handlebars-application.test.ts
@@ -75,4 +75,18 @@ describe('BaseHandlebarsApplication', () => {
     class ReportWindow extends BaseHandlebarsApplication() {}
     expect(() => new ReportWindow()).toThrow(/ReportWindow/);
   });
+
+  it('takes an overridden _prepareContext', async () => {
+    class Window extends BaseHandlebarsApplication() {
+      static PARTS = PARTS;
+      // `override` is required, not merely allowed: the factory reports what
+      // it adds, so TypeScript sees the member being replaced. A scaffolded
+      // project sets `noImplicitOverride`, so the example in the JSDoc has to
+      // compile there too.
+      override async _prepareContext(): Promise<Record<string, unknown>> {
+        return { rows: [1, 2] };
+      }
+    }
+    await expect(new Window()._prepareContext()).resolves.toEqual({ rows: [1, 2] });
+  });
 });

--- a/packages/core/src/base-actor-sheet.ts
+++ b/packages/core/src/base-actor-sheet.ts
@@ -246,7 +246,7 @@ export const VTTFORGE_SHEET_CLASS = 'vttforge';
  * @example
  * ```ts
  * class CharacterSheet extends BaseActorSheet() {
- *   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+ *   static override DEFAULT_OPTIONS = foundry.utils.mergeObject(
  *     super.DEFAULT_OPTIONS,
  *     { classes: ['my-system'], position: { width: 720 } },
  *     { inplace: false }, // never edit the parent's static options in place

--- a/packages/core/src/base-handlebars-application.ts
+++ b/packages/core/src/base-handlebars-application.ts
@@ -1,0 +1,117 @@
+/**
+ * BaseHandlebarsApplication: `ApplicationV2 + HandlebarsApplicationMixin`.
+ *
+ * `BaseApplication` builds the content itself, which suits a window whose
+ * markup comes from code. A window whose markup comes from a template wants
+ * the mixin instead, and until now the only bases carrying it were the two
+ * document sheets. A standalone templated window, a config screen, a picker,
+ * a report, had no typed base and had to reach into the untyped global for
+ * the mixin or hand-roll `_renderHTML` around `renderTemplate`.
+ *
+ * The mixin supplies both halves of the render contract from `static PARTS`,
+ * so the trap is different from `BaseApplication`'s. A class with no `PARTS`
+ * renders an empty window and says nothing about why. This checks at
+ * construction, so it fails where the class is used rather than leaving a
+ * blank frame on screen.
+ */
+
+import { VttfError } from './errors/registry.js';
+import type {
+  ApplicationRenderContext,
+  ApplicationRenderOptions,
+  ApplicationV2Members,
+  VttforgeClass,
+} from './foundry-base.js';
+
+// biome-ignore lint/suspicious/noExplicitAny: Foundry's ApplicationV2 class is resolved at runtime; the members the SDK stands on are in @vttforge/types
+type AnyConstructor = new (...args: any[]) => any;
+
+interface FoundryApplicationsApi {
+  ApplicationV2?: AnyConstructor;
+  HandlebarsApplicationMixin?: (base: AnyConstructor) => AnyConstructor;
+}
+
+interface FoundryRoot {
+  readonly applications?: { readonly api?: FoundryApplicationsApi };
+}
+
+function resolveBases(): { Base: AnyConstructor; mixin: (b: AnyConstructor) => AnyConstructor } {
+  const foundry = (globalThis as Record<string, unknown>).foundry as FoundryRoot | undefined;
+  const Base = foundry?.applications?.api?.ApplicationV2;
+  const mixin = foundry?.applications?.api?.HandlebarsApplicationMixin;
+  if (typeof Base !== 'function' || typeof mixin !== 'function') {
+    throw new VttfError(
+      'VTTF-0002',
+      'foundry.applications.api.ApplicationV2 and/or foundry.applications.api.HandlebarsApplicationMixin are not available. Define your BaseHandlebarsApplication subclasses inside the Foundry runtime (or stub the global in tests).',
+    );
+  }
+  return { Base, mixin };
+}
+
+/** What `BaseHandlebarsApplication` adds on top of Foundry's `ApplicationV2`. */
+export interface BaseHandlebarsApplicationMembers {
+  /**
+   * Per-part context, on top of what `_prepareContext` returned.
+   *
+   * Override it to give one part data the others do not need. The default
+   * hands the shared context straight back.
+   */
+  _preparePartContext(
+    partId: string,
+    context: ApplicationRenderContext,
+    options: ApplicationRenderOptions,
+  ): Promise<ApplicationRenderContext>;
+}
+
+/**
+ * Build the `BaseHandlebarsApplication` for the current Foundry runtime.
+ *
+ * ```ts
+ * class ReportWindow extends BaseHandlebarsApplication() {
+ *   static DEFAULT_OPTIONS = {
+ *     id: 'my-report',
+ *     window: { title: 'MY_MODULE.Report.title' },
+ *     position: { width: 560, height: 'auto' },
+ *     actions: { refresh: ReportWindow.onRefresh },
+ *   };
+ *
+ *   static PARTS = {
+ *     body: { template: 'modules/my-module/templates/report.hbs' },
+ *   };
+ *
+ *   async _prepareContext() {
+ *     return { rows: collectRows() };
+ *   }
+ * }
+ * ```
+ *
+ * Omitting `PARTS` throws when the class is constructed, rather than opening
+ * an empty window.
+ */
+export function BaseHandlebarsApplication(): VttforgeClass<
+  BaseHandlebarsApplicationMembers,
+  unknown,
+  ApplicationV2Members
+> {
+  const { Base, mixin } = resolveBases();
+
+  class VttforgeBaseHandlebarsApplication extends mixin(Base) {
+    // biome-ignore lint/suspicious/noExplicitAny: forwards Foundry's own constructor arity
+    constructor(...args: any[]) {
+      super(...args);
+      const parts = (this.constructor as { PARTS?: Record<string, unknown> }).PARTS;
+      if (parts === undefined || Object.keys(parts).length === 0) {
+        throw new VttfError(
+          'VTTF-0002',
+          `${this.constructor.name} extends BaseHandlebarsApplication but declares no static PARTS. The window would render empty.`,
+        );
+      }
+    }
+  }
+
+  return VttforgeBaseHandlebarsApplication as unknown as VttforgeClass<
+    BaseHandlebarsApplicationMembers,
+    unknown,
+    ApplicationV2Members
+  >;
+}

--- a/packages/core/src/base-handlebars-application.ts
+++ b/packages/core/src/base-handlebars-application.ts
@@ -79,11 +79,15 @@ export interface BaseHandlebarsApplicationMembers {
  *     body: { template: 'modules/my-module/templates/report.hbs' },
  *   };
  *
- *   async _prepareContext() {
+ *   override async _prepareContext() {
  *     return { rows: collectRows() };
  *   }
  * }
  * ```
+ *
+ * `override` on `_prepareContext` is required, not merely allowed: the factory
+ * reports what it adds, so TypeScript sees the member being replaced, and a
+ * scaffolded project sets `noImplicitOverride`.
  *
  * Omitting `PARTS` throws when the class is constructed, rather than opening
  * an empty window.

--- a/packages/core/src/base-item-sheet.ts
+++ b/packages/core/src/base-item-sheet.ts
@@ -91,7 +91,7 @@ function resolveDragDrop(): DragDropCtor | undefined {
  * @example
  * ```ts
  * class WeaponSheet extends BaseItemSheet() {
- *   static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+ *   static override DEFAULT_OPTIONS = foundry.utils.mergeObject(
  *     super.DEFAULT_OPTIONS,
  *     { classes: ['my-system'], position: { width: 540 } },
  *     { inplace: false }, // never edit the parent's static options in place

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,10 @@ export {
   type BaseDocumentSheetMembers,
   type DocumentSheetKind,
 } from './base-document-sheet.js';
+export {
+  BaseHandlebarsApplication,
+  type BaseHandlebarsApplicationMembers,
+} from './base-handlebars-application.js';
 export { BaseItemSheet } from './base-item-sheet.js';
 export {
   BaseTypeDataModel,


### PR DESCRIPTION
Second of four, from building a module on the SDK from scratch. **Merge after #245.**

The four branches are stacked. This one was cut from #245's branch, so after #245 squash-lands this needs a rebase before it will merge cleanly. Say the word and I will do it.

## The problem

`BaseActorSheet` and `BaseItemSheet` apply `HandlebarsApplicationMixin`. `BaseApplication` does not, by design: it builds its content in code and ships `_replaceHTML`.

That leaves a hole. A standalone window whose markup lives in a template, which is most of what a module puts on screen outside a document sheet, has no typed base. The two ways out were reaching into the untyped `foundry.*` global for the mixin, or hand-rolling `_renderHTML` around `renderTemplate`. The module took the second and lost the parts system for it.

## The change

`BaseHandlebarsApplication()` resolves `ApplicationV2` and `HandlebarsApplicationMixin` at runtime and returns the mixed class, the same way the two sheet bases already do, with the same `VTTF-0002` when either is missing.

```ts
class ReportWindow extends BaseHandlebarsApplication() {
  static PARTS = { body: { template: 'modules/my-module/templates/report.hbs' } };
  override async _prepareContext() {
    return { rows: collectRows() };
  }
}
```

`BaseApplication` is untouched. Use it when the markup comes from code.

## The trap it closes

`BaseApplication` exists because a missing `_renderHTML` fails late. The mixin has the opposite failure: it supplies both halves from `static PARTS`, so a class without `PARTS` opens a window, renders nothing, and reports nothing. The constructor checks for it and names the subclass in the message rather than the base.

`PARTS` is not in the statics type. Declaring it there would force `static override PARTS` on every subclass, which neither sheet base requires, and the runtime check is the guard the docs promise.

## The word the examples were missing

`override` on `_prepareContext` is required, not merely allowed: the factory reports what it adds, so TypeScript sees the member being replaced, and a scaffolded project sets `noImplicitOverride`. The first draft of this PR shipped an example without it, which is how the module found out. A test now declares an overriding `_prepareContext` so the requirement is pinned rather than described.

`BaseActorSheet` and `BaseItemSheet` had the same gap on `DEFAULT_OPTIONS`. The templates get it right; the docs did not.

## Pins

A core minor moves the templates out of their caret range, so they now pin `^0.20.0` with a `@vttforge/cli` patch changeset saying why.

## Verified

`pnpm typecheck`, `pnpm test` and `pnpm lint` with `--force`. Seven tests cover the two missing-global paths, that the mixin is applied rather than `ApplicationV2` extended bare, both empty-`PARTS` cases, that the error names the subclass, and the overriding `_prepareContext`.