### PR TITLE
fix(cli): the templates declare packageManager instead of pinning pnpm twice

### DIFF
--- a/.changeset/template-package-manager.md
+++ b/.changeset/template-package-manager.md
@@ -1,0 +1,12 @@
+---
+'@vttforge/cli': patch
+---
+
+The scaffold templates declare `packageManager` and stop pinning a pnpm
+version in the release workflow.
+
+`pnpm/action-setup` refuses to run when a `version` input and a
+`packageManager` field both name a pnpm version. The templates set the input
+and left the field out, so a project that later added `packageManager`, which
+is what Corepack asks for, broke its own release workflow with `Multiple
+versions of pnpm specified`. The manifest field is now the one source.

--- a/packages/cli/templates/module-js/.github/workflows/release.yml
+++ b/packages/cli/templates/module-js/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # No `version` here: package.json's `packageManager` is the one source,
+      # and the action fails when both are set.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/cli/templates/module-js/package.json
+++ b/packages/cli/templates/module-js/package.json
@@ -22,5 +22,6 @@
   },
   "engines": {
     "node": ">=26"
-  }
+  },
+  "packageManager": "pnpm@11.25.0"
 }

--- a/packages/cli/templates/module-ts/.github/workflows/release.yml
+++ b/packages/cli/templates/module-ts/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # No `version` here: package.json's `packageManager` is the one source,
+      # and the action fails when both are set.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/cli/templates/module-ts/package.json
+++ b/packages/cli/templates/module-ts/package.json
@@ -25,5 +25,6 @@
   },
   "engines": {
     "node": ">=26"
-  }
+  },
+  "packageManager": "pnpm@11.25.0"
 }

--- a/packages/cli/templates/system-js/.github/workflows/release.yml
+++ b/packages/cli/templates/system-js/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # No `version` here: package.json's `packageManager` is the one source,
+      # and the action fails when both are set.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/cli/templates/system-js/package.json
+++ b/packages/cli/templates/system-js/package.json
@@ -23,5 +23,6 @@
   },
   "engines": {
     "node": ">=26"
-  }
+  },
+  "packageManager": "pnpm@11.25.0"
 }

--- a/packages/cli/templates/system-ts/.github/workflows/release.yml
+++ b/packages/cli/templates/system-ts/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # No `version` here: package.json's `packageManager` is the one source,
+      # and the action fails when both are set.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/cli/templates/system-ts/package.json
+++ b/packages/cli/templates/system-ts/package.json
@@ -26,5 +26,6 @@
   },
   "engines": {
     "node": ">=26"
-  }
+  },
+  "packageManager": "pnpm@11.25.0"
 }


### PR DESCRIPTION
Found by adding CI to a module built on the SDK. The first run failed, and the cause came straight from the template.

## The trap

`pnpm/action-setup` refuses to run when both a `version` input and a `packageManager` field name a pnpm version:

```
Error: Multiple versions of pnpm specified:
  - version 11 in the GitHub Action config with the key "version"
  - version pnpm@11.25.0 in the package.json with the key "packageManager"
```

The templates set the input and left the field out. That works on a fresh scaffold, so nothing caught it. It breaks the moment a project adds `packageManager`, which is what Corepack asks for and what most people do sooner or later. The failure lands in the release workflow, the one place you find out late.

## The change

The four templates declare `packageManager: "pnpm@11.25.0"` and drop the `version` input from `pnpm/action-setup` in the release workflow. The manifest field is the one source, with a comment saying why the input is absent.

## Verified

`pnpm typecheck`, `pnpm test` and `pnpm lint` with `--force`. The module that found it now has a green CI run on the same shape: no `version` input, `packageManager` in the manifest, `pnpm install --frozen-lockfile` resolving from it.

Cut from `main`.