### PR TITLE
feat(testing): boot a real Foundry from @vttforge/testing/container

### DIFF
--- a/.changeset/testing-container-entry.md
+++ b/.changeset/testing-container-entry.md
@@ -1,0 +1,53 @@
+---
+'@vttforge/testing': minor
+---
+
+New entry point: `@vttforge/testing/container` boots a real Foundry in Docker,
+installs your build into it, and hands back the URL it answers on.
+
+Until now a package built on this SDK could test against mocks under Vitest, or
+against a world a person opened under Quench, and had nothing for the case in
+between: a CI job with no world, checking that the package it just built loads
+at all. The code that does this ran only inside this repo. It is published now.
+
+```ts
+import { startFoundryContainer } from '@vttforge/testing/container';
+
+const foundry = await startFoundryContainer({
+  acceptLicense: true,
+  name: 'my-module-e2e',
+  packages: [
+    { kind: 'system', id: 'some-system', from: 'test/fixtures/system' },
+    { kind: 'module', id: 'my-module', from: 'dist' },
+  ],
+});
+
+try {
+  await page.goto(foundry.baseUrl);
+} finally {
+  foundry.stop();
+}
+```
+
+Needs `docker` on the PATH, plus `FOUNDRY_LICENSE_KEY`, `FOUNDRY_USERNAME` and
+`FOUNDRY_PASSWORD` in the environment. Docker reads each by name, so no
+credential lands in an argument list.
+
+**You accept the licence, not this code.** Booting Foundry records an answer to
+its licence agreement. `startFoundryContainer` throws unless you pass
+`acceptLicense: true` or set `FOUNDRY_ACCEPT_LICENSE=1`. Read the agreement
+first.
+
+Two things the API is shaped around. Foundry scans its packages directory once,
+at startup, so `packages` installs before the world launches and a package
+added later needs `restart()`. And the container name, the volume and the world
+id all default, so two runs sharing a name fight over one container: name them
+per project.
+
+`stopFoundryContainer(name)` and `foundryContainerLogs(name)` do the same as the
+handle's `stop()` and `logs()`, for a teardown script running in its own process
+and for a boot that failed before there was a handle to hold.
+
+Nothing existing changes. The root, `/vitest` and `/quench` entries are
+untouched, and the new one is not re-exported from the root, because it reads
+`node:child_process` and would break a browser-side import of the package.

--- a/apps/docs/scripts/typedoc.mjs
+++ b/apps/docs/scripts/typedoc.mjs
@@ -21,12 +21,17 @@ const repoRoot = resolve(appRoot, '..', '..');
 const require = createRequire(import.meta.url);
 const typedoc = join(dirname(require.resolve('typedoc/package.json')), 'bin', 'typedoc');
 
+// `entries` rather than one entry, because a package whose subpaths cannot
+// share a root export still has to appear here whole.
 const PACKAGES = [
-  { name: 'core', entry: 'src/index.ts' },
-  { name: 'types', entry: 'src/index.ts' },
-  { name: 'cli', entry: 'src/index.ts' },
-  { name: 'vite-plugin', entry: 'src/index.ts' },
-  { name: 'testing', entry: 'src/index.ts' },
+  { name: 'core', entries: ['src/index.ts'] },
+  { name: 'types', entries: ['src/index.ts'] },
+  { name: 'cli', entries: ['src/index.ts'] },
+  { name: 'vite-plugin', entries: ['src/index.ts'] },
+  // The root re-exports the vitest and quench entries. It does not re-export
+  // the container one, which reads `node:child_process` and would then break a
+  // browser-side import, so that entry is named here as well.
+  { name: 'testing', entries: ['src/index.ts', 'src/container/index.ts'] },
 ];
 
 for (const pkg of PACKAGES) {
@@ -62,7 +67,7 @@ for (const pkg of PACKAGES) {
       'false',
       '--logLevel',
       'Warn',
-      join(packageDir, pkg.entry),
+      ...pkg.entries.map((entry) => join(packageDir, entry)),
     ],
     { stdio: 'inherit' },
   );

--- a/apps/docs/src/guide/testing.md
+++ b/apps/docs/src/guide/testing.md
@@ -92,6 +92,51 @@ registerBatch('my-module.sheets', ({ describe, it, assert }) => {
 before registering. Outside Foundry it does nothing, so a file holding both
 kinds of test still imports under Vitest.
 
+## Against a real Foundry
+
+Quench runs inside a world someone already opened. The other case is a world
+that does not exist yet: a CI job, or a check that the package you built loads
+at all. `@vttforge/testing/container` boots one.
+
+```ts
+import { startFoundryContainer } from '@vttforge/testing/container';
+
+const foundry = await startFoundryContainer({
+  acceptLicense: true,
+  name: 'my-module-e2e',
+  packages: [
+    { kind: 'system', id: 'some-system', from: 'test/fixtures/system' },
+    { kind: 'module', id: 'my-module', from: 'dist' },
+  ],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.goto(foundry.baseUrl);
+  // ... join the world and drive it
+} finally {
+  foundry.stop();
+}
+```
+
+It needs `docker` on the PATH and three variables in the environment:
+`FOUNDRY_LICENSE_KEY`, `FOUNDRY_USERNAME` and `FOUNDRY_PASSWORD`. Docker reads
+each by name, so no credential goes into an argument list. The first run
+downloads Foundry; later runs reuse the data volume and start in seconds.
+
+Booting Foundry records an answer to its licence agreement, and this code will
+not answer it for you. Read the agreement, then pass `acceptLicense: true` or
+set `FOUNDRY_ACCEPT_LICENSE=1`.
+
+Two things the API is shaped around. Foundry scans its packages directory once,
+at startup, so pass `packages` and let it install before the world launches; a
+package added later needs `restart()`. And the container name, the volume and
+the world id all default, so two runs sharing a name fight over one container.
+Name them per project.
+
+This SDK's own end-to-end run uses this entry point and nothing private, so the
+API a consumer gets is the API the repo tests with.
+
 ## Where to draw the line
 
 Anything before `_renderHTML` is testable with a mock. Real rendering, sockets
@@ -106,5 +151,5 @@ framework: the Handlebars mixin, `PARTS`, template loading, Foundry's own
 helpers, tabs, form handling. A copy of that inside a mock would render
 something like what Foundry renders, and a test that passes against the copy
 and fails in the real thing is worse than no test. Test the context with
-`_prepareContext` under Vitest, and test the render under Quench or the
-end-to-end run.
+`_prepareContext` under Vitest, and test the render under Quench or in a
+container.

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -9,6 +9,7 @@
     "e2e:down": "node -e \"import('./scripts/foundry.mjs').then(m => m.stop())\""
   },
   "devDependencies": {
-    "@playwright/test": "catalog:"
+    "@playwright/test": "catalog:",
+    "@vttforge/testing": "workspace:*"
   }
 }

--- a/apps/e2e/scripts/foundry.mjs
+++ b/apps/e2e/scripts/foundry.mjs
@@ -1,278 +1,74 @@
 /**
- * Boot a real Foundry v14 in Docker, with the example system and module
- * installed, and leave it sitting on the join screen.
+ * The end-to-end run's Foundry, booted through the same API a consumer gets.
  *
- * Foundry's setup screens are never driven, because that is the part that
- * would rot. Three plain steps replace them:
+ * Everything that boots a container lives in `@vttforge/testing/container`.
+ * This file is what an SDK consumer would write: pick the packages, pick the
+ * names, hold the handle. It stays here so the published API is exercised by
+ * the repo's own run and not only by its tests.
  *
- *   1. The end-user licence is a real HTML form. One POST signs it, and the
- *      signature lands in `Config/license.json`.
- *   2. A world is a directory with a manifest. Writing `world.json` is enough
- *      for Foundry to know the world exists.
- *   3. `Config/options.json` carries a `world` field. Setting it makes the
- *      next start launch that world and create its Gamemaster.
- *
- * So the browser only has to join a world that is already running.
- *
- * ## Why nothing here touches the host filesystem
- *
- * CI runs this from inside a container that shares the host's Docker socket.
- * Every path in a `docker` command is then resolved by the host daemon, not by
- * this process, so a bind mount and a `writeFileSync` to the same string are
- * two different directories. Foundry's data lives in a named volume instead,
- * and everything seeded into it goes through `docker cp`, which crosses that
- * boundary correctly from either side.
- *
- * The same split applies to the network: a published port lands on the host,
- * which is not this process's `localhost` when this process is in a container.
- * So when there is a container to join, Foundry joins its network and is
- * reached by name; otherwise the port is published and reached on localhost.
+ * Playwright runs `globalSetup` in one process and the specs in others, so the
+ * URL crosses that boundary through `E2E_BASE_URL`. The container handle does
+ * not; only the process that started it can stop it.
  */
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  foundryContainerLogs,
+  startFoundryContainer,
+  stopFoundryContainer,
+} from '@vttforge/testing/container';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
+/** Fixed, so `e2e:down` can take the container down from its own process. */
 const CONTAINER = 'vttforge-e2e';
-/** Named, so the licensed Foundry download survives between runs. */
-const VOLUME = process.env.E2E_VOLUME ?? 'vttforge-e2e-data';
-const PORT = Number(process.env.E2E_PORT ?? 30001);
-const WORLD_ID = 'e2e';
 
-/** Pinned rather than floating: a build the run does not choose is a build it cannot report. */
-const IMAGE = process.env.E2E_FOUNDRY_IMAGE ?? 'felddy/foundryvtt:14';
-
-/** The three the felddy image needs to fetch a licensed Foundry. */
-const REQUIRED_ENV = ['FOUNDRY_LICENSE_KEY', 'FOUNDRY_USERNAME', 'FOUNDRY_PASSWORD'];
-
-/** Set by `start`, read by the tests. Absolute, because it is not always localhost. */
+/** Set by `start`, read by the specs. Absolute, because it is not always localhost. */
 export function baseUrl() {
   const url = process.env.E2E_BASE_URL;
   if (!url) throw new Error('Foundry has not been started: E2E_BASE_URL is not set.');
   return url;
 }
 
-function docker(args, options = {}) {
-  return execFileSync('docker', args, { encoding: 'utf8', ...options });
-}
+/** The handle, once this process has started one. */
+let running;
 
-/**
- * Run a throwaway shell against the data volume. Works while Foundry is
- * stopped. As root, because the main container runs as root and everything it
- * writes into the volume is owned by root.
- */
-function inVolume(script) {
-  return docker([
-    'run',
-    '--rm',
-    '-u',
-    '0:0',
-    '-v',
-    `${VOLUME}:/data`,
-    '--entrypoint',
-    'sh',
-    IMAGE,
-    '-c',
-    script,
-  ]);
-}
-
-/**
- * How this process can reach a container it starts.
- *
- * When this process is itself a container the daemon knows about, the two
- * share a network and Foundry answers to its name. Otherwise the port is
- * published and answers on localhost.
- */
-function reachability() {
-  const self = process.env.HOSTNAME;
-  if (self) {
-    try {
-      const networks = docker([
-        'inspect',
-        self,
-        '--format',
-        '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}} {{end}}',
-      ]).trim();
-      const network = networks.split(/\s+/).filter(Boolean)[0];
-      if (network) {
-        return { args: ['--network', network], url: `http://${CONTAINER}:30000`, network };
-      }
-    } catch {
-      // Not a container this daemon knows. Publishing a port is right after all.
-    }
-  }
-  return { args: ['-p', `${PORT}:30000`], url: `http://localhost:${PORT}`, network: null };
-}
-
-async function waitFor(label, check, { attempts = 150, everyMs = 2000 } = {}) {
-  for (let i = 0; i < attempts; i += 1) {
-    if (await check()) return;
-    await new Promise((resolve) => setTimeout(resolve, everyMs));
-  }
-  throw new Error(`Timed out waiting for ${label} after ${(attempts * everyMs) / 1000}s`);
-}
-
-async function answers() {
-  try {
-    // Every Foundry route redirects somewhere, so any answer means it is up.
-    await fetch(baseUrl(), { redirect: 'manual' });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/** Where Foundry is redirecting to, which is how it reports the stage it is at. */
-async function stage() {
-  const response = await fetch(baseUrl(), { redirect: 'manual' });
-  return response.headers.get('location') ?? response.url;
-}
-
-/** Copy a built package into the volume, and hand back its manifest. */
-function installPackage(kind, id, from) {
-  const manifestName = kind === 'systems' ? 'system.json' : 'module.json';
-  inVolume(`rm -rf /data/Data/${kind}/${id} && mkdir -p /data/Data/${kind}/${id}`);
-  // The trailing `/.` copies the contents rather than the directory itself.
-  docker(['cp', `${from}/.`, `${CONTAINER}:/data/Data/${kind}/${id}`]);
-  return JSON.parse(readFileSync(join(from, manifestName), 'utf8'));
-}
-
-/** Read a config file out of the volume, hand it to `edit`, and put it back. */
-function editJson(pathInVolume, edit) {
-  const scratch = mkdtempSync(join(tmpdir(), 'vttforge-e2e-'));
-  const local = join(scratch, 'file.json');
-  docker(['cp', `${CONTAINER}:${pathInVolume}`, local]);
-  const value = edit(JSON.parse(readFileSync(local, 'utf8')));
-  writeFileSync(local, `${JSON.stringify(value, null, 2)}\n`);
-  docker(['cp', local, `${CONTAINER}:${pathInVolume}`]);
-}
-
-function writeWorld(system) {
-  const scratch = mkdtempSync(join(tmpdir(), 'vttforge-e2e-'));
-  const local = join(scratch, 'world.json');
-  writeFileSync(
-    local,
-    `${JSON.stringify(
+export async function start() {
+  running = await startFoundryContainer({
+    // The owner of this repo accepts Foundry's licence agreement for its own
+    // end-to-end run. A consumer answers for themselves.
+    acceptLicense: true,
+    name: CONTAINER,
+    volume: process.env.E2E_VOLUME ?? 'vttforge-e2e-data',
+    port: Number(process.env.E2E_PORT ?? 30001),
+    worldId: 'e2e',
+    worldTitle: 'VTTForge end-to-end',
+    image: process.env.E2E_FOUNDRY_IMAGE ?? 'felddy/foundryvtt:14',
+    coreVersion: process.env.E2E_CORE_VERSION ?? '14',
+    adminKey: 'vttforge-e2e',
+    packages: [
       {
-        id: WORLD_ID,
-        title: 'VTTForge end-to-end',
-        description: 'Created by the end-to-end test. Thrown away with the run.',
-        system: system.id,
-        systemVersion: system.version,
-        coreVersion: process.env.E2E_CORE_VERSION ?? '14',
-        version: '1.0.0',
-        compatibility: { minimum: '14', verified: '14' },
-        authors: [],
-        packs: [],
-        relationships: {},
+        kind: 'system',
+        id: 'vttforge-example',
+        from: join(repoRoot, 'examples/simple-system/dist'),
       },
-      null,
-      2,
-    )}\n`,
-  );
-  inVolume(`mkdir -p /data/Data/worlds/${WORLD_ID}`);
-  docker(['cp', local, `${CONTAINER}:/data/Data/worlds/${WORLD_ID}/world.json`]);
+      {
+        kind: 'module',
+        id: 'vttforge-example-module',
+        from: join(repoRoot, 'examples/simple-module/dist'),
+      },
+    ],
+  });
+  process.env.E2E_BASE_URL = running.baseUrl;
+  return { baseUrl: running.baseUrl, system: running.system, network: running.network };
 }
 
 export function stop() {
-  try {
-    docker(['rm', '-f', CONTAINER], { stdio: 'ignore' });
-  } catch {
-    // Not running. Nothing to stop.
-  }
+  stopFoundryContainer(CONTAINER);
+  running = undefined;
 }
 
-export async function start() {
-  const missing = REQUIRED_ENV.filter((name) => !process.env[name]);
-  if (missing.length > 0) {
-    throw new Error(
-      `Cannot boot Foundry without ${missing.join(', ')}. Copy .env.example to .env, or set them in the environment.`,
-    );
-  }
-
-  stop();
-  // The worlds and the config are per-run; the downloaded Foundry beside them
-  // is not, and re-downloading it every run would cost two minutes each time.
-  try {
-    inVolume('rm -rf /data/Data /data/Config');
-  } catch {
-    // First run: the volume does not exist yet, and `docker run` will make it.
-  }
-
-  const reach = reachability();
-  process.env.E2E_BASE_URL = reach.url;
-
-  docker([
-    'run',
-    '-d',
-    '--name',
-    CONTAINER,
-    // felddy's entrypoint chowns the volume on first boot, then drops privileges.
-    '-u',
-    '0:0',
-    ...reach.args,
-    '-e',
-    'FOUNDRY_LICENSE_KEY',
-    '-e',
-    'FOUNDRY_USERNAME',
-    '-e',
-    'FOUNDRY_PASSWORD',
-    '-e',
-    'FOUNDRY_ADMIN_KEY=vttforge-e2e',
-    '-e',
-    'CONTAINER_PRESERVE_CONFIG=true',
-    '-v',
-    `${VOLUME}:/data`,
-    IMAGE,
-  ]);
-
-  await waitFor(`Foundry to answer at ${reach.url}`, answers);
-
-  // 1. Sign the licence. Until this is done every route redirects to /license.
-  await fetch(`${baseUrl()}/license`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({ agree: 'on', accept: '' }),
-    redirect: 'manual',
-  });
-  await waitFor('the licence to be signed', async () => !(await stage()).endsWith('/license'));
-
-  // 2. Install what is under test, and declare a world on it.
-  const system = installPackage(
-    'systems',
-    'vttforge-example',
-    join(repoRoot, 'examples/simple-system/dist'),
-  );
-  installPackage(
-    'modules',
-    'vttforge-example-module',
-    join(repoRoot, 'examples/simple-module/dist'),
-  );
-  writeWorld(system);
-  editJson('/data/Config/options.json', (options) => ({ ...options, world: WORLD_ID }));
-
-  // 3. Restart into it. Foundry refuses to start over its own lock, and
-  // stopping the container does not always clear it. The lock is a directory.
-  docker(['stop', CONTAINER]);
-  inVolume('rm -rf /data/Config/options.json.lock');
-  docker(['start', CONTAINER]);
-
-  await waitFor('Foundry to answer again', answers);
-  await waitFor('the world to launch', async () => (await stage()).endsWith('/join'));
-
-  return { baseUrl: baseUrl(), system, network: reach.network };
-}
-
+/** By name, not through the handle: a boot that failed left no handle behind. */
 export function logs(tail = 40) {
-  try {
-    return docker(['logs', '--tail', String(tail), CONTAINER], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-  } catch {
-    return '(no container logs)';
-  }
+  return foundryContainerLogs(CONTAINER, tail);
 }

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -2,7 +2,7 @@
 
 Helpers for testing Foundry VTT packages.
 
-Two entry points, one for each place a test can run.
+Three entry points, one for each place a test can run.
 
 ## `@vttforge/testing/vitest`
 
@@ -74,10 +74,62 @@ Quench has already loaded registers a batch that never appears. Outside
 Foundry it is a no-op, so a file holding both kinds of test can still be
 imported by the vitest run.
 
+## `@vttforge/testing/container`
+
+Boots a real Foundry in Docker, installs your build into it, and leaves it on
+the join screen. For the questions a mock cannot answer and Quench cannot
+reach: whether the manifest you ship is the one Foundry reads, what a migration
+does to stored documents, whether the package loads at all.
+
+```ts
+import { startFoundryContainer } from '@vttforge/testing/container';
+
+const foundry = await startFoundryContainer({
+  acceptLicense: true,
+  name: 'my-module-e2e',
+  packages: [
+    { kind: 'system', id: 'some-system', from: 'test/fixtures/system' },
+    { kind: 'module', id: 'my-module', from: 'dist' },
+  ],
+});
+
+try {
+  // drive foundry.baseUrl with Playwright, or fetch it directly
+} finally {
+  foundry.stop();
+}
+```
+
+Needs `docker` on the PATH, and `FOUNDRY_LICENSE_KEY`, `FOUNDRY_USERNAME` and
+`FOUNDRY_PASSWORD` in the environment. They are handed to Docker by name, so no
+credential is written into an argument list. The first run downloads Foundry
+and takes a couple of minutes; later runs reuse the data volume.
+
+### You accept the licence
+
+Booting Foundry records an answer to its licence agreement. This code will not
+answer it for you: `startFoundryContainer` throws unless you pass
+`acceptLicense: true` or set `FOUNDRY_ACCEPT_LICENSE=1`. Read the agreement
+first.
+
+### Two things the API makes you notice
+
+Foundry scans its packages directory once, at startup. `install()` copies a
+package in; it becomes visible after `restart()`. That is why `packages` is an
+option on `startFoundryContainer`, which installs before the world launches.
+
+The container name, the volume and the world id all default, and two runs
+sharing a name collide. Name them when a project runs more than one, or runs
+alongside another project's.
+
+`stopFoundryContainer(name)` and `foundryContainerLogs(name)` do the same as
+the handle's `stop()` and `logs()`, for a teardown script in its own process
+and for a boot that failed before there was a handle.
+
 ## What to test where
 
-Anything before `_renderHTML` is testable in Vitest, and real rendering belongs
-to Quench. There is no helper that mounts a sheet against a mock actor and
+Anything before `_renderHTML` is testable in Vitest. Real rendering belongs to
+Quench. What only a whole Foundry can answer belongs to the container. There is no helper that mounts a sheet against a mock actor and
 returns its HTML, and none is planned: a copy of the Application framework
 inside a mock renders something like Foundry, so a test that passes against the
 copy says nothing about the real one.

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/quench/index.d.mts",
       "import": "./dist/quench/index.mjs"
     },
+    "./container": {
+      "types": "./dist/container/index.d.mts",
+      "import": "./dist/container/index.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.mjs",
@@ -50,6 +54,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@types/node": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/testing/src/__tests__/container.test.ts
+++ b/packages/testing/src/__tests__/container.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The guards in front of the container.
+ *
+ * Booting Foundry needs Docker, a licence and a few minutes, so none of that
+ * runs here. What runs is every refusal that happens before the first `docker`
+ * call: they are the whole reason a consumer gets a readable message instead of
+ * a stack trace out of `execFileSync`.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { startFoundryContainer } from '../container/index.js';
+
+const CREDENTIALS = ['FOUNDRY_LICENSE_KEY', 'FOUNDRY_USERNAME', 'FOUNDRY_PASSWORD'] as const;
+const TOUCHED = [...CREDENTIALS, 'FOUNDRY_ACCEPT_LICENSE'] as const;
+
+const saved = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  for (const name of TOUCHED) {
+    saved.set(name, process.env[name]);
+    delete process.env[name];
+  }
+});
+
+afterEach(() => {
+  for (const name of TOUCHED) {
+    const value = saved.get(name);
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+function withCredentials(): void {
+  for (const name of CREDENTIALS) process.env[name] = 'not-a-real-value';
+}
+
+/** A directory holding a manifest, which is what `from` has to point at. */
+function builtSystem(id = 'fixture-system'): string {
+  const dir = mkdtempSync(join(tmpdir(), 'vttforge-container-test-'));
+  writeFileSync(join(dir, 'system.json'), JSON.stringify({ id, version: '1.0.0' }));
+  return dir;
+}
+
+describe('the licence', () => {
+  it('refuses to answer the agreement on the caller behalf', async () => {
+    withCredentials();
+    await expect(startFoundryContainer()).rejects.toThrow(/will not answer it for you/);
+  });
+
+  it('takes acceptLicense as the answer', async () => {
+    // Past the licence, the missing credentials are what it complains about.
+    await expect(startFoundryContainer({ acceptLicense: true })).rejects.toThrow(
+      /Cannot fetch a licensed Foundry/,
+    );
+  });
+
+  it('takes FOUNDRY_ACCEPT_LICENSE as the answer too', async () => {
+    process.env.FOUNDRY_ACCEPT_LICENSE = '1';
+    await expect(startFoundryContainer()).rejects.toThrow(/Cannot fetch a licensed Foundry/);
+  });
+
+  it('does not read 0, false or empty as acceptance', async () => {
+    withCredentials();
+    for (const value of ['0', 'false', '']) {
+      process.env.FOUNDRY_ACCEPT_LICENSE = value;
+      await expect(startFoundryContainer()).rejects.toThrow(/will not answer it for you/);
+    }
+  });
+});
+
+describe('the credentials', () => {
+  it('names every one that is missing', async () => {
+    process.env.FOUNDRY_USERNAME = 'set';
+    await expect(startFoundryContainer({ acceptLicense: true })).rejects.toThrow(
+      /FOUNDRY_LICENSE_KEY, FOUNDRY_PASSWORD/,
+    );
+  });
+
+  it('never puts a value in the message', async () => {
+    process.env.FOUNDRY_LICENSE_KEY = 'super-secret-key';
+    const error = await startFoundryContainer({ acceptLicense: true }).catch((e: Error) => e);
+    // Assert it is the credentials error, so the check below cannot pass by
+    // rejecting somewhere else for some other reason.
+    expect(String(error)).toMatch(/FOUNDRY_USERNAME, FOUNDRY_PASSWORD/);
+    expect(String(error)).not.toContain('super-secret-key');
+  });
+});
+
+describe('the packages', () => {
+  it('asks for a system, because a world runs on one', async () => {
+    withCredentials();
+    await expect(
+      startFoundryContainer({
+        acceptLicense: true,
+        packages: [{ kind: 'module', id: 'only-a-module', from: builtSystem() }],
+      }),
+    ).rejects.toThrow(/A world needs a system/);
+  });
+
+  it('says which directory has no manifest, before starting anything', async () => {
+    withCredentials();
+    const missing = mkdtempSync(join(tmpdir(), 'vttforge-container-empty-'));
+    await expect(
+      startFoundryContainer({
+        acceptLicense: true,
+        packages: [{ kind: 'system', id: 'no-manifest', from: missing }],
+      }),
+    ).rejects.toThrow(/No system\.json in .*Point `from` at the build output/s);
+  });
+
+  it('reads the module manifest for a module', async () => {
+    withCredentials();
+    const dir = mkdtempSync(join(tmpdir(), 'vttforge-container-mod-'));
+    writeFileSync(join(dir, 'system.json'), JSON.stringify({ id: 'wrong', version: '1.0.0' }));
+    await expect(
+      startFoundryContainer({
+        acceptLicense: true,
+        packages: [
+          { kind: 'system', id: 'a-system', from: builtSystem() },
+          { kind: 'module', id: 'a-module', from: dir },
+        ],
+      }),
+    ).rejects.toThrow(/No module\.json in/);
+  });
+});

--- a/packages/testing/src/container/index.ts
+++ b/packages/testing/src/container/index.ts
@@ -112,7 +112,13 @@ export interface FoundryContainer {
    * into a running Foundry stays invisible until `restart()`.
    */
   install(source: FoundryPackageSource): FoundryManifest;
-  /** Stop and start, clearing the lock that a stop does not always clear. */
+  /**
+   * Stop and start, clearing the lock that a stop does not always clear.
+   *
+   * Resolves once the world is joinable, not merely once the server answers.
+   * Those are two different moments, and a package installed between them is
+   * not loaded yet.
+   */
   restart(): Promise<void>;
   /** The container's last log lines. */
   logs(tail?: number): string;
@@ -364,6 +370,10 @@ export async function startFoundryContainer(
     inVolume('rm -rf /data/Config/options.json.lock');
     docker(['start', name]);
     await waitFor('Foundry to answer again', answers);
+    // Answering is not the same as being joinable. Foundry answers as soon as
+    // the server is up and launches the world after, so a caller that returns
+    // here on the first answer can drive a world that is not there yet.
+    await waitFor('the world to launch', async () => (await stage()).endsWith('/join'));
   };
 
   await waitFor(`Foundry to answer at ${baseUrl}`, answers);
@@ -393,9 +403,8 @@ export async function startFoundryContainer(
   });
   editJson('/data/Config/options.json', (value) => ({ ...value, world: worldId }));
 
-  // 3. Restart into it, then wait for the world itself, not just the server.
+  // 3. Restart into it. `restart` waits for the world, not just the server.
   await restart();
-  await waitFor('the world to launch', async () => (await stage()).endsWith('/join'));
 
   return {
     baseUrl,

--- a/packages/testing/src/container/index.ts
+++ b/packages/testing/src/container/index.ts
@@ -1,0 +1,474 @@
+/**
+ * Boot a real Foundry in Docker, install built packages into it, and leave it
+ * on the join screen.
+ *
+ * A unit test with mocked globals answers most questions. Some it cannot: what
+ * a migration does to stored documents, whether a sheet renders, whether the
+ * manifest a package ships is the one Foundry reads. Those need a running
+ * Foundry, and this starts one.
+ *
+ * The setup screens are never driven, because that is the part that would rot.
+ * Three plain steps replace them:
+ *
+ *   1. The licence agreement is an HTML form. One POST records the answer, and
+ *      it lands in `Config/license.json`.
+ *   2. A world is a directory with a manifest. Writing `world.json` is enough
+ *      for Foundry to know the world exists.
+ *   3. `Config/options.json` carries a `world` field. Setting it makes the next
+ *      start launch that world and create its Gamemaster.
+ *
+ * So a browser only has to join a world that is already running.
+ *
+ * ## You accept the licence, not this code
+ *
+ * Step 1 answers a legal agreement between you and Foundry. This code will not
+ * answer it on your behalf: `startFoundryContainer` throws unless you pass
+ * `acceptLicense: true` or set `FOUNDRY_ACCEPT_LICENSE=1`. Read the agreement
+ * first. The same goes for the credentials the image needs to fetch a licensed
+ * build: they are read from the environment and handed to Docker, never stored
+ * and never printed.
+ *
+ * ## Why nothing here touches the host filesystem
+ *
+ * A run inside a container that shares the host's Docker socket resolves every
+ * path in a `docker` command through the host daemon, not through this process.
+ * A bind mount and a `writeFileSync` to the same string are then two different
+ * directories. Foundry's data lives in a named volume instead, and everything
+ * seeded into it goes through `docker cp`, which crosses that boundary
+ * correctly from either side.
+ *
+ * The same split applies to the network. A published port lands on the host,
+ * which is not this process's `localhost` when this process is in a container.
+ * So when there is a container to join, Foundry joins its network and is
+ * reached by name; otherwise the port is published and reached on localhost.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** What kind of package a directory holds, which names its manifest. */
+export type FoundryPackageKind = 'system' | 'module';
+
+/** A built package on disk, ready to copy into the container. */
+export interface FoundryPackageSource {
+  readonly kind: FoundryPackageKind;
+  /** The package id. Becomes the directory name Foundry reads. */
+  readonly id: string;
+  /** Directory holding the build, with its manifest at the root. */
+  readonly from: string;
+}
+
+/** The fields this harness reads out of a manifest. The rest is passed through. */
+export interface FoundryManifest {
+  readonly id: string;
+  readonly version: string;
+  readonly [key: string]: unknown;
+}
+
+export interface FoundryContainerOptions {
+  /**
+   * You have read Foundry's licence agreement and accept it. Required.
+   * `FOUNDRY_ACCEPT_LICENSE=1` in the environment does the same.
+   */
+  readonly acceptLicense?: boolean;
+  /** Packages to install before the world launches. One must be a system. */
+  readonly packages?: readonly FoundryPackageSource[];
+  /** Docker image. Default `felddy/foundryvtt:14`. */
+  readonly image?: string;
+  /** Container name. Default `vttforge-foundry`. Two runs sharing one collide. */
+  readonly name?: string;
+  /** Named volume for Foundry's data. Default `<name>-data`. */
+  readonly volume?: string;
+  /** Host port, used when the port has to be published. Default `30001`. */
+  readonly port?: number;
+  /** Id of the world the run creates. Default `vttforge-test`. */
+  readonly worldId?: string;
+  /** Title of that world. Default `VTTForge test world`. */
+  readonly worldTitle?: string;
+  /** Foundry major version the world declares. Default `14`. */
+  readonly coreVersion?: string;
+  /** Admin password for the setup screens. Default `vttforge`. */
+  readonly adminKey?: string;
+  /** How long to wait on each step. Default 150 tries, 2s apart. */
+  readonly wait?: { readonly attempts?: number; readonly everyMs?: number };
+}
+
+/** A running Foundry. Call `stop()` when the run is over. */
+export interface FoundryContainer {
+  /** Absolute, because it is not always localhost. */
+  readonly baseUrl: string;
+  /** The manifest of the system the world runs on. */
+  readonly system: FoundryManifest;
+  /** Manifests of everything installed, by package id. */
+  readonly packages: ReadonlyMap<string, FoundryManifest>;
+  /** The Docker network Foundry joined, or `null` when the port is published. */
+  readonly network: string | null;
+  /**
+   * Copy a built package into the container and hand back its manifest.
+   *
+   * Foundry scans its packages directory once, at startup. A package installed
+   * into a running Foundry stays invisible until `restart()`.
+   */
+  install(source: FoundryPackageSource): FoundryManifest;
+  /** Stop and start, clearing the lock that a stop does not always clear. */
+  restart(): Promise<void>;
+  /** The container's last log lines. */
+  logs(tail?: number): string;
+  /** Remove the container. The volume survives, so the next run starts faster. */
+  stop(): void;
+}
+
+/** The three the image needs to fetch a licensed build. */
+const REQUIRED_ENV = ['FOUNDRY_LICENSE_KEY', 'FOUNDRY_USERNAME', 'FOUNDRY_PASSWORD'] as const;
+
+const MANIFEST_NAME: Record<FoundryPackageKind, string> = {
+  system: 'system.json',
+  module: 'module.json',
+};
+
+/** The directory Foundry reads each kind from. */
+const PACKAGE_DIR: Record<FoundryPackageKind, string> = {
+  system: 'systems',
+  module: 'modules',
+};
+
+function docker(args: readonly string[], options: { stdio?: 'ignore' } = {}): string {
+  return execFileSync('docker', [...args], { encoding: 'utf8', ...options }) ?? '';
+}
+
+/**
+ * The last log lines from a container, by name.
+ *
+ * `FoundryContainer#logs` is the same thing with the name filled in. Reach for
+ * this one when the boot itself failed, because then there is no handle and the
+ * logs are the only account of what went wrong.
+ */
+export function foundryContainerLogs(name: string, tail = 40): string {
+  try {
+    return docker(['logs', '--tail', String(tail), name]);
+  } catch {
+    return '(no container logs)';
+  }
+}
+
+/**
+ * Remove a container by name, whether or not this process started it.
+ *
+ * `FoundryContainer#stop` is the same thing with the name already filled in.
+ * Use this from a teardown script that runs in its own process, which is where
+ * the handle is out of reach. Removing a container that is not there is not an
+ * error.
+ *
+ * The data volume survives, so the next run does not download Foundry again.
+ */
+export function stopFoundryContainer(name: string): void {
+  try {
+    docker(['rm', '-f', name], { stdio: 'ignore' });
+  } catch {
+    // Not running. Nothing to remove.
+  }
+}
+
+function readManifest(source: FoundryPackageSource): FoundryManifest {
+  const path = join(source.from, MANIFEST_NAME[source.kind]);
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    throw new Error(
+      `No ${MANIFEST_NAME[source.kind]} in ${source.from}. Point \`from\` at the build output, not the source tree.`,
+    );
+  }
+  return JSON.parse(text) as FoundryManifest;
+}
+
+function licenseAccepted(options: FoundryContainerOptions): boolean {
+  if (options.acceptLicense === true) return true;
+  const fromEnv = process.env.FOUNDRY_ACCEPT_LICENSE;
+  return fromEnv !== undefined && fromEnv !== '' && fromEnv !== '0' && fromEnv !== 'false';
+}
+
+/**
+ * Start Foundry, install the packages, launch a world on them, and wait for
+ * the join screen.
+ *
+ * ```ts
+ * const foundry = await startFoundryContainer({
+ *   acceptLicense: true,
+ *   name: 'my-module-e2e',
+ *   packages: [
+ *     { kind: 'system', id: 'some-system', from: 'test/fixtures/system' },
+ *     { kind: 'module', id: 'my-module', from: 'dist' },
+ *   ],
+ * });
+ * try {
+ *   // drive foundry.baseUrl with a browser
+ * } finally {
+ *   foundry.stop();
+ * }
+ * ```
+ *
+ * Needs `docker` on the PATH and `FOUNDRY_LICENSE_KEY`, `FOUNDRY_USERNAME` and
+ * `FOUNDRY_PASSWORD` in the environment. First run downloads Foundry, which
+ * takes a couple of minutes; later runs reuse the volume.
+ */
+export async function startFoundryContainer(
+  options: FoundryContainerOptions = {},
+): Promise<FoundryContainer> {
+  if (!licenseAccepted(options)) {
+    throw new Error(
+      'Booting Foundry records an answer to its licence agreement. This harness will not answer it for you. Read the agreement, then pass `acceptLicense: true` or set FOUNDRY_ACCEPT_LICENSE=1.',
+    );
+  }
+
+  const missing = REQUIRED_ENV.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Cannot fetch a licensed Foundry without ${missing.join(', ')}. Set them in the environment.`,
+    );
+  }
+
+  const image = options.image ?? 'felddy/foundryvtt:14';
+  const name = options.name ?? 'vttforge-foundry';
+  const volume = options.volume ?? `${name}-data`;
+  const port = options.port ?? 30001;
+  const worldId = options.worldId ?? 'vttforge-test';
+  const coreVersion = options.coreVersion ?? '14';
+  const attempts = options.wait?.attempts ?? 150;
+  const everyMs = options.wait?.everyMs ?? 2000;
+  const sources = options.packages ?? [];
+
+  const manifests = new Map<string, FoundryManifest>();
+  const systemSource = sources.find((source) => source.kind === 'system');
+  if (!systemSource) {
+    throw new Error(
+      'A world needs a system. Pass one package with `kind: "system"` in `packages`.',
+    );
+  }
+  // Read every manifest before anything is started, so a bad path fails fast.
+  for (const source of sources) manifests.set(source.id, readManifest(source));
+  const system = manifests.get(systemSource.id) as FoundryManifest;
+
+  /**
+   * Run a throwaway shell against the data volume. Works while Foundry is
+   * stopped. As root, because the main container runs as root and everything
+   * it writes into the volume is owned by root.
+   */
+  const inVolume = (script: string): string =>
+    docker([
+      'run',
+      '--rm',
+      '-u',
+      '0:0',
+      '-v',
+      `${volume}:/data`,
+      '--entrypoint',
+      'sh',
+      image,
+      '-c',
+      script,
+    ]);
+
+  const remove = (): void => stopFoundryContainer(name);
+
+  remove();
+  // The worlds and the config are per-run; the downloaded Foundry beside them
+  // is not, and re-downloading it every run would cost minutes each time.
+  try {
+    inVolume('rm -rf /data/Data /data/Config');
+  } catch {
+    // First run: the volume does not exist yet, and `docker run` will make it.
+  }
+
+  const reach = reachability(name, port);
+  const baseUrl = reach.url;
+
+  docker([
+    'run',
+    '-d',
+    '--name',
+    name,
+    // The image's entrypoint chowns the volume on first boot, then drops privileges.
+    '-u',
+    '0:0',
+    ...reach.args,
+    // Named, not valued: Docker reads each from this process's environment, so
+    // no credential is written into an argument list.
+    '-e',
+    'FOUNDRY_LICENSE_KEY',
+    '-e',
+    'FOUNDRY_USERNAME',
+    '-e',
+    'FOUNDRY_PASSWORD',
+    '-e',
+    `FOUNDRY_ADMIN_KEY=${options.adminKey ?? 'vttforge'}`,
+    '-e',
+    'CONTAINER_PRESERVE_CONFIG=true',
+    '-v',
+    `${volume}:/data`,
+    image,
+  ]);
+
+  const answers = async (): Promise<boolean> => {
+    try {
+      // Every Foundry route redirects somewhere, so any answer means it is up.
+      await fetch(baseUrl, { redirect: 'manual' });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  /** Where Foundry redirects to, which is how it reports the stage it is at. */
+  const stage = async (): Promise<string> => {
+    const response = await fetch(baseUrl, { redirect: 'manual' });
+    return response.headers.get('location') ?? response.url;
+  };
+
+  const waitFor = async (label: string, check: () => Promise<boolean>): Promise<void> => {
+    for (let i = 0; i < attempts; i += 1) {
+      if (await check()) return;
+      await new Promise((resolve) => setTimeout(resolve, everyMs));
+    }
+    throw new Error(`Timed out waiting for ${label} after ${(attempts * everyMs) / 1000}s`);
+  };
+
+  const install = (source: FoundryPackageSource): FoundryManifest => {
+    const manifest = manifests.get(source.id) ?? readManifest(source);
+    const dir = `/data/Data/${PACKAGE_DIR[source.kind]}/${source.id}`;
+    inVolume(`rm -rf ${dir} && mkdir -p ${dir}`);
+    // The trailing `/.` copies the contents rather than the directory itself.
+    docker(['cp', `${source.from}/.`, `${name}:${dir}`]);
+    manifests.set(source.id, manifest);
+    return manifest;
+  };
+
+  /** Read a config file out of the volume, hand it to `edit`, and put it back. */
+  const editJson = (
+    pathInVolume: string,
+    edit: (value: Record<string, unknown>) => Record<string, unknown>,
+  ): void => {
+    const local = join(mkdtempSync(join(tmpdir(), 'vttforge-foundry-')), 'file.json');
+    docker(['cp', `${name}:${pathInVolume}`, local]);
+    const value = edit(JSON.parse(readFileSync(local, 'utf8')) as Record<string, unknown>);
+    writeFileSync(local, `${JSON.stringify(value, null, 2)}\n`);
+    docker(['cp', local, `${name}:${pathInVolume}`]);
+  };
+
+  const restart = async (): Promise<void> => {
+    // Foundry refuses to start over its own lock, and stopping the container
+    // does not always clear it. The lock is a directory, not a file.
+    docker(['stop', name]);
+    inVolume('rm -rf /data/Config/options.json.lock');
+    docker(['start', name]);
+    await waitFor('Foundry to answer again', answers);
+  };
+
+  await waitFor(`Foundry to answer at ${baseUrl}`, answers);
+
+  // 1. Answer the licence agreement. Until this is done every route redirects
+  //    to /license. The caller accepted it above; this records that answer.
+  await fetch(`${baseUrl}/license`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ agree: 'on', accept: '' }),
+    redirect: 'manual',
+  });
+  await waitFor(
+    'the licence answer to register',
+    async () => !(await stage()).endsWith('/license'),
+  );
+
+  // 2. Install what is under test, and declare a world on it.
+  for (const source of sources) install(source);
+  writeWorld({
+    container: name,
+    inVolume,
+    worldId,
+    title: options.worldTitle ?? 'VTTForge test world',
+    system,
+    coreVersion,
+  });
+  editJson('/data/Config/options.json', (value) => ({ ...value, world: worldId }));
+
+  // 3. Restart into it, then wait for the world itself, not just the server.
+  await restart();
+  await waitFor('the world to launch', async () => (await stage()).endsWith('/join'));
+
+  return {
+    baseUrl,
+    system,
+    packages: manifests,
+    network: reach.network,
+    install,
+    restart,
+    logs: (tail = 40) => foundryContainerLogs(name, tail),
+    stop: remove,
+  };
+}
+
+/**
+ * How this process can reach a container it starts.
+ *
+ * When this process is itself a container the daemon knows about, the two share
+ * a network and Foundry answers to its name. Otherwise the port is published
+ * and answers on localhost.
+ */
+function reachability(
+  container: string,
+  port: number,
+): { args: string[]; url: string; network: string | null } {
+  const self = process.env.HOSTNAME;
+  if (self) {
+    try {
+      const networks = docker([
+        'inspect',
+        self,
+        '--format',
+        '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}} {{end}}',
+      ]).trim();
+      const network = networks.split(/\s+/).filter(Boolean)[0];
+      if (network) {
+        return { args: ['--network', network], url: `http://${container}:30000`, network };
+      }
+    } catch {
+      // Not a container this daemon knows. Publishing a port is right after all.
+    }
+  }
+  return { args: ['-p', `${port}:30000`], url: `http://localhost:${port}`, network: null };
+}
+
+function writeWorld(args: {
+  container: string;
+  inVolume: (script: string) => string;
+  worldId: string;
+  title: string;
+  system: FoundryManifest;
+  coreVersion: string;
+}): void {
+  const local = join(mkdtempSync(join(tmpdir(), 'vttforge-foundry-')), 'world.json');
+  writeFileSync(
+    local,
+    `${JSON.stringify(
+      {
+        id: args.worldId,
+        title: args.title,
+        description: 'Created by a test run. Thrown away with it.',
+        system: args.system.id,
+        systemVersion: args.system.version,
+        coreVersion: args.coreVersion,
+        version: '1.0.0',
+        compatibility: { minimum: args.coreVersion, verified: args.coreVersion },
+        authors: [],
+        packs: [],
+        relationships: {},
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  args.inVolume(`mkdir -p /data/Data/worlds/${args.worldId}`);
+  docker(['cp', local, `${args.container}:/data/Data/worlds/${args.worldId}/world.json`]);
+}

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]

--- a/packages/testing/tsdown.config.mjs
+++ b/packages/testing/tsdown.config.mjs
@@ -1,13 +1,13 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/vitest/index.ts', 'src/quench/index.ts'],
+  entry: ['src/index.ts', 'src/vitest/index.ts', 'src/quench/index.ts', 'src/container/index.ts'],
   format: 'esm',
   platform: 'neutral',
   target: 'es2022',
   sourcemap: true,
   dts: true,
   clean: true,
-  external: [/^foundry/, /^vitest/],
+  external: [/^foundry/, /^vitest/, /^node:/],
   outExtensions: () => ({ js: '.mjs', dts: '.d.mts' }),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
+      '@vttforge/testing':
+        specifier: workspace:*
+        version: link:../../packages/testing
 
   apps/web:
     dependencies:
@@ -363,6 +366,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.5
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.4.0
       publint:
         specifier: 'catalog:'
         version: 0.3.24


### PR DESCRIPTION
## What

New entry point, `@vttforge/testing/container`. It boots Foundry in Docker,
installs the builds you name, launches a world on them, and waits for the join
screen.

```ts
import { startFoundryContainer } from '@vttforge/testing/container';

const foundry = await startFoundryContainer({
  acceptLicense: true,
  name: 'my-module-e2e',
  packages: [
    { kind: 'system', id: 'some-system', from: 'test/fixtures/system' },
    { kind: 'module', id: 'my-module', from: 'dist' },
  ],
});
try {
  await page.goto(foundry.baseUrl);
} finally {
  foundry.stop();
}
```

## Why

A package built on this SDK could test against mocks under Vitest, or against a
world a person opened under Quench. Between the two there was nothing: a CI job
with no world, checking that the package it just built loads at all. The code
that boots one ran only inside this repo, so a module in its own repo had to
reach for it by filesystem path.

## Three changes from the version that was private

**The caller answers the licence agreement.** Every previous boot answered it
silently. `startFoundryContainer` throws unless the caller passes
`acceptLicense: true` or sets `FOUNDRY_ACCEPT_LICENSE`. Credentials are still
read from the environment and handed to Docker by name, so none lands in an
argument list.

**The names are options.** Container, volume, port and world id were constants,
so two runs would have fought over one container.

**The packages are an argument**, not this repo's own examples, and a handle
replaces module-level state. `stopFoundryContainer(name)` and
`foundryContainerLogs(name)` cover a teardown script in its own process and a
boot that failed before there was a handle.

## Verification

`apps/e2e` now goes through this entry point and nothing private, so the API a
consumer gets is the API this repo tests with.

- 21/21 end-to-end tests pass against a Foundry booted through it.
- The container was removed by the teardown script, which runs in its own
  process. That is the path `stopFoundryContainer` exists for.
- 9 unit tests cover every refusal that happens before the first `docker` call.
  Checked by breaking the licence gate on purpose: two of them fail, then pass
  again once it is restored.
- `publint` and `attw` pass on the new subpath.
- typecheck, test, build, lint and knip green with `--force`.

The reference generator learned to take more than one entry per package. The
root cannot re-export this one: it reads `node:child_process`, which would
break a browser-side import of the package.