### PR TITLE
chore: refuse a path out of this machine's home

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,8 @@
 pre-commit:
   parallel: true
   commands:
+    absolute-paths:
+      run: node scripts/check-no-absolute-paths.mjs
     biome:
       glob: '*.{js,jsx,ts,tsx,mjs,cjs,json,jsonc,css,md,yml,yaml}'
       run: pnpm exec biome check --staged --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "turbo run test",
     "publint": "turbo run publint",
     "attw": "turbo run attw",
-    "lint": "biome ci . --colors=off && syncpack lint && node scripts/check-template-pins.mjs",
+    "lint": "biome ci . --colors=off && syncpack lint && node scripts/check-template-pins.mjs && node scripts/check-no-absolute-paths.mjs",
     "format": "biome check --write . --colors=off",
     "knip": "knip",
     "changeset": "changeset",

--- a/scripts/check-no-absolute-paths.mjs
+++ b/scripts/check-no-absolute-paths.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Refuse a path out of the home directory of the machine a change was written
+ * on, and any absolute `link:` or `file:` dependency specifier.
+ *
+ * A lockfile is the usual carrier. Pointing a dependency at a local checkout,
+ * to try code that is not published yet, makes the package manager write the
+ * developer's home directory into the lock. Restoring the version range
+ * afterwards does not rewrite the lock, and `git add -A` sweeps the stale file
+ * into the commit.
+ *
+ * That is not a secret, and it is still not ours to publish. Taking one out of
+ * a pushed commit costs a history rewrite, and a rewrite alone leaves the old
+ * blob readable by SHA through the forge's API.
+ *
+ * The test matches this machine's own home, not `/Users/` or `/home/`. A test
+ * asserting where Foundry keeps its data on macOS says `/Users/dev`, which is
+ * a fixture and not anyone's home.
+ *
+ * Two modes. With a staged diff, read the added lines: that is the hook. With
+ * none, read every tracked file: that is CI, and the mode that still catches a
+ * commit made with `--no-verify`.
+ */
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+
+const HOME = homedir();
+
+/** Escape for both POSIX ERE and JS RegExp. */
+function escapeForPattern(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const ERE = `(${escapeForPattern(HOME)}|(link|file):/)`;
+const JS_RE = new RegExp(`(${escapeForPattern(HOME)}|(?:link|file):/)`);
+
+/** A line that exists to describe the rule, not to break it. */
+const ALLOWED = [/check-no-absolute-paths/];
+
+function git(args) {
+  const run = spawnSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  // `git grep` exits 1 for "no matches", which is success here. Anything above
+  // that is a broken invocation, and reporting it as "nothing found" is how a
+  // check returns a result it never computed.
+  if (run.status !== null && run.status > 1) {
+    console.error(`check-no-absolute-paths: git ${args.join(' ')} failed`);
+    console.error(run.stderr?.trim() ?? '');
+    process.exit(2);
+  }
+  return run.stdout ?? '';
+}
+
+const staged = git(['diff', '--cached', '-U0']);
+const fromStage = staged.trim() !== '';
+
+const lines = fromStage
+  ? staged
+      .split('\n')
+      .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+      .map((line) => line.slice(1))
+  : git(['grep', '-nI', '-E', ERE, '--', '.']).split('\n').filter(Boolean);
+
+const hits = lines.filter((line) => JS_RE.test(line) && !ALLOWED.some((ok) => ok.test(line)));
+
+if (hits.length > 0) {
+  console.error(`A path from this machine is ${fromStage ? 'staged' : 'tracked'}:\n`);
+  for (const hit of hits.slice(0, 20)) console.error(`  ${hit}`);
+  if (hits.length > 20) console.error(`  ... and ${hits.length - 20} more`);
+  console.error('\nReinstall, or take the file out of the commit.');
+  process.exit(1);
+}


### PR DESCRIPTION
A guard for a mistake that already cost a history rewrite and a deleted repository.

## What happened

Building a module on the SDK meant pointing its dependencies at local checkouts, because the SDK versions it needs are not published yet. `pnpm install` wrote the absolute path into the lockfile. Restoring the version ranges afterwards did not rewrite the lock, `git add -A` swept the stale file in, and four lines of `specifier: link:/Users/...` reached a remote.

A history rewrite is not enough on its own: the old blob stays readable by SHA through the GitHub API until their garbage collection runs, and there is no way to force it. That one ended with the repository deleted and recreated.

## The check

`scripts/check-no-absolute-paths.mjs` refuses this machine's own home, from `os.homedir()`, and any absolute `link:` or `file:` dependency specifier.

**Not `/Users/` or `/home/`.** The first draft matched those and reported eleven findings in `foundry-data-dir.test.ts`, which asserts where Foundry keeps its data on macOS and Linux using `/Users/dev` and `/home/dev`. Those are fixtures. Matching the real home is both narrower and the thing that actually went wrong.

Two modes:

- A staged diff: read the added lines. That is the hook.
- No staged diff: read every tracked file through `git grep`. That is CI, and it is the mode that still catches a commit made with `--no-verify`.

`git grep` exits 1 for "no matches" and above that for a broken invocation. The second is an error here, not a pass. The first draft derived the expression from the JS regex, produced an invalid POSIX ERE, and exited 0 on a tree it never scanned. A check that reports a result it did not compute is worse than no check, and this repo has paid for that twice.

## Wired in

An `absolute-paths` command in `lefthook.yml`, and the tail of `pnpm lint` so CI runs the tree scan.

## Proven against the input it exists to catch

Four runs, not four assertions:

1. Clean tree, nothing staged: exit 0.
2. `x: link:/Users/<home>/y` staged: exit 1, prints the line.
3. The same line committed with `--no-verify`, then scanned with nothing staged: exit 1, prints file and line number.
4. `foundry-data-dir.test.ts` with its `/Users/dev` fixtures still tracked: exit 0.

## Also

`.gitignore` picks up `.firecrawl/`, the scrape output this work left in the tree. It got swept into a staged commit by the same `git add -A` reflex, which is how I noticed.

## Stacking

Cut from `main`, so this is independent of the other four open PRs and can merge in any order relative to them.