### PR TITLE
feat(vite-plugin): write the release URLs into the built manifest

### DIFF
--- a/.changeset/manifest-release-urls.md
+++ b/.changeset/manifest-release-urls.md
@@ -1,0 +1,25 @@
+---
+'@vttforge/vite-plugin': minor
+'@vttforge/cli': patch
+---
+
+The plugin writes the `manifest` and `download` URLs into the built manifest.
+
+`vttforge build` emits `dist/` and zips it in one step, so a release workflow
+that patched `dist/module.json` afterwards shipped a zip holding the unpatched
+manifest. The templates worked around it by calling `vite build` directly,
+patching the JSON with an inline `node -e`, and zipping by hand.
+
+Two options, `manifestUrl` and `downloadUrl`, each falling back to
+`VTTFORGE_MANIFEST_URL` and `VTTFORGE_DOWNLOAD_URL` so a workflow sets them
+without editing the Vite config. `{version}` in the download URL is replaced
+with the version being built. Neither given, the source manifest is left
+alone.
+
+The release workflow the templates ship now runs `pnpm build` with those two
+variables set, and the three-step dance is gone.
+
+`vttforge audit` rule 020 knows that `vttforge build` writes the zip itself,
+from `dist/`, so a workflow naming that zip is not shipping the checkout. A
+workflow that runs a plain `vite build` and then zips the source tree is still
+a HIGH finding.

--- a/packages/cli/src/__tests__/release-rules.test.ts
+++ b/packages/cli/src/__tests__/release-rules.test.ts
@@ -63,6 +63,32 @@ jobs:
 `;
 
 describe('VTTF-AUDIT-020', () => {
+  it('still flags a workflow that zips the checkout after a plain vite build', async () => {
+    await writeFile(
+      join(cwd, 'vite.config.mjs'),
+      "import { vttforge } from '@vttforge/vite-plugin';\n",
+    );
+    await mkdir(join(cwd, '.github/workflows'), { recursive: true });
+    await writeFile(
+      join(cwd, '.github/workflows/release.yml'),
+      [
+        'on:',
+        '  push:',
+        '    tags: [v*]',
+        'jobs:',
+        '  release:',
+        '    steps:',
+        '      - run: pnpm exec vite build',
+        '      - run: zip -r pkg.zip system.json scripts lang',
+        '      - uses: softprops/action-gh-release@v2',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    const findings = await runReleaseRules(cwd);
+    expect(findings.map((f) => f.ruleId)).toContain('VTTF-AUDIT-020');
+  });
+
   let cwd: string;
 
   beforeEach(async () => {

--- a/packages/cli/src/audit/release-rules.ts
+++ b/packages/cli/src/audit/release-rules.ts
@@ -37,7 +37,7 @@ const BUILD_STEP = /\b(?:vttforge\s+build|vite\s+build|(?:pnpm|npm|yarn|bun)\s+(
  * not shipping the checkout.
  */
 const VTTFORGE_BUILD = /\bvttforge\s+build\b/;
-const SCRIPT_BUILD = /\b(?:pnpm|npm|yarn|bun)\s+(?:run\s+)?build\b/;
+const SCRIPT_BUILD = /\b(?:pnpm|npm|yarn|bun)\s+(?:run\s+)?build(?=\s|$)/;
 /** A line that makes or names the artifact. */
 const ZIP_COMMAND = /\bzip\s+(?:-\S+\s+)*\S+\.zip\b|\bzip\s+-r\b/;
 const ARTIFACT_LIST = /^\s*(?:artifacts|files|asset_path|path)\s*:/;

--- a/packages/cli/src/audit/release-rules.ts
+++ b/packages/cli/src/audit/release-rules.ts
@@ -29,28 +29,51 @@ const VITE_CONFIGS = [
 
 /** A line that runs the build. */
 const BUILD_STEP = /\b(?:vttforge\s+build|vite\s+build|(?:pnpm|npm|yarn|bun)\s+(?:run\s+)?build)\b/;
+/**
+ * A line that runs `vttforge build`, directly or through the `build` script.
+ *
+ * That command writes the zip itself, from `dist/`, so the artifact it leaves
+ * in the project root is already the right one. A workflow naming that zip is
+ * not shipping the checkout.
+ */
+const VTTFORGE_BUILD = /\bvttforge\s+build\b/;
+const SCRIPT_BUILD = /\b(?:pnpm|npm|yarn|bun)\s+(?:run\s+)?build\b/;
 /** A line that makes or names the artifact. */
 const ZIP_COMMAND = /\bzip\s+(?:-\S+\s+)*\S+\.zip\b|\bzip\s+-r\b/;
 const ARTIFACT_LIST = /^\s*(?:artifacts|files|asset_path|path)\s*:/;
 const MANIFEST = /\b(?:system|module)\.json\b/;
 const RELEASE_ACTION = /(?:release-action|action-gh-release|upload-release-asset)/;
 
-/** Whether this project builds through the vite plugin (or a `build` script that runs vite). */
-async function buildsToDist(cwd: string): Promise<boolean> {
+interface BuildShape {
+  /** The project bundles to `dist/`. */
+  toDist: boolean;
+  /** The `build` script is `vttforge build`, which also writes the zip. */
+  scriptZips: boolean;
+}
+
+/** Whether this project builds through the vite plugin, and whether its build script zips. */
+async function buildShape(cwd: string): Promise<BuildShape> {
+  let toDist = false;
   for (const name of VITE_CONFIGS) {
     const path = join(cwd, name);
     if (!existsSync(path)) continue;
     const text = await readFile(path, 'utf8');
-    if (/@vttforge\/vite-plugin|vttforge\s*\(/.test(text)) return true;
+    if (/@vttforge\/vite-plugin|vttforge\s*\(/.test(text)) {
+      toDist = true;
+      break;
+    }
   }
   const pkg = join(cwd, 'package.json');
-  if (!existsSync(pkg)) return false;
+  if (!existsSync(pkg)) return { toDist, scriptZips: false };
   try {
     const parsed = JSON.parse(await readFile(pkg, 'utf8')) as { scripts?: Record<string, string> };
     const build = parsed.scripts?.build ?? '';
-    return /vttforge\s+build|vite\s+build/.test(build);
+    return {
+      toDist: toDist || /vttforge\s+build|vite\s+build/.test(build),
+      scriptZips: VTTFORGE_BUILD.test(build),
+    };
   } catch {
-    return false;
+    return { toDist, scriptZips: false };
   }
 }
 
@@ -74,16 +97,23 @@ interface Shipping {
 }
 
 /** The first step that ships a package, or null when the workflow ships nothing. */
-function shippingStep(text: string): Shipping | null {
+function shippingStep(text: string, scriptZips: boolean): Shipping | null {
   const lines = text.split('\n');
   let builtBefore = false;
+  // Set once `vttforge build` has run, because that command already wrote the
+  // zip from dist/. Without it the rule reads its artifact as the checkout.
+  let zipCameFromBuild = false;
   let inArtifactList = false;
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? '';
     if (BUILD_STEP.test(line)) builtBefore = true;
+    if (VTTFORGE_BUILD.test(line) || (scriptZips && SCRIPT_BUILD.test(line))) {
+      zipCameFromBuild = true;
+    }
     if (ZIP_COMMAND.test(line)) {
       // `cd dist && zip ...`, `zip -r ../x.zip dist/`, or a zip of the checkout's own files.
       const fromDist =
+        zipCameFromBuild ||
         /\bdist\b/.test(line) ||
         /\bcd\s+dist\b/.test(lines.slice(Math.max(0, i - 3), i).join('\n'));
       return { line: i + 1, fromDist, builtBefore };
@@ -92,7 +122,7 @@ function shippingStep(text: string): Shipping | null {
       inArtifactList = true;
       const inline = line.slice(line.indexOf(':') + 1);
       if (MANIFEST.test(inline) || /\.zip\b/.test(inline)) {
-        return { line: i + 1, fromDist: /\bdist\//.test(inline), builtBefore };
+        return { line: i + 1, fromDist: zipCameFromBuild || /\bdist\//.test(inline), builtBefore };
       }
       continue;
     }
@@ -100,7 +130,7 @@ function shippingStep(text: string): Shipping | null {
       if (/^\s*-?\s*\S/.test(line) && !/^\s*-\s/.test(line) && !/^\s{4,}\S/.test(line))
         inArtifactList = false;
       else if (MANIFEST.test(line) || /\.zip\b/.test(line)) {
-        return { line: i + 1, fromDist: /\bdist\//.test(line), builtBefore };
+        return { line: i + 1, fromDist: zipCameFromBuild || /\bdist\//.test(line), builtBefore };
       }
     }
   }
@@ -112,14 +142,15 @@ function shippingStep(text: string): Shipping | null {
  * and ship `dist/`.
  */
 export async function runReleaseRules(cwd: string): Promise<RuleResult[]> {
-  if (!(await buildsToDist(cwd))) return [];
+  const shape = await buildShape(cwd);
+  if (!shape.toDist) return [];
   const findings: RuleResult[] = [];
   for (const file of await workflowFiles(cwd)) {
     const text = await readFile(file, 'utf8');
     const publishes =
       RELEASE_ACTION.test(text) || /\brelease\s*:/.test(text) || /\btags\s*:/.test(text);
     if (!publishes) continue;
-    const ship = shippingStep(text);
+    const ship = shippingStep(text, shape.scriptZips);
     if (!ship) continue;
     const relPath = relative(cwd, file);
     if (!ship.builtBefore) {

--- a/packages/cli/templates/module-js/.github/workflows/release.yml
+++ b/packages/cli/templates/module-js/.github/workflows/release.yml
@@ -46,31 +46,18 @@ jobs:
         run: |
           node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
 
-      # We invoke vite directly (not `pnpm build` → `vttforge build`) because
-      # the release workflow needs to:
-      #   1. Run vite build → emit dist/module.json
-      #   2. Patch manifest/download URLs into dist/module.json
-      #   3. Zip dist/ → release artifact (so the zipped manifest carries URLs)
-      # `vttforge build` zips at step 1, which would freeze the un-patched
-      # manifest. Eventually the vite-plugin will support env-driven URL
-      # injection and this dance disappears.
-      - run: pnpm exec vite build
-
-      - name: Inject release URLs into manifest
+      # `vttforge build` emits dist/ and zips it in one step. The plugin
+      # writes the two release URLs into the manifest before the zip is made,
+      # so the archive carries them.
+      - name: Build
         env:
           VERSION: ${{ steps.version.outputs.version }}
           REPO: ${{ github.repository }}
           PKG_ID: '{{ID}}'
+          VTTFORGE_MANIFEST_URL: https://github.com/${{ github.repository }}/releases/latest/download/module.json
         run: |
-          node -e "const fs=require('node:fs');const path='dist/module.json';const m=JSON.parse(fs.readFileSync(path,'utf8'));const r=process.env.REPO;const v=process.env.VERSION;const id=process.env.PKG_ID;m.manifest=\`https://github.com/\${r}/releases/latest/download/module.json\`;m.download=\`https://github.com/\${r}/releases/download/v\${v}/\${id}-\${v}.zip\`;fs.writeFileSync(path,JSON.stringify(m,null,2)+'\n');"
-
-      - name: Build release zip
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          PKG_ID: '{{ID}}'
-        run: |
-          cd dist
-          zip -r "../${PKG_ID}-${VERSION}.zip" .
+          export VTTFORGE_DOWNLOAD_URL="https://github.com/$REPO/releases/download/v$VERSION/$PKG_ID-{version}.zip"
+          pnpm build
 
       - name: Create GitHub Release
         env:

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@vttforge/cli": "^0.18.0",
-    "@vttforge/vite-plugin": "^0.5.0",
+    "@vttforge/vite-plugin": "^0.6.0",
     "vite": "^8.2.2"
   },
   "engines": {

--- a/packages/cli/templates/module-ts/.github/workflows/release.yml
+++ b/packages/cli/templates/module-ts/.github/workflows/release.yml
@@ -46,31 +46,18 @@ jobs:
         run: |
           node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
 
-      # We invoke vite directly (not `pnpm build` → `vttforge build`) because
-      # the release workflow needs to:
-      #   1. Run vite build → emit dist/module.json
-      #   2. Patch manifest/download URLs into dist/module.json
-      #   3. Zip dist/ → release artifact (so the zipped manifest carries URLs)
-      # `vttforge build` zips at step 1, which would freeze the un-patched
-      # manifest. Eventually the vite-plugin will support env-driven URL
-      # injection and this dance disappears.
-      - run: pnpm exec vite build
-
-      - name: Inject release URLs into manifest
+      # `vttforge build` emits dist/ and zips it in one step. The plugin
+      # writes the two release URLs into the manifest before the zip is made,
+      # so the archive carries them.
+      - name: Build
         env:
           VERSION: ${{ steps.version.outputs.version }}
           REPO: ${{ github.repository }}
           PKG_ID: '{{ID}}'
+          VTTFORGE_MANIFEST_URL: https://github.com/${{ github.repository }}/releases/latest/download/module.json
         run: |
-          node -e "const fs=require('node:fs');const path='dist/module.json';const m=JSON.parse(fs.readFileSync(path,'utf8'));const r=process.env.REPO;const v=process.env.VERSION;const id=process.env.PKG_ID;m.manifest=\`https://github.com/\${r}/releases/latest/download/module.json\`;m.download=\`https://github.com/\${r}/releases/download/v\${v}/\${id}-\${v}.zip\`;fs.writeFileSync(path,JSON.stringify(m,null,2)+'\n');"
-
-      - name: Build release zip
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          PKG_ID: '{{ID}}'
-        run: |
-          cd dist
-          zip -r "../${PKG_ID}-${VERSION}.zip" .
+          export VTTFORGE_DOWNLOAD_URL="https://github.com/$REPO/releases/download/v$VERSION/$PKG_ID-{version}.zip"
+          pnpm build
 
       - name: Create GitHub Release
         env:

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@vttforge/cli": "^0.18.0",
     "@vttforge/types": "^0.5.0",
-    "@vttforge/vite-plugin": "^0.5.0",
+    "@vttforge/vite-plugin": "^0.6.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/cli/templates/system-js/.github/workflows/release.yml
+++ b/packages/cli/templates/system-js/.github/workflows/release.yml
@@ -46,31 +46,18 @@ jobs:
         run: |
           node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
 
-      # We invoke vite directly (not `pnpm build` → `vttforge build`) because
-      # the release workflow needs to:
-      #   1. Run vite build → emit dist/system.json
-      #   2. Patch manifest/download URLs into dist/system.json
-      #   3. Zip dist/ → release artifact (so the zipped manifest carries URLs)
-      # `vttforge build` zips at step 1, which would freeze the un-patched
-      # manifest. Eventually the vite-plugin will support env-driven URL
-      # injection and this dance disappears.
-      - run: pnpm exec vite build
-
-      - name: Inject release URLs into manifest
+      # `vttforge build` emits dist/ and zips it in one step. The plugin
+      # writes the two release URLs into the manifest before the zip is made,
+      # so the archive carries them.
+      - name: Build
         env:
           VERSION: ${{ steps.version.outputs.version }}
           REPO: ${{ github.repository }}
           PKG_ID: '{{ID}}'
+          VTTFORGE_MANIFEST_URL: https://github.com/${{ github.repository }}/releases/latest/download/system.json
         run: |
-          node -e "const fs=require('node:fs');const path='dist/system.json';const m=JSON.parse(fs.readFileSync(path,'utf8'));const r=process.env.REPO;const v=process.env.VERSION;const id=process.env.PKG_ID;m.manifest=\`https://github.com/\${r}/releases/latest/download/system.json\`;m.download=\`https://github.com/\${r}/releases/download/v\${v}/\${id}-\${v}.zip\`;fs.writeFileSync(path,JSON.stringify(m,null,2)+'\n');"
-
-      - name: Build release zip
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          PKG_ID: '{{ID}}'
-        run: |
-          cd dist
-          zip -r "../${PKG_ID}-${VERSION}.zip" .
+          export VTTFORGE_DOWNLOAD_URL="https://github.com/$REPO/releases/download/v$VERSION/$PKG_ID-{version}.zip"
+          pnpm build
 
       - name: Create GitHub Release
         env:

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@vttforge/cli": "^0.18.0",
-    "@vttforge/vite-plugin": "^0.5.0",
+    "@vttforge/vite-plugin": "^0.6.0",
     "vite": "^8.2.2"
   },
   "engines": {

--- a/packages/cli/templates/system-ts/.github/workflows/release.yml
+++ b/packages/cli/templates/system-ts/.github/workflows/release.yml
@@ -46,31 +46,18 @@ jobs:
         run: |
           node -e "const fs=require('node:fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version=process.env.VERSION;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
 
-      # We invoke vite directly (not `pnpm build` → `vttforge build`) because
-      # the release workflow needs to:
-      #   1. Run vite build → emit dist/system.json
-      #   2. Patch manifest/download URLs into dist/system.json
-      #   3. Zip dist/ → release artifact (so the zipped manifest carries URLs)
-      # `vttforge build` zips at step 1, which would freeze the un-patched
-      # manifest. Eventually the vite-plugin will support env-driven URL
-      # injection and this dance disappears.
-      - run: pnpm exec vite build
-
-      - name: Inject release URLs into manifest
+      # `vttforge build` emits dist/ and zips it in one step. The plugin
+      # writes the two release URLs into the manifest before the zip is made,
+      # so the archive carries them.
+      - name: Build
         env:
           VERSION: ${{ steps.version.outputs.version }}
           REPO: ${{ github.repository }}
           PKG_ID: '{{ID}}'
+          VTTFORGE_MANIFEST_URL: https://github.com/${{ github.repository }}/releases/latest/download/system.json
         run: |
-          node -e "const fs=require('node:fs');const path='dist/system.json';const m=JSON.parse(fs.readFileSync(path,'utf8'));const r=process.env.REPO;const v=process.env.VERSION;const id=process.env.PKG_ID;m.manifest=\`https://github.com/\${r}/releases/latest/download/system.json\`;m.download=\`https://github.com/\${r}/releases/download/v\${v}/\${id}-\${v}.zip\`;fs.writeFileSync(path,JSON.stringify(m,null,2)+'\n');"
-
-      - name: Build release zip
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          PKG_ID: '{{ID}}'
-        run: |
-          cd dist
-          zip -r "../${PKG_ID}-${VERSION}.zip" .
+          export VTTFORGE_DOWNLOAD_URL="https://github.com/$REPO/releases/download/v$VERSION/$PKG_ID-{version}.zip"
+          pnpm build
 
       - name: Create GitHub Release
         env:

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@vttforge/cli": "^0.18.0",
     "@vttforge/types": "^0.5.0",
-    "@vttforge/vite-plugin": "^0.5.0",
+    "@vttforge/vite-plugin": "^0.6.0",
     "typescript": "^5.4.0",
     "vite": "^8.2.2"
   },

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -233,6 +233,58 @@ describe('@vttforge/vite-plugin', () => {
       expect(manifest.styles).toEqual([{ src: 'styles/main.css' }]);
     });
 
+    it('writes the release URLs, and expands {version} in the download', async () => {
+      const plugin = mainPlugin(
+        vttforge(
+          defaultOptions({
+            manifestUrl: 'https://example.invalid/releases/latest/download/system.json',
+            downloadUrl: 'https://example.invalid/releases/download/v{version}/pkg-{version}.zip',
+          }),
+        ),
+      );
+      await invokeConfigHook(plugin, workdir);
+      await invokeHook(plugin, 'writeBundle');
+      const manifest = JSON.parse(
+        readFileSync(resolve(workdir, 'dist/system.json'), 'utf8'),
+      ) as Record<string, unknown>;
+      expect(manifest.manifest).toBe(
+        'https://example.invalid/releases/latest/download/system.json',
+      );
+      // The version comes from package.json, the same source the sync uses.
+      expect(manifest.download).toBe(
+        'https://example.invalid/releases/download/v9.9.9/pkg-9.9.9.zip',
+      );
+    });
+
+    it('reads the release URLs from the environment, for a workflow', async () => {
+      process.env.VTTFORGE_MANIFEST_URL = 'https://example.invalid/m.json';
+      process.env.VTTFORGE_DOWNLOAD_URL = 'https://example.invalid/v{version}.zip';
+      try {
+        const plugin = mainPlugin(vttforge(defaultOptions()));
+        await invokeConfigHook(plugin, workdir);
+        await invokeHook(plugin, 'writeBundle');
+        const manifest = JSON.parse(
+          readFileSync(resolve(workdir, 'dist/system.json'), 'utf8'),
+        ) as Record<string, unknown>;
+        expect(manifest.manifest).toBe('https://example.invalid/m.json');
+        expect(manifest.download).toBe('https://example.invalid/v9.9.9.zip');
+      } finally {
+        delete process.env.VTTFORGE_MANIFEST_URL;
+        delete process.env.VTTFORGE_DOWNLOAD_URL;
+      }
+    });
+
+    it('leaves the manifest alone when neither URL is given', async () => {
+      const plugin = mainPlugin(vttforge(defaultOptions()));
+      await invokeConfigHook(plugin, workdir);
+      await invokeHook(plugin, 'writeBundle');
+      const manifest = JSON.parse(
+        readFileSync(resolve(workdir, 'dist/system.json'), 'utf8'),
+      ) as Record<string, unknown>;
+      expect(manifest.manifest).toBeUndefined();
+      expect(manifest.download).toBeUndefined();
+    });
+
     it('throws when manifest id does not match plugin option', async () => {
       const plugin = mainPlugin(vttforge(defaultOptions({ id: 'wrong-id' })));
       await invokeConfigHook(plugin, workdir);

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -57,6 +57,24 @@ export interface VttforgeOptions {
    * always copied separately so the version sync hook can rewrite it.
    */
   staticAssets?: string[];
+  /**
+   * The `manifest` URL written into the built manifest: where Foundry looks
+   * to learn whether a newer release exists.
+   *
+   * Falls back to `VTTFORGE_MANIFEST_URL`, so a release workflow sets it
+   * without editing the Vite config. Left unset, whatever the source manifest
+   * holds is kept.
+   */
+  manifestUrl?: string;
+  /**
+   * The `download` URL written into the built manifest: the archive of this
+   * version. `{version}` is replaced with the version being built, which is
+   * the one thing that changes per release.
+   *
+   * Falls back to `VTTFORGE_DOWNLOAD_URL`. Left unset, whatever the source
+   * manifest holds is kept.
+   */
+  downloadUrl?: string;
 }
 
 interface ResolvedOptions {
@@ -65,6 +83,8 @@ interface ResolvedOptions {
   entry: string;
   manifest: string;
   staticAssets: string[];
+  manifestUrl: string | undefined;
+  downloadUrl: string | undefined;
   root: string;
   outDir: string;
 }
@@ -90,6 +110,8 @@ function resolveOptions(options: VttforgeOptions, root: string): ResolvedOptions
     entry,
     manifest,
     staticAssets,
+    manifestUrl: options.manifestUrl ?? process.env.VTTFORGE_MANIFEST_URL,
+    downloadUrl: options.downloadUrl ?? process.env.VTTFORGE_DOWNLOAD_URL,
     root,
     outDir: resolve(root, 'dist'),
   };
@@ -221,6 +243,17 @@ function syncManifest(opts: ResolvedOptions, builtCssSources: Set<string>): Mani
   const pkg = readJsonSafe(resolve(opts.root, 'package.json'));
   if (pkg && typeof pkg.version === 'string') {
     manifest.version = pkg.version;
+  }
+  // The two release URLs, written here rather than patched into dist/ after
+  // the fact. `vttforge build` zips as soon as the build finishes, so a
+  // workflow that edits the manifest afterwards ships a zip holding the
+  // unedited one.
+  if (opts.manifestUrl !== undefined) {
+    manifest.manifest = opts.manifestUrl;
+  }
+  if (opts.downloadUrl !== undefined) {
+    const version = typeof manifest.version === 'string' ? manifest.version : '';
+    manifest.download = opts.downloadUrl.replaceAll('{version}', version);
   }
   manifest.esmodules = [JS_ENTRY_FILENAME];
   const originalStyles = extractStyleEntries(manifest.styles);


### PR DESCRIPTION
Last of four, from building a module on the SDK from scratch. Merge after types, core and cli.

## The problem, in the template's own words

The release workflow the templates ship carried this:

> We invoke vite directly (not `pnpm build` → `vttforge build`) because the release workflow needs to: run vite build, patch manifest/download URLs into `dist/module.json`, zip `dist/`. `vttforge build` zips at step 1, which would freeze the un-patched manifest. Eventually the vite-plugin will support env-driven URL injection and this dance disappears.

So every scaffolded project shipped with a hand-rolled `node -e` rewriting JSON inside a YAML string, and a hand-rolled `zip`. The comment named the fix and nobody had written it.

## The change

The plugin already rewrites `version`, `esmodules` and `styles` into the built manifest. It now writes `manifest` and `download` as well.

```js
vttforge({
  id: 'my-module',
  kind: 'module',
  manifestUrl: 'https://github.com/me/my-module/releases/latest/download/module.json',
  downloadUrl: 'https://github.com/me/my-module/releases/download/v{version}/my-module-{version}.zip',
})
```

Both fall back to `VTTFORGE_MANIFEST_URL` and `VTTFORGE_DOWNLOAD_URL`, which is how the workflow uses them: a release sets two variables and runs `pnpm build`. `{version}` is replaced with the version being built, read from the same `package.json` the version sync uses. Give neither and the source manifest is left exactly as written.

## The workflow the templates ship

Three steps collapse to one. No `node -e`, no hand-rolled `zip`.

## The rule that had to learn

`vttforge audit` rule 020 exists because a workflow that zips the checkout publishes a package with no entry file. It read the new workflow as exactly that fault, because the artifact is a zip whose name has no `dist/` in it.

It now tracks whether `vttforge build` ran, directly or through a `build` script that is `vttforge build`. That command writes the zip from `dist/` itself, so the artifact is already right. A workflow that runs a plain `vite build` and then zips the source tree is still a HIGH finding, and there is a test for that, because a fix that silenced the rule would be worse than the false positive.

## Pins

A vite-plugin minor moves the templates out of their caret range, so they pin `^0.6.0`.

## Verified

`pnpm typecheck`, `pnpm test` and `pnpm lint` with `--force`. Three plugin tests cover the option form, the environment form, and that an absent option leaves the manifest alone.

---

**Stacking.** The four branches are stacked, each cut from the one before, so this PR's diff against `main` contains the earlier commits too. This repo squash-merges, so after each earlier PR lands this one needs a rebase before it will merge cleanly. Say the word and I will rebase in order.